### PR TITLE
Fix issue 1 prompt and embedding quick wins

### DIFF
--- a/src/linkura_story_indexer/database.py
+++ b/src/linkura_story_indexer/database.py
@@ -5,15 +5,23 @@ from typing import Any, cast
 import chromadb
 from dotenv import load_dotenv
 from google import genai
+from google.genai import types
 from pydantic_ai import Agent
 from pydantic_ai.models.google import GoogleModel
 from pydantic_ai.providers.google import GoogleProvider
 
 load_dotenv()
 
-CHAT_MODEL = "gemini-3-flash-preview"
-EMBEDDING_MODEL = "gemini-embedding-2"
-CHROMA_DB_PATH = "./chroma_db"
+DEFAULT_CHAT_MODEL = "gemini-3-flash-preview"
+DEFAULT_EMBEDDING_MODEL = "gemini-embedding-2"
+DEFAULT_CHROMA_DB_PATH = "./chroma_db"
+RETRIEVAL_DOCUMENT = "RETRIEVAL_DOCUMENT"
+RETRIEVAL_QUERY = "RETRIEVAL_QUERY"
+
+_chroma_clients: dict[str, Any] = {}
+_chroma_collections: dict[tuple[str, str], Any] = {}
+_genai_clients: dict[str, genai.Client] = {}
+_google_models: dict[tuple[str, str], GoogleModel] = {}
 
 
 def get_google_api_key() -> str:
@@ -21,6 +29,18 @@ def get_google_api_key() -> str:
     if not api_key:
         raise ValueError("GOOGLE_API_KEY not found in .env file")
     return api_key
