### PR TITLE
Add glossary-expanded lexical retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,4 @@ config.json
 chroma_db/
 summaries_cache.json
 world_state.json
+lexical_index.db

--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -16,6 +16,7 @@ from .indexer.chunker import build_retrieval_chunks
 from .indexer.extractor import StateExtractor
 from .indexer.processor import StoryProcessor
 from .indexer.summarizer import HierarchicalSummarizer, episode_sort_key, natural_sort_key
+from .lexical import LexicalIndex, get_lexical_db_path, glossary_alias_groups
 from .models.story import StoryNode
 from .query.engine import StoryQueryEngine
 
@@ -58,13 +59,13 @@ def _translation_aliases(node: StoryNode, glossary: dict | None) -> list[str]:
     aliases = []
     seen = set()
     searchable_text = "\n".join([node.text, *node.metadata.detected_speakers])
-    for terms in glossary.values():
-        if not isinstance(terms, dict):
+    for group in glossary_alias_groups(glossary):
+        if len(group) < 2:
             continue
-        for japanese, english in terms.items():
-            if japanese in searchable_text and english not in seen:
-                aliases.append(english)
-                seen.add(english)
+        english = group[1]
+        if any(alias in searchable_text for alias in group) and english not in seen:
+            aliases.append(english)
+            seen.add(english)
     return aliases
 
 
@@ -115,6 +116,24 @@ def _embedding_document(node: StoryNode, glossary: dict | None = None) -> Embedd
     return EmbeddingDocument(text=f"{header}{node.text}", title=_embedding_document_title(node))
 
 
+def _lexical_document(node: StoryNode, glossary: dict | None = None) -> str:
+    embedding_document = _embedding_document(node, glossary)
+    if node.summary_level != 4:
+        meta = node.metadata
+        header = "\n".join(
+            [
+                f"Year: {meta.arc_id}",
+                f"Story type: {meta.story_type}",
+                f"Episode: {meta.episode_name}",
+                f"Part: {meta.part_name}",
+                f"Summary level: {node.summary_level}",
+                "",
+            ]
+        )
+        return f"{header}{node.text}"
+    return embedding_document.text
+
+
 def _metadata_for_node(node: StoryNode) -> dict:
     metadata = node.metadata.model_dump()
     metadata["detected_speakers"] = "|".join(node.metadata.detected_speakers)
@@ -127,6 +146,7 @@ def _upsert_story_nodes(
     *,
     progress_label: str,
     glossary: dict | None = None,
+    lexical_index: LexicalIndex | None = None,
 ) -> None:
     collection = get_chroma_collection()
     batch_size = 32
