### PR TITLE
Index tier 4 raw scenes into Chroma

### DIFF
--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -5,10 +5,10 @@ import typer
 from rich.console import Console
 from rich.progress import Progress
 
-from .database import embed_texts, get_chroma_collection, initialize_settings
+from .database import RETRIEVAL_DOCUMENT, embed_texts, get_chroma_collection, initialize_settings
 from .indexer.extractor import StateExtractor
 from .indexer.processor import StoryProcessor
-from .indexer.summarizer import HierarchicalSummarizer
+from .indexer.summarizer import HierarchicalSummarizer, episode_sort_key, natural_sort_key
 from .models.story import StoryNode
 from .query.engine import StoryQueryEngine
 
@@ -18,32 +18,101 @@ console = Console()
 
 def _node_id(node: StoryNode) -> str:
     meta = node.metadata
+    if node.summary_level == 4:
+        return f"scene:{meta.parent_part_id}:{meta.scene_index}"
+    if node.summary_level == 3:
+        return f"summary:part:{meta.parent_part_id}"
+    if node.summary_level == 2:
+        return f"summary:episode:{meta.parent_episode_id}"
+    if node.summary_level == 1:
+        return f"summary:year:{meta.parent_year_id}"
+    return f"level:{node.summary_level}:{meta.parent_part_id}:{meta.scene_index}"
+
+
+def _story_order_key(node: StoryNode) -> tuple:
+    meta = node.metadata
     return (
-        f"{meta.arc_id}|{meta.story_type}|{meta.episode_name}|{meta.part_name}|"
-        f"level:{node.summary_level}|scene:{meta.scene_index}"
+        episode_sort_key((meta.arc_id, meta.story_type, meta.episode_name)),
+        natural_sort_key(meta.part_name),
+        meta.scene_index,
+        meta.file_path,
     )
 
 
-def _upsert_summary_nodes(nodes: list[StoryNode]) -> None:
+def _assign_canonical_story_order(nodes: list[StoryNode]) -> None:
+    for order, node in enumerate(sorted(nodes, key=_story_order_key), start=1):
+        node.metadata.canonical_story_order = order
+
+
+def _translation_aliases(node: StoryNode, glossary: dict | None) -> list[str]:
+    if not glossary:
+        return []
+
+    aliases = []
+    seen = set()
+    searchable_text = "\n".join([node.text, *node.metadata.detected_speakers])
+    for terms in glossary.values():
+        if not isinstance(terms, dict):
+            continue
+        for japanese, english in terms.items():
+            if japanese in searchable_text and english not in seen:
+                aliases.append(english)
+                seen.add(english)
+    return aliases
+
+
+def _embedding_document(node: StoryNode, glossary: dict | None = None) -> str:
+    if node.summary_level != 4:
+        return node.text
+
+    meta = node.metadata
+    speakers = ", ".join(meta.detected_speakers) if meta.detected_speakers else "none"
+    aliases = ", ".join(_translation_aliases(node, glossary)) or "none"
+    header = "\n".join(
+        [
+            f"Year: {meta.arc_id}",
+            f"Story type: {meta.story_type}",
+            f"Episode: {meta.episode_name}",
+            f"Part: {meta.part_name}",
+            f"Scene: {meta.scene_index}",
+            f"Canonical story order: {meta.canonical_story_order}",
+            f"Speakers: {speakers}",
+            f"Aliases: {aliases}",
+            "",
+        ]
+    )
+    return f"{header}{node.text}"
+
+
+def _metadata_for_node(node: StoryNode) -> dict:
+    metadata = node.metadata.model_dump()
+    metadata["detected_speakers"] = "|".join(node.metadata.detected_speakers)
+    metadata["summary_level"] = node.summary_level
+    return metadata
+
+
+def _upsert_story_nodes(
+    nodes: list[StoryNode],
+    *,
+    progress_label: str,
+    glossary: dict | None = None,
+) -> None:
     collection = get_chroma_collection()
     batch_size = 32
 
     with Progress() as progress:
-        task = progress.add_task("[green]Embedding summaries...", total=len(nodes))
+        task = progress.add_task(progress_label, total=len(nodes))
         for start in range(0, len(nodes), batch_size):
             batch = nodes[start : start + batch_size]
             documents = [node.text for node in batch]
