### PR TITLE
Implement evidence-gate retrieval policy

### DIFF
--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -6,6 +6,13 @@ from typing import Any
 
 from ..console import safe_print
 from ..database import RETRIEVAL_QUERY, create_text_agent, embed_texts, get_chroma_collection
+from ..indexer.parser import StoryParser
+
+INITIAL_RESULT_COUNT = 3
+RAW_FALLBACK_RESULT_COUNT = 5
+INSUFFICIENT_SOURCE_CONTEXT = (
+    "Insufficient source context: no raw source scenes were found for this question."
+)
 
 
 class StoryQueryEngine:
@@ -38,9 +45,7 @@ class StoryQueryEngine:
         """Builds the system prompt with invariants and state ledger."""
         prompt = (
             "You are an expert lore-keeper and archivist for a Japanese narrative story.\n"
-            "Use only the retrieved context provided in this request. Some retrieved context may "
-            "be generated summaries rather than raw source scenes until raw evidence retrieval is "
-            "implemented.\n"
+            "Answer based strictly on the provided raw source text in retrieved context.\n"
             "Do NOT use outside knowledge. If the provided context does not contain the answer, "
             "say so.\n"
             "Cite sources using only the CITATION labels provided in retrieved context. "
@@ -73,16 +78,20 @@ class StoryQueryEngine:
 
     def _citation_label(self, metadata: dict[str, Any]) -> str:
         arc_id = metadata.get("arc_id", "unknown")
-        level = metadata.get("summary_level", 4)
-        if level == 1:
-            return f"[{arc_id}]"
-
         episode = self._episode_label(metadata)
-        if level == 2:
-            return f"[{arc_id}, {episode}]"
 
         part = metadata.get("part_name", "unknown")
-        return f"[{arc_id}, {episode}, Part {part}]"
+        scene_index = metadata.get("scene_index")
+        if isinstance(scene_index, int) and scene_index >= 0:
+            return f"{arc_id} · {episode} · Part {part} · Scene {scene_index + 1}"
+        return f"{arc_id} · {episode} · Part {part}"
+
+    def _citation_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "file_path": metadata.get("file_path"),
+            "scene_index": metadata.get("scene_index"),
+            "canonical_story_order": metadata.get("canonical_story_order"),
+        }
 
     def _episode_label(self, metadata: dict[str, Any]) -> str:
         story_type = metadata.get("story_type")
@@ -95,32 +104,45 @@ class StoryQueryEngine:
         return f"Episode {episode_name}"
 
     def _fetch_raw_text(self, metadata: dict[str, Any]) -> str:
-        """Fetches the raw text from disk based on the retrieved summary metadata."""
-        level = metadata.get("summary_level", 4)
+        """Fetches one raw scene from disk based on (file_path, scene_index)."""
         file_path = metadata.get("file_path", "")
+        scene_index = metadata.get("scene_index")
 
-        if not file_path or not os.path.exists(file_path):
-            return "Raw text not found."
+        if not file_path or not isinstance(scene_index, int) or scene_index < 0:
+            return ""
+        if not os.path.exists(file_path):
+            return ""
 
         path = Path(file_path)
+        with open(path, encoding="utf-8") as f:
+            scenes = StoryParser.split_into_scenes(f.read())
 
-        if level == 3:
-            with open(path, encoding="utf-8") as f:
-                return f"Source: {metadata.get('episode_name')} - {metadata.get('part_name')}\n" + f.read()
+        if scene_index >= len(scenes):
+            return ""
 
-        return (
-            "Broad Summary retrieved; raw text omitted to preserve context window. "
-            "Relying on the SUMMARY text provided above."
-        )
+        return scenes[scene_index]
 
-    def _retrieve(self, question: str) -> list[tuple[str, dict[str, Any]]]:
+    def _retrieve(
+        self,
+        question: str,
+        *,
+        n_results: int = INITIAL_RESULT_COUNT,
+        where: dict[str, Any] | None = None,
+    ) -> list[tuple[str, dict[str, Any]]]:
         query_embedding = embed_texts([question], task_type=RETRIEVAL_QUERY)[0]
-        results = self.collection.query(
-            query_embeddings=[query_embedding],
-            n_results=3,
-            include=["documents", "metadatas"],
-        )
+        query_kwargs: dict[str, Any] = {
+            "query_embeddings": [query_embedding],
+            "n_results": n_results,
+            "include": ["documents", "metadatas"],
+        }
+        if where:
+            query_kwargs["where"] = where
 