@@ -137,14 +157,23 @@ def _upsert_story_nodes(
             batch = nodes[start : start + batch_size]
             documents = [node.text for node in batch]
             embedding_documents = [_embedding_document(node, glossary) for node in batch]
+            lexical_documents = [_lexical_document(node, glossary) for node in batch]
             metadatas = [_metadata_for_node(node) for node in batch]
+            ids = [_node_id(node) for node in batch]
 
             collection.upsert(
-                ids=[_node_id(node) for node in batch],
+                ids=ids,
                 documents=documents,
                 metadatas=metadatas,
                 embeddings=embed_texts(embedding_documents, task_type=RETRIEVAL_DOCUMENT),
             )
+            if lexical_index is not None:
+                lexical_index.upsert_records(
+                    ids=ids,
+                    documents=documents,
+                    metadatas=metadatas,
+                    search_texts=lexical_documents,
+                )
             progress.update(task, advance=len(batch))
 
 @app.command()
@@ -235,13 +264,20 @@ def ingest(story_dir: str = typer.Option("story", help="Directory containing sto
     summary_nodes = summarizer.summarize_hierarchy(raw_nodes)
     
     console.print(f"Generated {len(summary_nodes)} hierarchical summaries. Upserting to Vector DB...")
+    lexical_index = LexicalIndex(get_lexical_db_path())
     
     _upsert_story_nodes(
         retrieval_chunks,
         progress_label="[green]Embedding raw retrieval chunks...",
         glossary=glossary,
+        lexical_index=lexical_index,
     )
-    _upsert_story_nodes(summary_nodes, progress_label="[green]Embedding summaries...")
+    _upsert_story_nodes(
+        summary_nodes,
+        progress_label="[green]Embedding summaries...",
+        glossary=glossary,
+        lexical_index=lexical_index,
+    )
     
     console.print("[bold green]Hierarchical Ingestion complete![/bold green]")
 

--- a/src/linkura_story_indexer/lexical.py
+++ b/src/linkura_story_indexer/lexical.py
@@ -1,0 +1,251 @@
+import json
+import os
+import re
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+DEFAULT_LEXICAL_DB_PATH = "./lexical_index.db"
+
+_CJK_RE = re.compile(r"[\u3040-\u30ff\u3400-\u9fff々〆〤ー]+")
+_WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9'_-]*")
+
+
+def get_lexical_db_path() -> str:
+    return os.getenv("LINKURA_LEXICAL_DB_PATH", DEFAULT_LEXICAL_DB_PATH)
+
+
+def _ordered_unique(values: Iterable[str]) -> list[str]:
+    unique = []
+    seen = set()
+    for value in values:
+        cleaned = value.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        unique.append(cleaned)
+        seen.add(cleaned)
+    return unique
+
+
+def _english_alias_parts(value: str) -> list[str]:
+    return [part for part in _WORD_RE.findall(value) if len(part) >= 2]
+
+
+def _japanese_short_aliases(value: str) -> list[str]:
+    if not _CJK_RE.fullmatch(value):
+        return []
+    aliases = []
+    if len(value) >= 4:
+        aliases.append(value[-2:])
+    if len(value) >= 5:
+        aliases.append(value[-3:])
+    return aliases
+
+
+def glossary_alias_groups(glossary: dict[str, dict[str, str]] | None) -> list[list[str]]:
+    if not glossary:
+        return []
+
+    groups = []
+    for terms in glossary.values():
+        if not isinstance(terms, dict):
+            continue
+        for japanese, english in terms.items():
+            aliases = [japanese, english]
+            aliases.extend(_english_alias_parts(english))
+            aliases.extend(_japanese_short_aliases(japanese))
+            groups.append(_ordered_unique(aliases))
+    return groups
+
+
+def expand_query_with_glossary(
+    question: str,
+    glossary: dict[str, dict[str, str]] | None,
+) -> str:
+    additions = []
+    question_lower = question.casefold()
+
+    for aliases in glossary_alias_groups(glossary):
+        if any(alias in question or alias.casefold() in question_lower for alias in aliases):
+            additions.extend(aliases)
+
+    expanded_aliases = _ordered_unique(additions)
+    if not expanded_aliases:
+        return question
+    return f"{question} {' / '.join(expanded_aliases)}"
+
+
+def _fts_terms(query: str) -> list[str]:
+    terms = []
+    terms.extend(term for term in _CJK_RE.findall(query) if len(term) >= 3)
+    terms.extend(term for term in _WORD_RE.findall(query) if len(term) >= 3)
+    return _ordered_unique(terms)
+
+
+def _like_terms(query: str) -> list[str]:
+    terms = []
+    terms.extend(term for term in _CJK_RE.findall(query) if len(term) >= 2)
+    terms.extend(term for term in _WORD_RE.findall(query) if len(term) >= 3)
+    return _ordered_unique(terms)
+
+
+def _quote_fts_term(term: str) -> str:
+    escaped = term.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _metadata_matches_where(metadata: dict[str, Any], where: dict[str, Any] | None) -> bool:
+    if not where:
+        return True
+
+    and_filters = where.get("$and")
+    if isinstance(and_filters, list):
+        return all(
+            isinstance(item, dict) and _metadata_matches_where(metadata, item)
+            for item in and_filters
+        )
+
+    for key, expected in where.items():
+        if key == "$and":
+            continue
+        if metadata.get(key) != expected:
+            return False
+    return True
+
+
+class LexicalIndex:
+    def __init__(self, path: str | Path | None = None):
+        self.path = Path(path or get_lexical_db_path())
+        if self.path.parent != Path("."):
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS lexical_records (
+                    id TEXT PRIMARY KEY,
+                    document TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL,
+                    search_text TEXT NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE VIRTUAL TABLE IF NOT EXISTS lexical_records_fts
+                USING fts5(id UNINDEXED, search_text, tokenize='trigram')
+                """
+            )
+
+    def upsert_records(
+        self,
+        *,
+        ids: list[str],
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+        search_texts: list[str] | None = None,
+    ) -> None:
+        if search_texts is None:
+            search_texts = documents
+        if not (len(ids) == len(documents) == len(metadatas) == len(search_texts)):
+            raise ValueError("ids, documents, metadatas, and search_texts must have matching lengths")
+
+        with self._connect() as connection:
+            for record_id, document, metadata, search_text in zip(
+                ids,
+                documents,
+                metadatas,
+                search_texts,
+                strict=True,
+            ):
+                connection.execute("DELETE FROM lexical_records WHERE id = ?", (record_id,))
+                connection.execute("DELETE FROM lexical_records_fts WHERE id = ?", (record_id,))
+                metadata_json = json.dumps(metadata, ensure_ascii=False, separators=(",", ":"))
+                connection.execute(
+                    """
+                    INSERT INTO lexical_records (id, document, metadata_json, search_text)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (record_id, document, metadata_json, search_text),
+                )
+                connection.execute(
+                    """
+                    INSERT INTO lexical_records_fts (id, search_text)
+                    VALUES (?, ?)
+                    """,
+                    (record_id, search_text),
+                )
+
+    def search(
+        self,
+        query: str,
+        *,
+        n_results: int,
+        where: dict[str, Any] | None = None,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        if n_results < 1:
+            return []
+
+        candidate_limit = max(n_results * 10, 50) if where else n_results
+        rows: list[sqlite3.Row] = []
+        seen_ids: set[str] = set()
+
+        fts_query = " OR ".join(_quote_fts_term(term) for term in _fts_terms(query))
+        with self._connect() as connection:
+            if fts_query:
+                try:
+                    rows.extend(
+                        connection.execute(
+                            """
+                            SELECT r.id, r.document, r.metadata_json
+                            FROM lexical_records_fts AS f
+                            JOIN lexical_records AS r ON r.id = f.id
+                            WHERE f.search_text MATCH ?
+                            ORDER BY bm25(f)
+                            LIMIT ?
+                            """,
+                            (fts_query, candidate_limit),
+                        ).fetchall()
+                    )
+                except sqlite3.OperationalError:
+                    rows = []
+
+            for term in _like_terms(query):
+                for row in connection.execute(
+                    """
+                    SELECT id, document, metadata_json
+                    FROM lexical_records
+                    WHERE search_text LIKE ?
+                    LIMIT ?
+                    """,
+                    (f"%{term}%", candidate_limit),
+                ).fetchall():
+                    if row["id"] not in seen_ids:
+                        rows.append(row)
+                        seen_ids.add(row["id"])
+
+        results = []
+        emitted_ids = set()
+        for row in rows:
+            record_id = str(row["id"])
+            if record_id in emitted_ids:
+                continue
+            emitted_ids.add(record_id)
+            metadata = json.loads(str(row["metadata_json"]))
+            if not isinstance(metadata, dict):
+                continue
+            if not _metadata_matches_where(metadata, where):
+                continue
+            results.append((str(row["document"]), metadata))
+            if len(results) >= n_results:
+                break
+
+        return results

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -7,6 +7,7 @@ from typing import Any
 from ..console import safe_print
 from ..database import RETRIEVAL_QUERY, create_text_agent, embed_texts, get_chroma_collection
 from ..indexer.parser import StoryParser
+from ..lexical import LexicalIndex, expand_query_with_glossary
 
 INITIAL_RESULT_COUNT = 3
 RAW_FALLBACK_RESULT_COUNT = 5
@@ -18,6 +19,7 @@ INSUFFICIENT_SOURCE_CONTEXT = (
 class StoryQueryEngine:
     def __init__(self, state_file: str = "world_state.json", glossary_file: str = "glossary.json"):
         self.collection = get_chroma_collection()
+        self.lexical_index = LexicalIndex()
 
         self.state_ledger: dict[str, Any] = {}
         if os.path.exists(state_file):
@@ -28,6 +30,9 @@ class StoryQueryEngine:
         if os.path.exists(glossary_file):
             with open(glossary_file, encoding="utf-8") as f:
                 self.glossary = json.load(f)
+
+    def _expanded_question(self, question: str) -> str:
+        return expand_query_with_glossary(question, self.glossary)
 
     def _question_arc_ids(self, question: str) -> set[str]:
         """Find explicit story arc IDs mentioned in the user's question."""
@@ -183,6 +188,63 @@ class StoryQueryEngine:
             for document, metadata in zip(documents[0], metadatas[0], strict=False)
         ]
 
+    def _lexical_retrieve(
+        self,
+        question: str,
+        *,
+        n_results: int = INITIAL_RESULT_COUNT,
+        where: dict[str, Any] | None = None,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        lexical_index = getattr(self, "lexical_index", None)
+        if lexical_index is None:
+            return []
+        return lexical_index.search(question, n_results=n_results, where=where)
+
+    def _node_key(self, document: str, metadata: dict[str, Any]) -> tuple[Any, ...]:
+        scene_start = metadata.get("scene_start")
+        if not isinstance(scene_start, int):
+            scene_start = metadata.get("scene_index")
+        scene_end = metadata.get("scene_end")
+        if not isinstance(scene_end, int):
+            scene_end = scene_start
+        key = (
+            metadata.get("summary_level"),
+            metadata.get("parent_year_id"),
+            metadata.get("parent_episode_id"),
+            metadata.get("parent_part_id"),
+            metadata.get("file_path"),
+            scene_start,
+            scene_end,
+        )
+        if any(part not in (None, "") for part in key):
+            return key
+        return (document,)
+
+    def _dedupe_nodes(
+        self,
+        nodes: list[tuple[str, dict[str, Any]]],
+    ) -> list[tuple[str, dict[str, Any]]]:
+        deduped = []
+        seen = set()
+        for document, metadata in nodes:
+            key = self._node_key(document, metadata)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append((document, metadata))
+        return deduped
+
+    def _hybrid_retrieve(
+        self,
+        question: str,
+        *,
+        n_results: int = INITIAL_RESULT_COUNT,
+        where: dict[str, Any] | None = None,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        dense_nodes = self._retrieve(question, n_results=n_results, where=where)
+        lexical_nodes = self._lexical_retrieve(question, n_results=n_results, where=where)
+        return self._dedupe_nodes([*dense_nodes, *lexical_nodes])
+
     def _raw_scene_filter_for_summary(self, metadata: dict[str, Any]) -> dict[str, Any] | None:
         level = metadata.get("summary_level")
         if level == 1:
@@ -227,7 +289,7 @@ class StoryQueryEngine:
             if raw_filter is None:
                 continue
 
-            for document, raw_metadata in self._retrieve(
+            for document, raw_metadata in self._hybrid_retrieve(
                 question,
                 n_results=RAW_FALLBACK_RESULT_COUNT,
                 where=raw_filter,
@@ -311,28 +373,27 @@ class StoryQueryEngine:
         return result.output.strip() or "No answer generated."
 
     def _raw_only_retrieve(self, question: str) -> list[tuple[str, dict[str, Any]]]:
-        results = self.collection.query(
-            query_embeddings=[embed_texts([question], task_type=RETRIEVAL_QUERY)[0]],
+        return self._hybrid_retrieve(
+            question,
             n_results=RAW_FALLBACK_RESULT_COUNT,
             where={"summary_level": 4},
-            include=["documents", "metadatas"],
         )
-        return self._results_to_nodes(results)
 
     def query(self, question: str) -> str:
         """Executes the Hierarchical RAG query flow."""
         safe_print("Searching vector index for relevant context...")
-        retrieved_nodes = self._retrieve(question)
+        expanded_question = self._expanded_question(question)
+        retrieved_nodes = self._hybrid_retrieve(expanded_question)
 
         if not retrieved_nodes:
             safe_print("Initial retrieval returned no hits; trying raw-scene retrieval...")
-            raw_nodes = self._raw_evidence_nodes(self._raw_only_retrieve(question))
+            raw_nodes = self._raw_evidence_nodes(self._raw_only_retrieve(expanded_question))
         else:
             raw_nodes = self._raw_evidence_nodes(retrieved_nodes)
 
         if not raw_nodes and retrieved_nodes:
             safe_print("Initial retrieval found only summaries; expanding to child raw scenes...")
-            raw_nodes = self._expand_summaries_to_raw_scenes(question, retrieved_nodes)
+            raw_nodes = self._expand_summaries_to_raw_scenes(expanded_question, retrieved_nodes)
 
         if not raw_nodes:
             return INSUFFICIENT_SOURCE_CONTEXT

--- a/tests/test_lexical.py
+++ b/tests/test_lexical.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+from typing import Any
+
+from linkura_story_indexer import cli
+from linkura_story_indexer.lexical import LexicalIndex, expand_query_with_glossary
+from linkura_story_indexer.models.story import StoryMetadata, StoryNode
+
+
+def _metadata(**overrides: Any) -> dict[str, Any]:
+    metadata = {
+        "arc_id": "103",
+        "story_type": "Main",
+        "episode_name": "第1話『花咲きたい！』",
+        "part_name": "1",
+        "file_path": "story/103/第1話『花咲きたい！』/1.md",
+        "scene_index": 0,
+        "scene_start": 0,
+        "scene_end": 1,
+        "source_scene_count": 2,
+        "canonical_story_order": 1,
+        "parent_year_id": "103",
+        "parent_episode_id": "103|Main|第1話『花咲きたい！』",
+        "parent_part_id": "103|Main|第1話『花咲きたい！』|1",
+        "summary_level": 4,
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+def test_glossary_expansion_adds_full_and_short_aliases() -> None:
+    glossary = {"characters": {"日野下花帆": "Kaho Hinoshita"}}
+
+    expanded = expand_query_with_glossary("What does Kaho say?", glossary)
+
+    assert "What does Kaho say?" in expanded
+    assert "Kaho Hinoshita" in expanded
+    assert "日野下花帆" in expanded
+    assert "花帆" in expanded
+
+
+def test_lexical_index_finds_short_japanese_name_and_preserves_span(tmp_path: Path) -> None:
+    index = LexicalIndex(tmp_path / "lexical.db")
+    index.upsert_records(
+        ids=["chunk:one:0-1", "chunk:two:0-0"],
+        documents=["花帆: 走ろう", "さやか: 待って"],
+        metadatas=[
+            _metadata(scene_start=0, scene_end=1),
+            _metadata(scene_start=0, scene_end=0, parent_part_id="other"),
+        ],
+    )
+
+    results = index.search("花帆", n_results=5)
+
+    assert results == [("花帆: 走ろう", _metadata(scene_start=0, scene_end=1))]
+
+
+def test_lexical_index_replaces_records_cleanly(tmp_path: Path) -> None:
+    index = LexicalIndex(tmp_path / "lexical.db")
+    index.upsert_records(
+        ids=["chunk:one:0-0"],
+        documents=["花帆: 古い"],
+        metadatas=[_metadata()],
+    )
+    index.upsert_records(
+        ids=["chunk:one:0-0"],
+        documents=["さやか: 新しい"],
+        metadatas=[_metadata()],
+    )
+
+    assert index.search("花帆", n_results=5) == []
+    assert index.search("さやか", n_results=5) == [("さやか: 新しい", _metadata())]
+
+
+def test_lexical_search_honors_chroma_style_where_filter(tmp_path: Path) -> None:
+    index = LexicalIndex(tmp_path / "lexical.db")
+    index.upsert_records(
+        ids=["chunk:one:0-0", "chunk:two:0-0"],
+        documents=["花帆: one", "花帆: two"],
+        metadatas=[
+            _metadata(parent_part_id="part-one"),
+            _metadata(parent_part_id="part-two"),
+        ],
+    )
+
+    results = index.search(
+        "花帆",
+        n_results=5,
+        where={"$and": [{"summary_level": 4}, {"parent_part_id": "part-two"}]},
+    )
+
+    assert results == [("花帆: two", _metadata(parent_part_id="part-two"))]
+
+
+def test_upsert_story_nodes_writes_matching_lexical_records(tmp_path: Path, monkeypatch) -> None:
+    collection_records: dict[str, dict[str, Any]] = {}
+
+    class FakeCollection:
+        def upsert(
+            self,
+            *,
+            ids: list[str],
+            documents: list[str],
+            metadatas: list[dict[str, Any]],
+            embeddings: list[list[float]],
+        ) -> None:
+            for record_id, document, metadata in zip(ids, documents, metadatas, strict=True):
+                collection_records[record_id] = {"document": document, "metadata": metadata}
+
+    node = StoryNode(
+        text="花帆: こんにちは",
+        metadata=StoryMetadata(
+            arc_id="103",
+            story_type="Main",
+            episode_name="第1話『花咲きたい！』",
+            part_name="1",
+            file_path="story/103/第1話『花咲きたい！』/1.md",
+            detected_speakers=["花帆"],
+            parent_year_id="103",
+            parent_episode_id="103|Main|第1話『花咲きたい！』",
+            parent_part_id="103|Main|第1話『花咲きたい！』|1",
+        ),
+        summary_level=4,
+    )
+    lexical_index = LexicalIndex(tmp_path / "lexical.db")
+
+    monkeypatch.setattr(cli, "get_chroma_collection", lambda: FakeCollection())
+    monkeypatch.setattr(cli, "embed_texts", lambda texts, *, task_type: [[1.0] for _ in texts])
+
+    cli._upsert_story_nodes(
+        [node],
+        progress_label="Embedding test node",
+        glossary={"characters": {"日野下花帆": "Kaho Hinoshita"}},
+        lexical_index=lexical_index,
+    )
+
+    record_id = cli._node_id(node)
+    assert record_id in collection_records
+    assert lexical_index.search("Kaho", n_results=5) == [
+        ("花帆: こんにちは", collection_records[record_id]["metadata"])
+    ]

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -69,6 +69,46 @@ def test_retrieve_uses_query_embedding_task_type(monkeypatch):
     assert calls[1]["query_embeddings"] == [[0.1, 0.2]]
 
 
+def test_hybrid_retrieve_concatenates_and_dedupes_dense_and_lexical(monkeypatch):
+    engine = make_engine()
+    dense_node = (
+        "dense raw",
+        {
+            "summary_level": 4,
+            "file_path": "story/part.md",
+            "scene_start": 0,
+            "scene_end": 1,
+        },
+    )
+    lexical_duplicate = (
+        "lexical raw",
+        {
+            "summary_level": 4,
+            "file_path": "story/part.md",
+            "scene_start": 0,
+            "scene_end": 1,
+        },
+    )
+    lexical_new = (
+        "lexical second",
+        {
+            "summary_level": 4,
+            "file_path": "story/part.md",
+            "scene_start": 2,
+            "scene_end": 2,
+        },
+    )
+
+    monkeypatch.setattr(engine, "_retrieve", lambda question, **kwargs: [dense_node])
+    monkeypatch.setattr(
+        engine,
+        "_lexical_retrieve",
+        lambda question, **kwargs: [lexical_duplicate, lexical_new],
+    )
+
+    assert engine._hybrid_retrieve("expanded question") == [dense_node, lexical_new]
+
+
 def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
     engine = make_engine()
     query_calls: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- add a SQLite FTS lexical side index for the same retrieval records written to Chroma
- expand user queries with glossary aliases before dense and lexical retrieval
- run hybrid dense + lexical retrieval with concat-and-dedupe behavior while preserving raw citation metadata
- add lexical indexing and hybrid retrieval tests

Closes #4.

## Verification
- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`