-            metadatas = []
-            for node in batch:
-                metadata = node.metadata.model_dump()
-                metadata["summary_level"] = node.summary_level
-                metadatas.append(metadata)
+            embedding_documents = [_embedding_document(node, glossary) for node in batch]
+            metadatas = [_metadata_for_node(node) for node in batch]
 
             collection.upsert(
                 ids=[_node_id(node) for node in batch],
                 documents=documents,
                 metadatas=metadatas,
-                embeddings=embed_texts(documents),
+                embeddings=embed_texts(embedding_documents, task_type=RETRIEVAL_DOCUMENT),
             )
             progress.update(task, advance=len(batch))
 
@@ -114,6 +183,8 @@ def ingest(story_dir: str = typer.Option("story", help="Directory containing sto
             raw_nodes.extend(nodes)
             progress.update(task, advance=1)
 
+    _assign_canonical_story_order(raw_nodes)
+
     console.print(f"Parsed {len(raw_nodes)} raw scenes. Starting Hierarchical Summarization...")
     
     glossary = None
@@ -129,7 +200,12 @@ def ingest(story_dir: str = typer.Option("story", help="Directory containing sto
     
     console.print(f"Generated {len(summary_nodes)} hierarchical summaries. Upserting to Vector DB...")
     
-    _upsert_summary_nodes(summary_nodes)
+    _upsert_story_nodes(
+        raw_nodes,
+        progress_label="[green]Embedding raw scenes...",
+        glossary=glossary,
+    )
+    _upsert_story_nodes(summary_nodes, progress_label="[green]Embedding summaries...")
     
     console.print("[bold green]Hierarchical Ingestion complete![/bold green]")
 

--- a/src/linkura_story_indexer/indexer/parser.py
+++ b/src/linkura_story_indexer/indexer/parser.py
@@ -23,6 +23,18 @@ class StoryParser:
         return "", ""
 
     @staticmethod
+    def detect_speakers(content: str) -> list[str]:
+        """Returns unique script speakers in first-seen order."""
+        speakers = []
+        seen = set()
+        for line in content.splitlines():
+            speaker, _ = StoryParser.parse_script_line(line)
+            if speaker and speaker not in seen:
+                speakers.append(speaker)
+                seen.add(speaker)
+        return speakers
+
+    @staticmethod
     def is_script_format(content: str) -> bool:
         """Heuristically determines if a scene is in script format."""
         lines = content.strip().split("\n")

--- a/src/linkura_story_indexer/indexer/processor.py
+++ b/src/linkura_story_indexer/indexer/processor.py
@@ -4,6 +4,13 @@ from ..models.story import StoryMetadata, StoryNode
 from .parser import StoryParser
 
 
+def _parent_ids(arc_id: str, story_type: str, episode_name: str, part_name: str) -> tuple[str, str, str]:
+    year_id = arc_id
+    episode_id = f"{arc_id}|{story_type}|{episode_name}"
+    part_id = f"{episode_id}|{part_name}"
+    return year_id, episode_id, part_id
+
+
 class StoryProcessor:
     """Processes story directories into StoryNodes."""
 
@@ -39,20 +46,39 @@ class StoryProcessor:
                 ep_name = folder_name
                 part_name = file_path.stem
 
+            parent_year_id, parent_episode_id, parent_part_id = _parent_ids(
+                arc_id,
+                story_type,
+                ep_name,
+                part_name,
+            )
             return StoryMetadata(
                 arc_id=arc_id,
                 story_type=story_type,
                 episode_name=ep_name,
                 part_name=part_name,
-                file_path=str(file_path)
+                file_path=str(file_path),
+                parent_year_id=parent_year_id,
+                parent_episode_id=parent_episode_id,
+                parent_part_id=parent_part_id,
             )
         except (ValueError, IndexError):
+            part_name = file_path.parent.name
+            parent_year_id, parent_episode_id, parent_part_id = _parent_ids(
+                "unknown",
+                "unknown",
+                "unknown",
+                part_name,
+            )
             return StoryMetadata(
                 arc_id="unknown",
                 story_type="unknown",
                 episode_name="unknown",
-                part_name=file_path.parent.name,
-                file_path=str(file_path)
+                part_name=part_name,
+                file_path=str(file_path),
+                parent_year_id=parent_year_id,
+                parent_episode_id=parent_episode_id,
+                parent_part_id=parent_part_id,
             )
 
     @classmethod
@@ -70,6 +96,7 @@ class StoryProcessor:
             meta = metadata_base.model_copy(deep=True)
             meta.scene_index = i
             meta.is_prose = not is_script
+            meta.detected_speakers = StoryParser.detect_speakers(scene_text)
             nodes.append(StoryNode(text=scene_text, metadata=meta))
             
         return nodes

--- a/src/linkura_story_indexer/models/story.py
+++ b/src/linkura_story_indexer/models/story.py
@@ -9,6 +9,15 @@ class StoryMetadata(BaseModel):
     file_path: str = Field(..., description="Path to the original markdown file")
     scene_index: int = Field(0, description="Index of the scene within the file (split by ---)")
     is_prose: bool = Field(False, description="True if the content is prose/narrative, False if script")
+    canonical_story_order: int = Field(0, description="Global chronological order for this story node")
+    parent_year_id: str = Field("", description="Stable parent year identifier")
+    parent_episode_id: str = Field("", description="Stable parent episode identifier")
+    parent_part_id: str = Field("", description="Stable parent part identifier")
+    detected_speakers: list[str] = Field(
+        default_factory=list,
+        description="Speakers detected in this scene",
+    )
+
 
 class StoryNode(BaseModel):
     text: str = Field(..., description="The actual text content of the scene or summary")

--- a/tests/test_ingest_raw_scenes.py
+++ b/tests/test_ingest_raw_scenes.py
@@ -1,0 +1,183 @@
+from pathlib import Path
+from typing import Any
+
+from linkura_story_indexer import cli
+from linkura_story_indexer.database import RETRIEVAL_DOCUMENT
+from linkura_story_indexer.indexer.processor import StoryProcessor
+
+
+class FakeCollection:
+    def __init__(self) -> None:
+        self.records: dict[str, dict[str, Any]] = {}
+
+    def upsert(
+        self,
+        *,
+        ids: list[str],
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+        embeddings: list[list[float]],
+    ) -> None:
+        for record_id, document, metadata, embedding in zip(
+            ids,
+            documents,
+            metadatas,
+            embeddings,
+            strict=True,
+        ):
+            self.records[record_id] = {
+                "document": document,
+                "metadata": metadata,
+                "embedding": embedding,
+            }
+
+
+def _write_story_file(root: Path, relative_path: str, content: str) -> Path:
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_raw_scene_upsert_indexes_every_scene_with_required_metadata(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    story_root = tmp_path / "story"
+    script_path = _write_story_file(
+        story_root,
+        "103/第1話『花咲きたい！』/1.md",
+        "花帆: こんにちは\nさやか: どうしたの？\n---\n花帆: 行こう\nさやか: うん",
+    )
+    prose_path = _write_story_file(
+        story_root,
+        "103/第1話『花咲きたい！』/2.md",
+        "花帆は廊下を歩いた。\n朝の光が差していた。",
+    )
+    raw_nodes = [
+        *StoryProcessor.process_file(script_path),
+        *StoryProcessor.process_file(prose_path),
+    ]
+    cli._assign_canonical_story_order(raw_nodes)
+
+    collection = FakeCollection()
+    embedding_calls: list[dict[str, Any]] = []
+
+    def fake_embed_texts(texts: list[str], *, task_type: str) -> list[list[float]]:
+        embedding_calls.append({"texts": texts, "task_type": task_type})
+        return [[float(index)] for index, _ in enumerate(texts)]
+
+    monkeypatch.setattr(cli, "get_chroma_collection", lambda: collection)
+    monkeypatch.setattr(cli, "embed_texts", fake_embed_texts)
+
+    cli._upsert_story_nodes(
+        raw_nodes,
+        progress_label="Embedding test scenes",
+        glossary={"characters": {"花帆": "Kaho Hinoshita", "さやか": "Sayaka Murano"}},
+    )
+
+    assert len(collection.records) == 3
+    assert embedding_calls[0]["task_type"] == RETRIEVAL_DOCUMENT
+    assert "Aliases: Kaho Hinoshita, Sayaka Murano" in embedding_calls[0]["texts"][0]
+
+    required_keys = {
+        "arc_id",
+        "story_type",
+        "episode_name",
+        "part_name",
+        "scene_index",
+        "canonical_story_order",
+        "parent_year_id",
+        "parent_episode_id",
+        "parent_part_id",
+        "file_path",
+        "detected_speakers",
+        "is_prose",
+        "summary_level",
+    }
+    for record in collection.records.values():
+        metadata = record["metadata"]
+        assert required_keys <= metadata.keys()
+        assert isinstance(metadata["scene_index"], int)
+        assert isinstance(metadata["canonical_story_order"], int)
+        assert isinstance(metadata["detected_speakers"], str)
+        assert isinstance(metadata["is_prose"], bool)
+        assert metadata["summary_level"] == 4
+
+    records = list(collection.records.values())
+    assert records[0]["metadata"]["detected_speakers"] == "花帆|さやか"
+    assert records[0]["metadata"]["is_prose"] is False
+    assert records[-1]["metadata"]["detected_speakers"] == ""
+    assert records[-1]["metadata"]["is_prose"] is True
+
+
+def test_node_ids_are_unique_for_summaries_and_scenes(tmp_path: Path) -> None:
+    story_root = tmp_path / "story"
+    part_one = _write_story_file(
+        story_root,
+        "103/第1話『花咲きたい！』/1.md",
+        "花帆: one\nさやか: two\n---\n花帆: three\nさやか: four",
+    )
+    part_two = _write_story_file(
+        story_root,
+        "103/第1話『花咲きたい！』/2.md",
+        "花帆: five\nさやか: six",
+    )
+    raw_nodes = [
+        *StoryProcessor.process_file(part_one),
+        *StoryProcessor.process_file(part_two),
+    ]
+
+    part_summary_one = raw_nodes[0].model_copy(deep=True)
+    part_summary_one.summary_level = 3
+    part_summary_one.metadata.scene_index = -1
+    part_summary_two = raw_nodes[-1].model_copy(deep=True)
+    part_summary_two.summary_level = 3
+    part_summary_two.metadata.scene_index = -1
+    episode_summary = raw_nodes[0].model_copy(deep=True)
+    episode_summary.summary_level = 2
+    episode_summary.metadata.scene_index = -1
+    year_summary = raw_nodes[0].model_copy(deep=True)
+    year_summary.summary_level = 1
+    year_summary.metadata.scene_index = -1
+
+    nodes = [
+        *raw_nodes,
+        part_summary_one,
+        part_summary_two,
+        episode_summary,
+        year_summary,
+    ]
+
+    ids = [cli._node_id(node) for node in nodes]
+
+    assert len(ids) == len(set(ids))
+    assert cli._node_id(raw_nodes[0]) != cli._node_id(raw_nodes[1])
+    assert cli._node_id(part_summary_one) != cli._node_id(part_summary_two)
+
+
+def test_upsert_raw_scenes_is_idempotent(tmp_path: Path, monkeypatch) -> None:
+    story_root = tmp_path / "story"
+    path = _write_story_file(
+        story_root,
+        "103/第1話『花咲きたい！』/1.md",
+        "花帆: こんにちは\nさやか: どうしたの？\n---\n花帆: 行こう\nさやか: うん",
+    )
+    raw_nodes = StoryProcessor.process_file(path)
+    cli._assign_canonical_story_order(raw_nodes)
+
+    collection = FakeCollection()
+
+    monkeypatch.setattr(cli, "get_chroma_collection", lambda: collection)
+    monkeypatch.setattr(
+        cli,
+        "embed_texts",
+        lambda texts, *, task_type: [[1.0] for _ in texts],
+    )
+
+    cli._upsert_story_nodes(raw_nodes, progress_label="Embedding test scenes")
+    first_count = len(collection.records)
+    cli._upsert_story_nodes(raw_nodes, progress_label="Embedding test scenes")
+
+    assert first_count == 2
+    assert len(collection.records) == first_count


### PR DESCRIPTION
## Summary

- Index raw scene nodes into the existing `story_nodes` Chroma collection with `summary_level=4`
- Add scene metadata for canonical order, parent IDs, detected speakers, and prose/script detection
- Use level-specific stable IDs to avoid collisions between summaries and raw scenes
- Add an embedding-only metadata header for raw scenes to improve English/Japanese retrieval anchors while storing the raw scene text as the document
- Add tests for raw-scene metadata shape, ID uniqueness, and idempotent upserts

## Collection decision

This keeps raw scenes in the existing `story_nodes` collection rather than creating a separate `story_scenes` collection. The current query path already uses one collection, and `summary_level` cleanly distinguishes tiers. Keeping one collection avoids adding multi-collection result merging before the retrieval router work lands.

## Validation

- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`

Closes #2