+        results = self.collection.query(**query_kwargs)
+
+        return self._results_to_nodes(results)
+
+    def _results_to_nodes(self, results: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
         documents = results.get("documents") or [[]]
         metadatas = results.get("metadatas") or [[]]
         return [
@@ -128,43 +150,115 @@ class StoryQueryEngine:
             for document, metadata in zip(documents[0], metadatas[0], strict=False)
         ]
 
-    def query(self, question: str) -> str:
-        """Executes the Hierarchical RAG query flow."""
-        safe_print("Searching vector index for relevant summaries...")
-        retrieved_nodes = self._retrieve(question)
+    def _raw_scene_filter_for_summary(self, metadata: dict[str, Any]) -> dict[str, Any] | None:
+        level = metadata.get("summary_level")
+        if level == 1:
+            parent_year_id = metadata.get("parent_year_id") or metadata.get("arc_id")
+            if isinstance(parent_year_id, str) and parent_year_id:
+                return {
+                    "$and": [
+                        {"summary_level": 4},
+                        {"parent_year_id": parent_year_id},
+                    ]
+                }
+        if level == 2:
+            parent_episode_id = metadata.get("parent_episode_id")
+            if isinstance(parent_episode_id, str) and parent_episode_id:
+                return {
+                    "$and": [
+                        {"summary_level": 4},
+                        {"parent_episode_id": parent_episode_id},
+                    ]
+                }
+        if level == 3:
+            parent_part_id = metadata.get("parent_part_id")
+            if isinstance(parent_part_id, str) and parent_part_id:
+                return {
+                    "$and": [
+                        {"summary_level": 4},
+                        {"parent_part_id": parent_part_id},
+                    ]
+                }
+        return None
 
-        if not retrieved_nodes:
-            return "No relevant information found in the index."
+    def _expand_summaries_to_raw_scenes(
+        self,
+        question: str,
+        summaries: list[tuple[str, dict[str, Any]]],
+    ) -> list[tuple[str, dict[str, Any]]]:
+        expanded_nodes: list[tuple[str, dict[str, Any]]] = []
+        seen: set[tuple[str, int]] = set()
 
-        arc_ids = set()
-        raw_contexts = []
+        for _, metadata in summaries:
+            raw_filter = self._raw_scene_filter_for_summary(metadata)
+            if raw_filter is None:
+                continue
 
-        safe_print("Fetching raw text from disk for top matches...")
-        for idx, (summary, meta) in enumerate(retrieved_nodes):
+            for document, raw_metadata in self._retrieve(
+                question,
+                n_results=RAW_FALLBACK_RESULT_COUNT,
+                where=raw_filter,
+            ):
+                if raw_metadata.get("summary_level") != 4:
+                    continue
+                scene_key = (
+                    str(raw_metadata.get("file_path", "")),
+                    int(raw_metadata.get("scene_index", -1)),
+                )
+                if scene_key in seen:
+                    continue
+                seen.add(scene_key)
+                expanded_nodes.append((document, raw_metadata))
+
+        return expanded_nodes
+
+    def _raw_evidence_nodes(
+        self,
+        nodes: list[tuple[str, dict[str, Any]]],
+    ) -> list[tuple[str, dict[str, Any]]]:
+        return [(document, metadata) for document, metadata in nodes if metadata.get("summary_level") == 4]
+
+    def _build_context_chunks(self, raw_nodes: list[tuple[str, dict[str, Any]]]) -> list[str]:
+        context_chunks = []
+        for idx, (document, meta) in enumerate(raw_nodes):
             arc_id = meta.get("arc_id")
+            safe_print(
+                f"  Evidence {idx + 1}: Year {arc_id}, Ep: {meta.get('episode_name')}, "
+                f"Part: {meta.get('part_name')}, Scene: {meta.get('scene_index')}"
+            )
+
+            raw_text = self._fetch_raw_text(meta) or document
+            citation = self._citation_label(meta)
+            citation_metadata = self._citation_metadata(meta)
+            context_chunk = (
+                f"--- RAW EVIDENCE {idx + 1} "
+                f"(CITATION: {citation}; "
+                f"METADATA: {json.dumps(citation_metadata, ensure_ascii=False)}) ---\n"
+            )
+            context_chunk += f"RAW SOURCE TEXT:\n{raw_text}\n"
+            context_chunks.append(context_chunk)
+
+        return context_chunks
+
+    def _raw_arc_ids(self, raw_nodes: list[tuple[str, dict[str, Any]]]) -> set[str]:
+        arc_ids = set()
+        for _, metadata in raw_nodes:
+            arc_id = metadata.get("arc_id")
             if isinstance(arc_id, str):
                 arc_ids.add(arc_id)
+        return arc_ids
 
-            safe_print(
-                f"  Match {idx + 1}: Tier {meta.get('summary_level')} - Year {arc_id}, "
-                f"Ep: {meta.get('episode_name')}, Part: {meta.get('part_name')}"
-            )
-
-            raw_text = self._fetch_raw_text(meta)
-            citation = self._citation_label(meta)
-            context_chunk = (
-                f"--- RETRIEVED CONTEXT {idx + 1} "
-                f"(Citation: {citation}; Metadata: {json.dumps(meta, ensure_ascii=False)}) ---\n"
-            )
-            context_chunk += f"SUMMARY:\n{summary}\n\nRAW TEXT:\n{raw_text}\n"
-            raw_contexts.append(context_chunk)
-
-        state_ledger_arc_ids = self._state_ledger_arc_ids(question, arc_ids)
+    def _answer_from_raw_evidence(
+        self,
+        question: str,
+        raw_nodes: list[tuple[str, dict[str, Any]]],
+    ) -> str:
+        state_ledger_arc_ids = self._state_ledger_arc_ids(question, self._raw_arc_ids(raw_nodes))
         system_prompt = self._build_system_prompt(state_ledger_arc_ids)
-        combined_context = "\n".join(raw_contexts)
+        combined_context = "\n".join(self._build_context_chunks(raw_nodes))
 
         user_prompt = (
-            "Please answer the following question based ONLY on the context provided below.\n\n"
+            "Please answer the following question based ONLY on the raw source text provided below.\n\n"
             "Every factual claim should cite one or more provided CITATION labels exactly as written. "
             "Use episode numbers in citations, never Japanese episode titles.\n\n"
             f"QUESTION: {question}\n\n"
@@ -174,3 +268,33 @@ class StoryQueryEngine:
         safe_print("Synthesizing final answer with Gemini...")
         result = create_text_agent(system_prompt).run_sync(user_prompt)
         return result.output.strip() or "No answer generated."
+
+    def _raw_only_retrieve(self, question: str) -> list[tuple[str, dict[str, Any]]]:
+        results = self.collection.query(
+            query_embeddings=[embed_texts([question], task_type=RETRIEVAL_QUERY)[0]],
+            n_results=RAW_FALLBACK_RESULT_COUNT,
+            where={"summary_level": 4},
+            include=["documents", "metadatas"],
+        )
+        return self._results_to_nodes(results)
+
+    def query(self, question: str) -> str:
+        """Executes the Hierarchical RAG query flow."""
+        safe_print("Searching vector index for relevant context...")
+        retrieved_nodes = self._retrieve(question)
+
+        if not retrieved_nodes:
+            safe_print("Initial retrieval returned no hits; trying raw-scene retrieval...")
+            raw_nodes = self._raw_evidence_nodes(self._raw_only_retrieve(question))
+        else:
+            raw_nodes = self._raw_evidence_nodes(retrieved_nodes)
+
+        if not raw_nodes and retrieved_nodes:
+            safe_print("Initial retrieval found only summaries; expanding to child raw scenes...")
+            raw_nodes = self._expand_summaries_to_raw_scenes(question, retrieved_nodes)
+
+        if not raw_nodes:
+            return INSUFFICIENT_SOURCE_CONTEXT
+
+        safe_print("Building answer context from raw source scenes...")
+        return self._answer_from_raw_evidence(question, raw_nodes)

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from linkura_story_indexer import database
 from linkura_story_indexer.query import engine as query_engine
-from linkura_story_indexer.query.engine import StoryQueryEngine
+from linkura_story_indexer.query.engine import INSUFFICIENT_SOURCE_CONTEXT, StoryQueryEngine
 
 
 def make_engine() -> StoryQueryEngine:
@@ -15,13 +15,13 @@ def make_engine() -> StoryQueryEngine:
     return engine
 
 
-def test_system_prompt_softens_raw_source_claim_and_compacts_ledger():
+def test_system_prompt_restores_raw_source_claim_and_compacts_ledger():
     engine = make_engine()
 
     prompt = engine._build_system_prompt({"103"})
 
-    assert "based strictly on the provided raw source text" not in prompt
-    assert "Some retrieved context may be generated summaries" in prompt
+    assert "based strictly on the provided raw source text" in prompt
+    assert "Some retrieved context may be generated summaries" not in prompt
     assert '{"characters":[{"name":"Kaho Hinoshita"}]}' in prompt
     assert '\n  "characters"' not in prompt
     assert "YEAR 104 FACTS" not in prompt
@@ -67,3 +67,145 @@ def test_retrieve_uses_query_embedding_task_type(monkeypatch):
     assert retrieved == [("summary", {"arc_id": "103", "summary_level": 3})]
     assert calls[0] == {"texts": ["question"], "task_type": database.RETRIEVAL_QUERY}
     assert calls[1]["query_embeddings"] == [[0.1, 0.2]]
+
+
+def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
+    engine = make_engine()
+    query_calls: list[dict[str, Any]] = []
+    agent_prompts: list[str] = []
+
+    class FakeCollection:
+        def query(self, **kwargs: Any) -> dict[str, list[list[Any]]]:
+            query_calls.append(kwargs)
+            if len(query_calls) == 1:
+                return {
+                    "documents": [["part summary"]],
+                    "metadatas": [
+                        [
+                            {
+                                "arc_id": "103",
+                                "story_type": "Main",
+                                "episode_name": "第3話『テスト』",
+                                "part_name": "2",
+                                "summary_level": 3,
+                                "parent_part_id": "103|Main|第3話『テスト』|2",
+                            }
+                        ]
+                    ],
+                }
+            return {
+                "documents": [["花帆: raw scene"]],
+                "metadatas": [
+                    [
+                        {
+                            "arc_id": "103",
+                            "story_type": "Main",
+                            "episode_name": "第3話『テスト』",
+                            "part_name": "2",
+                            "summary_level": 4,
+                            "file_path": "missing.md",
+                            "scene_index": 4,
+                            "canonical_story_order": 30,
+                            "parent_part_id": "103|Main|第3話『テスト』|2",
+                        }
+                    ]
+                ],
+            }
+
+    class FakeAgent:
+        def run_sync(self, prompt: str) -> Any:
+            agent_prompts.append(prompt)
+
+            class Result:
+                output = "answered from raw scene"
+
+            return Result()
+
+    monkeypatch.setattr(query_engine, "embed_texts", lambda texts, *, task_type: [[0.1]])
+    monkeypatch.setattr(query_engine, "create_text_agent", lambda system_prompt: FakeAgent())
+    engine.collection = FakeCollection()
+
+    answer = engine.query("What happened?")
+
+    assert answer == "answered from raw scene"
+    assert len(query_calls) == 2
+    assert query_calls[1]["where"] == {
+        "$and": [
+            {"summary_level": 4},
+            {"parent_part_id": "103|Main|第3話『テスト』|2"},
+        ]
+    }
+    assert "SUMMARY:" not in agent_prompts[0]
+    assert "花帆: raw scene" in agent_prompts[0]
+    assert "103 · Episode 3 · Part 2 · Scene 5" in agent_prompts[0]
+
+
+def test_query_reports_insufficient_source_context_without_raw_evidence(monkeypatch):
+    engine = make_engine()
+    query_calls: list[dict[str, Any]] = []
+    agent_called = False
+
+    class FakeCollection:
+        def query(self, **kwargs: Any) -> dict[str, list[list[Any]]]:
+            query_calls.append(kwargs)
+            return {
+                "documents": [["part summary"]],
+                "metadatas": [
+                    [
+                        {
+                            "arc_id": "103",
+                            "summary_level": 3,
+                            "parent_part_id": "103|Main|第3話『テスト』|2",
+                        }
+                    ]
+                ],
+            }
+
+    def fake_create_text_agent(system_prompt: str) -> Any:
+        nonlocal agent_called
+        agent_called = True
+        return object()
+
+    monkeypatch.setattr(query_engine, "embed_texts", lambda texts, *, task_type: [[0.1]])
+    monkeypatch.setattr(query_engine, "create_text_agent", fake_create_text_agent)
+    engine.collection = FakeCollection()
+
+    answer = engine.query("What happened?")
+
+    assert answer == INSUFFICIENT_SOURCE_CONTEXT
+    assert len(query_calls) == 2
+    assert agent_called is False
+
+
+def test_fetch_raw_text_returns_only_requested_scene(tmp_path):
+    engine = make_engine()
+    story_file = tmp_path / "part.md"
+    story_file.write_text("scene zero\n---\nscene one\n---\nscene two", encoding="utf-8")
+
+    raw_text = engine._fetch_raw_text({"file_path": str(story_file), "scene_index": 1})
+
+    assert raw_text == "scene one"
+
+
+def test_citation_label_and_metadata_are_split():
+    engine = make_engine()
+    metadata = {
+        "arc_id": "103",
+        "story_type": "Main",
+        "episode_name": "第3話『テスト』",
+        "part_name": "2",
+        "file_path": "story/103/第3話『テスト』/2.md",
+        "scene_index": 4,
+        "canonical_story_order": 30,
+    }
+
+    label = engine._citation_label(metadata)
+    citation_metadata = engine._citation_metadata(metadata)
+
+    assert label == "103 · Episode 3 · Part 2 · Scene 5"
+    assert "story/" not in label
+    assert citation_metadata == {
+        "file_path": "story/103/第3話『テスト』/2.md",
+        "scene_index": 4,
+        "canonical_story_order": 30,
+    }


### PR DESCRIPTION
## Summary

- Gate answer generation on raw scene evidence (`summary_level == 4`)
- Add summary-to-child-scene expansion fallback for Tier 1/2/3 routing hits
- Return an explicit insufficient-source-context response when no raw scenes are found
- Fetch exact raw scene spans by `(file_path, scene_index)` and clean up citation labels/metadata
- Restore strict raw-source grounding in the system prompt

Closes #3

## Validation

- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`