+
+
+def get_chat_model_name() -> str:
+    return os.getenv("LINKURA_CHAT_MODEL", DEFAULT_CHAT_MODEL)
+
+
+def get_embedding_model_name() -> str:
+    return os.getenv("LINKURA_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
+
+
+def get_chroma_db_path() -> str:
+    return os.getenv("LINKURA_CHROMA_DB_PATH", DEFAULT_CHROMA_DB_PATH)
 
 
 def initialize_settings() -> None:
@@ -34,34 +54,96 @@ def create_text_agent(instructions: str) -> Agent[None, str]:
 
 
 def create_google_model() -> GoogleModel:
-    return GoogleModel(CHAT_MODEL, provider=GoogleProvider(api_key=get_google_api_key()))
+    api_key = get_google_api_key()
+    model_name = get_chat_model_name()
+    cache_key = (api_key, model_name)
+    if cache_key not in _google_models:
+        _google_models[cache_key] = GoogleModel(
+            model_name,
+            provider=GoogleProvider(api_key=api_key),
+        )
+    return _google_models[cache_key]
 
 
 def get_genai_client() -> genai.Client:
-    return genai.Client(api_key=get_google_api_key())
+    api_key = get_google_api_key()
+    if api_key not in _genai_clients:
+        _genai_clients[api_key] = genai.Client(api_key=api_key)
+    return _genai_clients[api_key]
 
 
-def embed_texts(texts: Sequence[str]) -> list[list[float]]:
-    if not texts:
-        return []
+def _supports_batch_embeddings(model_name: str) -> bool:
+    # google-genai special-cases gemini-embedding-2 by normalizing a list of
+    # strings into one Content, so it does not produce one embedding per string.
+    return "gemini-embedding-2" not in model_name
 
-    client = get_genai_client()
+
+def _embed_text_batch(client: genai.Client, texts: Sequence[str], model_name: str, task_type: str) -> list[list[float]]:
+    response = client.models.embed_content(
+        model=model_name,
+        contents=cast(Any, list(texts)),
+        config=types.EmbedContentConfig(task_type=task_type),
+    )
+    embeddings = response.embeddings or []
+    if not embeddings:
+        raise ValueError("Google embedding response did not include embeddings")
+    if len(embeddings) != len(texts):
+        raise ValueError("Google embedding response did not match input batch size")
+
     vectors = []
-    for text in texts:
-        response = client.models.embed_content(
-            model=EMBEDDING_MODEL,
-            contents=cast(Any, text),
-        )
-        embeddings = response.embeddings or []
-        if not embeddings:
-            raise ValueError("Google embedding response did not include embeddings")
-        values = cast(list[float] | None, embeddings[0].values)
+    for embedding in embeddings:
+        values = cast(list[float] | None, embedding.values)
         if values is None:
             raise ValueError("Google embedding response did not include vector values")
         vectors.append(values)
     return vectors
 
 
+def embed_texts(
+    texts: Sequence[str],
+    *,
+    task_type: str = RETRIEVAL_DOCUMENT,
+    batch_size: int = 32,
+) -> list[list[float]]:
+    if not texts:
+        return []
+    if batch_size < 1:
+        raise ValueError("batch_size must be at least 1")
+
+    client = get_genai_client()
+    model_name = get_embedding_model_name()
+    effective_batch_size = batch_size if _supports_batch_embeddings(model_name) else 1
+    vectors = []
+    for start in range(0, len(texts), effective_batch_size):
+        batch = list(texts[start : start + effective_batch_size])
+        try:
+            vectors.extend(_embed_text_batch(client, batch, model_name, task_type))
+        except ValueError:
+            if len(batch) == 1:
+                raise
+            for text in batch:
+                vectors.extend(_embed_text_batch(client, [text], model_name, task_type))
+    return vectors
+
+
+def get_chroma_client() -> Any:
+    path = get_chroma_db_path()
+    if path not in _chroma_clients:
+        _chroma_clients[path] = chromadb.PersistentClient(path=path)
+    return _chroma_clients[path]
+
+
 def get_chroma_collection(collection_name: str = "story_nodes") -> Any:
-    db = chromadb.PersistentClient(path=CHROMA_DB_PATH)
-    return db.get_or_create_collection(collection_name)
+    path = get_chroma_db_path()
+    cache_key = (path, collection_name)
+    if cache_key not in _chroma_collections:
+        _chroma_collections[cache_key] = get_chroma_client().get_or_create_collection(collection_name)
+    return _chroma_collections[cache_key]
+
+
+def reset_client_caches() -> None:
+    """Clears cached clients and models, primarily for tests."""
+    _chroma_clients.clear()
+    _chroma_collections.clear()
+    _genai_clients.clear()
+    _google_models.clear()

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from ..console import safe_print
-from ..database import create_text_agent, embed_texts, get_chroma_collection
+from ..database import RETRIEVAL_QUERY, create_text_agent, embed_texts, get_chroma_collection
 
 
 class StoryQueryEngine:
@@ -22,12 +22,27 @@ class StoryQueryEngine:
             with open(glossary_file, encoding="utf-8") as f:
                 self.glossary = json.load(f)
 
+    def _question_arc_ids(self, question: str) -> set[str]:
+        """Find explicit story arc IDs mentioned in the user's question."""
+        if not self.state_ledger:
+            return set()
+        return {arc_id for arc_id in re.findall(r"\b\d{3}\b", question) if arc_id in self.state_ledger}
+
+    def _state_ledger_arc_ids(self, question: str, retrieved_arc_ids: set[str]) -> set[str]:
+        explicit_arc_ids = self._question_arc_ids(question)
+        if explicit_arc_ids:
+            return explicit_arc_ids
+        return retrieved_arc_ids
+
     def _build_system_prompt(self, arc_ids: set[str]) -> str:
         """Builds the system prompt with invariants and state ledger."""
         prompt = (
             "You are an expert lore-keeper and archivist for a Japanese narrative story.\n"
-            "You are answering a user's question based strictly on the provided raw source text.\n"
-            "Do NOT use outside knowledge. If the provided text does not contain the answer, say so.\n"
+            "Use only the retrieved context provided in this request. Some retrieved context may "
+            "be generated summaries rather than raw source scenes until raw evidence retrieval is "
+            "implemented.\n"
+            "Do NOT use outside knowledge. If the provided context does not contain the answer, "
+            "say so.\n"
             "Cite sources using only the CITATION labels provided in retrieved context. "
             "Do not cite raw Japanese episode titles. "
             "Do not convert the Year/Arc ID to a real-world year like 2024.\n"
@@ -45,7 +60,14 @@ class StoryQueryEngine:
             for arc_id in arc_ids:
                 if arc_id in self.state_ledger:
                     prompt += f"\nYEAR {arc_id} FACTS:\n"
-                    prompt += json.dumps(self.state_ledger[arc_id], ensure_ascii=False, indent=2) + "\n"
+                    prompt += (
+                        json.dumps(
+                            self.state_ledger[arc_id],
+                            ensure_ascii=False,
+                            separators=(",", ":"),
+                        )
+                        + "\n"
+                    )
 
         return prompt
 
@@ -92,7 +114,7 @@ class StoryQueryEngine:
         )
 
     def _retrieve(self, question: str) -> list[tuple[str, dict[str, Any]]]:
-        query_embedding = embed_texts([question])[0]
+        query_embedding = embed_texts([question], task_type=RETRIEVAL_QUERY)[0]
         results = self.collection.query(
             query_embeddings=[query_embedding],
             n_results=3,
@@ -137,7 +159,8 @@ class StoryQueryEngine:
             context_chunk += f"SUMMARY:\n{summary}\n\nRAW TEXT:\n{raw_text}\n"
             raw_contexts.append(context_chunk)
 
-        system_prompt = self._build_system_prompt(arc_ids)
+        state_ledger_arc_ids = self._state_ledger_arc_ids(question, arc_ids)
+        system_prompt = self._build_system_prompt(state_ledger_arc_ids)
         combined_context = "\n".join(raw_contexts)
 
         user_prompt = (

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,206 @@
+from typing import Any
+
+from linkura_story_indexer import database
+
+
+def test_model_and_chroma_env_defaults_and_overrides(monkeypatch):
+    monkeypatch.delenv("LINKURA_CHAT_MODEL", raising=False)
+    monkeypatch.delenv("LINKURA_EMBEDDING_MODEL", raising=False)
+    monkeypatch.delenv("LINKURA_CHROMA_DB_PATH", raising=False)
+
+    assert database.get_chat_model_name() == database.DEFAULT_CHAT_MODEL
+    assert database.get_embedding_model_name() == database.DEFAULT_EMBEDDING_MODEL
+    assert database.get_chroma_db_path() == database.DEFAULT_CHROMA_DB_PATH
+
+    monkeypatch.setenv("LINKURA_CHAT_MODEL", "custom-chat")
+    monkeypatch.setenv("LINKURA_EMBEDDING_MODEL", "custom-embedding")
+    monkeypatch.setenv("LINKURA_CHROMA_DB_PATH", "./custom_chroma")
+
+    assert database.get_chat_model_name() == "custom-chat"
+    assert database.get_embedding_model_name() == "custom-embedding"
+    assert database.get_chroma_db_path() == "./custom_chroma"
+
+
+def test_client_and_model_helpers_return_singletons(monkeypatch):
+    database.reset_client_caches()
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+
+    class FakePersistentClient:
+        created: list[str] = []
+
+        def __init__(self, path: str):
+            self.path = path
+            self.collections: dict[str, object] = {}
+            self.created.append(path)
+
+        def get_or_create_collection(self, name: str) -> object:
+            if name not in self.collections:
+                self.collections[name] = object()
+            return self.collections[name]
+
+    class FakeGenAIClient:
+        created: list[str] = []
+
+        def __init__(self, api_key: str):
+            self.api_key = api_key
+            self.created.append(api_key)
+
+    class FakeGoogleProvider:
+        def __init__(self, api_key: str):
+            self.api_key = api_key
+
+    class FakeGoogleModel:
+        created: list[tuple[str, Any]] = []
+
+        def __init__(self, model_name: str, *, provider: Any):
+            self.model_name = model_name
+            self.provider = provider
+            self.created.append((model_name, provider))
+
+    monkeypatch.setattr(database.chromadb, "PersistentClient", FakePersistentClient)
+    monkeypatch.setattr(database.genai, "Client", FakeGenAIClient)
+    monkeypatch.setattr(database, "GoogleProvider", FakeGoogleProvider)
+    monkeypatch.setattr(database, "GoogleModel", FakeGoogleModel)
+
+    assert database.get_chroma_client() is database.get_chroma_client()
+    assert database.get_chroma_collection() is database.get_chroma_collection()
+    assert database.get_genai_client() is database.get_genai_client()
+    assert database.create_google_model() is database.create_google_model()
+
+    assert FakePersistentClient.created == [database.DEFAULT_CHROMA_DB_PATH]
+    assert FakeGenAIClient.created == ["test-key"]
+    assert len(FakeGoogleModel.created) == 1
+
+
+def test_embed_texts_batches_single_sdk_call_for_batch(monkeypatch):
+    database.reset_client_caches()
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("LINKURA_EMBEDDING_MODEL", "text-embedding-004")
+
+    calls: list[dict[str, Any]] = []
+
+    class FakeEmbedding:
+        def __init__(self, values: list[float]):
+            self.values = values
+
+    class FakeResponse:
+        def __init__(self, embeddings: list[FakeEmbedding]):
+            self.embeddings = embeddings
+
+    class FakeModels:
+        def embed_content(self, *, model: str, contents: list[str], config: Any) -> FakeResponse:
+            calls.append({"model": model, "contents": contents, "config": config})
+            return FakeResponse(
+                [FakeEmbedding([float(index)]) for index, _ in enumerate(contents)]
+            )
+
+    class FakeGenAIClient:
+        def __init__(self, api_key: str):
+            self.models = FakeModels()
+
+    monkeypatch.setattr(database.genai, "Client", FakeGenAIClient)
+
+    vectors = database.embed_texts(["one", "two", "three"], batch_size=10)
+
+    assert vectors == [[0.0], [1.0], [2.0]]
+    assert len(calls) == 1
+    assert calls[0]["model"] == "text-embedding-004"
+    assert calls[0]["contents"] == ["one", "two", "three"]
+    assert calls[0]["config"].task_type == database.RETRIEVAL_DOCUMENT
+
+
+def test_embed_texts_respects_batch_size(monkeypatch):
+    database.reset_client_caches()
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("LINKURA_EMBEDDING_MODEL", "text-embedding-004")
+
+    batch_lengths: list[int] = []
+
+    class FakeEmbedding:
+        def __init__(self, values: list[float]):
+            self.values = values
+
+    class FakeResponse:
+        def __init__(self, embeddings: list[FakeEmbedding]):
+            self.embeddings = embeddings
+
+    class FakeModels:
+        def embed_content(self, *, model: str, contents: list[str], config: Any) -> FakeResponse:
+            batch_lengths.append(len(contents))
+            return FakeResponse([FakeEmbedding([1.0]) for _ in contents])
+
+    class FakeGenAIClient:
+        def __init__(self, api_key: str):
+            self.models = FakeModels()
+
+    monkeypatch.setattr(database.genai, "Client", FakeGenAIClient)
+
+    database.embed_texts(["one", "two", "three"], batch_size=2)
+
+    assert batch_lengths == [2, 1]
+
+
+def test_embed_texts_uses_single_item_calls_for_gemini_embedding_2(monkeypatch):
+    database.reset_client_caches()
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.delenv("LINKURA_EMBEDDING_MODEL", raising=False)
+
+    call_contents: list[list[str]] = []
+
+    class FakeEmbedding:
+        def __init__(self, values: list[float]):
+            self.values = values
+
+    class FakeResponse:
+        def __init__(self, embeddings: list[FakeEmbedding]):
+            self.embeddings = embeddings
+
+    class FakeModels:
+        def embed_content(self, *, model: str, contents: list[str], config: Any) -> FakeResponse:
+            call_contents.append(contents)
+            return FakeResponse([FakeEmbedding([float(len(call_contents))])])
+
+    class FakeGenAIClient:
+        def __init__(self, api_key: str):
+            self.models = FakeModels()
+
+    monkeypatch.setattr(database.genai, "Client", FakeGenAIClient)
+
+    vectors = database.embed_texts(["one", "two", "three"], batch_size=10)
+
+    assert vectors == [[1.0], [2.0], [3.0]]
+    assert call_contents == [["one"], ["two"], ["three"]]
+
+
+def test_embed_texts_falls_back_when_batch_response_count_mismatches(monkeypatch):
+    database.reset_client_caches()
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("LINKURA_EMBEDDING_MODEL", "text-embedding-004")
+
+    call_contents: list[list[str]] = []
+
+    class FakeEmbedding:
+        def __init__(self, values: list[float]):
+            self.values = values
+
+    class FakeResponse:
+        def __init__(self, embeddings: list[FakeEmbedding]):
+            self.embeddings = embeddings
+
+    class FakeModels:
+        def embed_content(self, *, model: str, contents: list[str], config: Any) -> FakeResponse:
+            call_contents.append(contents)
+            if len(contents) > 1:
+                return FakeResponse([FakeEmbedding([0.0])])
+            return FakeResponse([FakeEmbedding([float(len(call_contents))])])
+
+    class FakeGenAIClient:
+        def __init__(self, api_key: str):
+            self.models = FakeModels()
+
+    monkeypatch.setattr(database.genai, "Client", FakeGenAIClient)
+
+    vectors = database.embed_texts(["one", "two"], batch_size=10)
+
+    assert vectors == [[2.0], [3.0]]
+    assert call_contents == [["one", "two"], ["one"], ["two"]]

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+from linkura_story_indexer import database
+from linkura_story_indexer.query import engine as query_engine
+from linkura_story_indexer.query.engine import StoryQueryEngine
+
+
+def make_engine() -> StoryQueryEngine:
+    engine = StoryQueryEngine.__new__(StoryQueryEngine)
+    engine.state_ledger = {
+        "103": {"characters": [{"name": "Kaho Hinoshita"}]},
+        "104": {"characters": [{"name": "Sayaka Murano"}]},
+    }
+    engine.glossary = None
+    return engine
+
+
+def test_system_prompt_softens_raw_source_claim_and_compacts_ledger():
+    engine = make_engine()
+
+    prompt = engine._build_system_prompt({"103"})
+
+    assert "based strictly on the provided raw source text" not in prompt
+    assert "Some retrieved context may be generated summaries" in prompt
+    assert '{"characters":[{"name":"Kaho Hinoshita"}]}' in prompt
+    assert '\n  "characters"' not in prompt
+    assert "YEAR 104 FACTS" not in prompt
+
+
+def test_state_ledger_arc_ids_prefers_explicit_question_arc():
+    engine = make_engine()
+
+    arc_ids = engine._state_ledger_arc_ids("What happened in 103?", {"104"})
+
+    assert arc_ids == {"103"}
+
+
+def test_state_ledger_arc_ids_falls_back_to_retrieved_arcs():
+    engine = make_engine()
+
+    arc_ids = engine._state_ledger_arc_ids("What happened to Kaho?", {"103", "104"})
+
+    assert arc_ids == {"103", "104"}
+
+
+def test_retrieve_uses_query_embedding_task_type(monkeypatch):
+    engine = StoryQueryEngine.__new__(StoryQueryEngine)
+    calls: list[dict[str, Any]] = []
+
+    class FakeCollection:
+        def query(self, **kwargs: Any) -> dict[str, list[list[Any]]]:
+            calls.append(kwargs)
+            return {
+                "documents": [["summary"]],
+                "metadatas": [[{"arc_id": "103", "summary_level": 3}]],
+            }
+
+    def fake_embed_texts(texts: list[str], *, task_type: str) -> list[list[float]]:
+        calls.append({"texts": texts, "task_type": task_type})
+        return [[0.1, 0.2]]
+
+    engine.collection = FakeCollection()
+    monkeypatch.setattr(query_engine, "embed_texts", fake_embed_texts)
+
+    retrieved = engine._retrieve("question")
+
+    assert retrieved == [("summary", {"arc_id": "103", "summary_level": 3})]
+    assert calls[0] == {"texts": ["question"], "task_type": database.RETRIEVAL_QUERY}
+    assert calls[1]["query_embeddings"] == [[0.1, 0.2]]


### PR DESCRIPTION
## Summary

- Add env-backed defaults for chat model, embedding model, and Chroma DB path.
- Cache Chroma clients/collections, Gemini client, and PydanticAI GoogleModel instances.
- Apply Gemini embedding task types: RETRIEVAL_DOCUMENT for ingest and RETRIEVAL_QUERY for query.
- Keep embedding calls robust for gemini-embedding-2, whose SDK path returns one embedding for list input, while preserving batch support for compatible models.
- Soften the query system prompt so it no longer claims strict raw-source grounding while retrieval can include summaries.
- Compact and scope State Ledger prompt injection to relevant arcs.

Closes #1

## Tests

- uv run ruff check . --fix
- uv run pyrefly check .
- uv run pytest