### PR TITLE
Implement hierarchical retrieval with RRF

### DIFF
--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -18,6 +18,7 @@ MAX_RANKED_CANDIDATES = 40
 FINAL_TOP_K = 8
 MIN_FINAL_TOP_K = 5
 MAX_FINAL_TOP_K = 12
+RRF_K = 60
 INSUFFICIENT_SOURCE_CONTEXT = (
     "Insufficient source context: no raw source scenes were found for this question."
 )
@@ -33,6 +34,7 @@ class RetrievalConfig:
     neighbor_scene_window: int = NEIGHBOR_SCENE_WINDOW
     max_ranked_candidates: int = MAX_RANKED_CANDIDATES
     final_top_k: int = FINAL_TOP_K
+    rrf_k: int = RRF_K
 
     def __post_init__(self) -> None:
         if self.routing_candidate_count < 1:
@@ -47,6 +49,8 @@ class RetrievalConfig:
             raise ValueError("max_ranked_candidates must be at least 1")
         if not MIN_FINAL_TOP_K <= self.final_top_k <= MAX_FINAL_TOP_K:
             raise ValueError(f"final_top_k must be between {MIN_FINAL_TOP_K} and {MAX_FINAL_TOP_K}")
+        if self.rrf_k < 1:
+            raise ValueError("rrf_k must be at least 1")
 
 
 DEFAULT_RETRIEVAL_CONFIG = RetrievalConfig()
@@ -287,6 +291,42 @@ class StoryQueryEngine:
             deduped.append((document, metadata))
         return deduped
 
+    def _rrf_fuse(
+        self,
+        ranked_lists: list[list[Node]],
+        *,
+        k: int | None = None,
+    ) -> list[Node]:
+        rrf_k = self._config().rrf_k if k is None else k
+        if rrf_k < 1:
+            raise ValueError("rrf k must be at least 1")
+
+        scores: dict[tuple[Any, ...], float] = {}
+        nodes_by_key: dict[tuple[Any, ...], Node] = {}
+        first_seen: dict[tuple[Any, ...], int] = {}
+        seen_order = 0
+
+        for ranked_list in ranked_lists:
+            seen_in_list: set[tuple[Any, ...]] = set()
+            for rank, (document, metadata) in enumerate(ranked_list, start=1):
+                key = self._node_key(document, metadata)
+                if key in seen_in_list:
+                    continue
+                seen_in_list.add(key)
+
+                if key not in nodes_by_key:
+                    nodes_by_key[key] = (document, metadata)
+                    first_seen[key] = seen_order
+                    seen_order += 1
+
+                scores[key] = scores.get(key, 0.0) + (1.0 / (rrf_k + rank))
+
+        ranked_keys = sorted(
+            scores,
+            key=lambda key: (-scores[key], first_seen[key]),
+        )
+        return [nodes_by_key[key] for key in ranked_keys]
+
     def _hybrid_retrieve(
         self,
         question: str,
@@ -296,7 +336,26 @@ class StoryQueryEngine:
     ) -> list[Node]:
         dense_nodes = self._retrieve(question, n_results=n_results, where=where)
         lexical_nodes = self._lexical_retrieve(question, n_results=n_results, where=where)
-        return self._dedupe_nodes([*dense_nodes, *lexical_nodes])
+        return self._rrf_fuse([dense_nodes, lexical_nodes])[:n_results]
+
+    def _tiered_retrieve(self, question: str) -> list[Node]:
+        config = self._config()
+        ranked_lists = [
+            self._hybrid_retrieve(
+                question,
+                n_results=config.routing_candidate_count,
+                where={"summary_level": summary_level},
+            )
+            for summary_level in (1, 2, 3)
+        ]
+        ranked_lists.append(
+            self._hybrid_retrieve(
+                question,
+                n_results=config.raw_candidate_count,
+                where={"summary_level": 4},
+            )
+        )
+        return self._rrf_fuse(ranked_lists)
 
     def _raw_scene_filter_for_summary(self, metadata: dict[str, Any]) -> dict[str, Any] | None:
         level = metadata.get("summary_level")
@@ -334,39 +393,24 @@ class StoryQueryEngine:
         question: str,
         summaries: list[Node],
     ) -> list[Node]:
-        expanded_nodes: list[Node] = []
-        seen: set[tuple[str, int, int]] = set()
+        child_ranked_lists: list[list[Node]] = []
 
         for _, metadata in summaries:
             raw_filter = self._raw_scene_filter_for_summary(metadata)
             if raw_filter is None:
                 continue
 
-            for document, raw_metadata in self._hybrid_retrieve(
-                question,
-                n_results=self._config().summary_child_candidate_count,
-                where=raw_filter,
-            ):
-                if raw_metadata.get("summary_level") != 4:
-                    continue
-                scene_start_value = raw_metadata.get("scene_start")
-                if not isinstance(scene_start_value, int):
-                    scene_start_value = raw_metadata.get("scene_index", -1)
-                scene_start = scene_start_value if isinstance(scene_start_value, int) else -1
-
-                scene_end_value = raw_metadata.get("scene_end")
-                scene_end = scene_end_value if isinstance(scene_end_value, int) else scene_start
-                scene_key = (
-                    str(raw_metadata.get("file_path", "")),
-                    scene_start,
-                    scene_end,
+            child_nodes = self._raw_evidence_nodes(
+                self._hybrid_retrieve(
+                    question,
+                    n_results=self._config().summary_child_candidate_count,
+                    where=raw_filter,
                 )
-                if scene_key in seen:
-                    continue
-                seen.add(scene_key)
-                expanded_nodes.append((document, raw_metadata))
+            )
+            if child_nodes:
+                child_ranked_lists.append(child_nodes)
 
-        return expanded_nodes
+        return self._rrf_fuse(child_ranked_lists)
 
     def _raw_evidence_nodes(
         self,
@@ -670,23 +714,25 @@ class StoryQueryEngine:
 
     def query(self, question: str) -> str:
         """Executes the Hierarchical RAG query flow."""
-        safe_print("Searching vector index for relevant context...")
+        safe_print("Searching vector index by summary tiers and raw evidence...")
         expanded_question = self._expanded_question(question)
-        retrieved_nodes = self._hybrid_retrieve(
-            expanded_question,
-            n_results=self._config().routing_candidate_count,
-        )
+        retrieved_nodes = self._tiered_retrieve(expanded_question)
 
         if not retrieved_nodes:
-            safe_print("Initial retrieval returned no hits; trying raw-scene retrieval...")
-        raw_nodes = self._raw_evidence_nodes(retrieved_nodes)
-        raw_nodes.extend(self._raw_evidence_nodes(self._raw_only_retrieve(expanded_question)))
+            safe_print("Tiered retrieval returned no hits.")
 
+        direct_raw_nodes = self._raw_evidence_nodes(retrieved_nodes)
+        raw_ranked_lists = [direct_raw_nodes] if direct_raw_nodes else []
         if retrieved_nodes:
             safe_print("Expanding summary hits to child raw scenes...")
-            raw_nodes.extend(self._expand_summaries_to_raw_scenes(expanded_question, retrieved_nodes))
+            child_raw_nodes = self._expand_summaries_to_raw_scenes(
+                expanded_question,
+                retrieved_nodes,
+            )
+            if child_raw_nodes:
+                raw_ranked_lists.append(child_raw_nodes)
 
-        raw_nodes = self._dedupe_nodes(raw_nodes)
+        raw_nodes = self._rrf_fuse(raw_ranked_lists)
 
         if not raw_nodes:
             return INSUFFICIENT_SOURCE_CONTEXT

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -209,14 +209,19 @@ class StoryQueryEngine:
 
         return "\n\n---\n\n".join(scenes[scene_start : scene_end + 1])
 
+    def _query_embedding(self, question: str) -> list[float]:
+        return embed_texts([question], task_type=RETRIEVAL_QUERY)[0]
+
     def _retrieve(
         self,
         question: str,
         *,
         n_results: int = ROUTING_CANDIDATE_COUNT,
         where: dict[str, Any] | None = None,
+        query_embedding: list[float] | None = None,
     ) -> list[Node]:
-        query_embedding = embed_texts([question], task_type=RETRIEVAL_QUERY)[0]
+        if query_embedding is None:
+            query_embedding = self._query_embedding(question)
         query_kwargs: dict[str, Any] = {
             "query_embeddings": [query_embedding],
             "n_results": n_results,
@@ -333,18 +338,32 @@ class StoryQueryEngine:
         *,
         n_results: int = ROUTING_CANDIDATE_COUNT,
         where: dict[str, Any] | None = None,
+        query_embedding: list[float] | None = None,
     ) -> list[Node]:
-        dense_nodes = self._retrieve(question, n_results=n_results, where=where)
+        dense_nodes = self._retrieve(
+            question,
+            n_results=n_results,
+            where=where,
+            query_embedding=query_embedding,
+        )
         lexical_nodes = self._lexical_retrieve(question, n_results=n_results, where=where)
         return self._rrf_fuse([dense_nodes, lexical_nodes])[:n_results]
 
-    def _tiered_retrieve(self, question: str) -> list[Node]:
+    def _tiered_retrieve(
+        self,
+        question: str,
+        *,
+        query_embedding: list[float] | None = None,
+    ) -> list[Node]:
+        if query_embedding is None:
+            query_embedding = self._query_embedding(question)
         config = self._config()
         ranked_lists = [
             self._hybrid_retrieve(
                 question,
                 n_results=config.routing_candidate_count,
                 where={"summary_level": summary_level},
+                query_embedding=query_embedding,
             )
             for summary_level in (1, 2, 3)
         ]
@@ -353,6 +372,7 @@ class StoryQueryEngine:
                 question,
                 n_results=config.raw_candidate_count,
                 where={"summary_level": 4},
+                query_embedding=query_embedding,
             )
         )
         return self._rrf_fuse(ranked_lists)
@@ -392,7 +412,11 @@ class StoryQueryEngine:
         self,
         question: str,
         summaries: list[Node],
+        *,
+        query_embedding: list[float] | None = None,
     ) -> list[Node]:
+        if query_embedding is None:
+            query_embedding = self._query_embedding(question)
         child_ranked_lists: list[list[Node]] = []
 
         for _, metadata in summaries:
@@ -405,6 +429,7 @@ class StoryQueryEngine:
                     question,
                     n_results=self._config().summary_child_candidate_count,
                     where=raw_filter,
+                    query_embedding=query_embedding,
                 )
             )
             if child_nodes:
@@ -455,7 +480,13 @@ class StoryQueryEngine:
             }
         return None
 
-    def _raw_nodes_for_part(self, question: str, metadata: dict[str, Any]) -> list[Node]:
+    def _raw_nodes_for_part(
+        self,
+        question: str,
+        metadata: dict[str, Any],
+        *,
+        query_embedding: list[float] | None = None,
+    ) -> list[Node]:
         raw_filter = self._raw_part_filter(metadata)
         if raw_filter is None:
             return []
@@ -476,6 +507,7 @@ class StoryQueryEngine:
             question,
             n_results=max(self._config().raw_candidate_count, self._config().max_ranked_candidates),
             where=raw_filter,
+            query_embedding=query_embedding,
         )
 
     def _sort_raw_nodes(self, nodes: list[Node]) -> list[Node]:
@@ -492,7 +524,13 @@ class StoryQueryEngine:
 
         return sorted(nodes, key=sort_key)
 
-    def _expand_raw_neighbors(self, question: str, raw_nodes: list[Node]) -> list[Node]:
+    def _expand_raw_neighbors(
+        self,
+        question: str,
+        raw_nodes: list[Node],
+        *,
+        query_embedding: list[float] | None = None,
+    ) -> list[Node]:
         window = self._config().neighbor_scene_window
         if window < 1:
             return self._dedupe_nodes(raw_nodes)
@@ -515,8 +553,16 @@ class StoryQueryEngine:
                 )
             )
             if part_cache_key not in part_cache:
+                if query_embedding is not None:
+                    part_nodes = self._raw_nodes_for_part(
+                        question,
+                        metadata,
+                        query_embedding=query_embedding,
+                    )
+                else:
+                    part_nodes = self._raw_nodes_for_part(question, metadata)
                 part_cache[part_cache_key] = self._sort_raw_nodes(
-                    self._raw_nodes_for_part(question, metadata)
+                    part_nodes
                 )
 
             window_start = span[0] - window
@@ -705,18 +751,28 @@ class StoryQueryEngine:
         result = create_text_agent(system_prompt).run_sync(user_prompt)
         return result.output.strip() or "No answer generated."
 
-    def _raw_only_retrieve(self, question: str) -> list[Node]:
+    def _raw_only_retrieve(
+        self,
+        question: str,
+        *,
+        query_embedding: list[float] | None = None,
+    ) -> list[Node]:
         return self._hybrid_retrieve(
             question,
             n_results=self._config().raw_candidate_count,
             where={"summary_level": 4},
+            query_embedding=query_embedding,
         )
 
     def query(self, question: str) -> str:
         """Executes the Hierarchical RAG query flow."""
         safe_print("Searching vector index by summary tiers and raw evidence...")
         expanded_question = self._expanded_question(question)
-        retrieved_nodes = self._tiered_retrieve(expanded_question)
+        query_embedding = self._query_embedding(expanded_question)
+        retrieved_nodes = self._tiered_retrieve(
+            expanded_question,
+            query_embedding=query_embedding,
+        )
 
         if not retrieved_nodes:
             safe_print("Tiered retrieval returned no hits.")
@@ -728,6 +784,7 @@ class StoryQueryEngine:
             child_raw_nodes = self._expand_summaries_to_raw_scenes(
                 expanded_question,
                 retrieved_nodes,
+                query_embedding=query_embedding,
             )
             if child_raw_nodes:
                 raw_ranked_lists.append(child_raw_nodes)
@@ -738,7 +795,11 @@ class StoryQueryEngine:
             return INSUFFICIENT_SOURCE_CONTEXT
 
         safe_print("Expanding neighboring raw evidence...")
-        expanded_raw_nodes = self._expand_raw_neighbors(expanded_question, raw_nodes)
+        expanded_raw_nodes = self._expand_raw_neighbors(
+            expanded_question,
+            raw_nodes,
+            query_embedding=query_embedding,
+        )
         ranked_raw_nodes = self._rank_raw_candidates(
             question,
             expanded_question,

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -74,7 +74,27 @@ def test_retrieve_uses_query_embedding_task_type(monkeypatch):
     assert calls[1]["query_embeddings"] == [[0.1, 0.2]]
 
 
-def test_hybrid_retrieve_concatenates_and_dedupes_dense_and_lexical(monkeypatch):
+def test_retrieval_config_rejects_invalid_rrf_k():
+    try:
+        RetrievalConfig(rrf_k=0)
+    except ValueError as exc:
+        assert "rrf_k must be at least 1" in str(exc)
+    else:
+        raise AssertionError("RetrievalConfig accepted an invalid RRF k")
+
+
+def test_rrf_fusion_combines_fixed_ranked_lists():
+    engine = make_engine()
+    a = raw_node("a", scene_start=0)
+    b = raw_node("b", scene_start=1)
+    c = raw_node("c", scene_start=2)
+
+    fused = engine._rrf_fuse([[a, b], [b, c]], k=1)
+
+    assert fused == [b, a, c]
+
+
+def test_hybrid_retrieve_rrf_fuses_and_dedupes_dense_and_lexical(monkeypatch):
     engine = make_engine()
     dense_node = (
         "dense raw",
@@ -171,17 +191,133 @@ def test_query_uses_configured_candidate_counts(monkeypatch):
         where: dict[str, Any] | None = None,
     ) -> list[tuple[str, dict[str, Any]]]:
         calls.append({"n_results": n_results, "where": where})
-        if where is None:
+        if where == {"summary_level": 3}:
             return [summary_node]
         if where == {"summary_level": 4}:
             return []
-        return [raw_child]
+        if where == {
+            "$and": [
+                {"summary_level": 4},
+                {"parent_part_id": "103|Main|第3話『テスト』|2"},
+            ]
+        }:
+            return [raw_child]
+        return []
 
     monkeypatch.setattr(engine, "_hybrid_retrieve", fake_hybrid_retrieve)
     monkeypatch.setattr(engine, "_answer_from_raw_evidence", lambda question, nodes: "answered")
 
     assert engine.query("What happened?") == "answered"
-    assert [call["n_results"] for call in calls] == [21, 41, 31]
+    assert calls == [
+        {"n_results": 21, "where": {"summary_level": 1}},
+        {"n_results": 21, "where": {"summary_level": 2}},
+        {"n_results": 21, "where": {"summary_level": 3}},
+        {"n_results": 41, "where": {"summary_level": 4}},
+        {
+            "n_results": 31,
+            "where": {
+                "$and": [
+                    {"summary_level": 4},
+                    {"parent_part_id": "103|Main|第3話『テスト』|2"},
+                ]
+            },
+        },
+    ]
+
+
+def test_tiered_retrieve_dispatches_each_summary_tier_and_raw(monkeypatch):
+    engine = make_engine()
+    calls: list[dict[str, Any]] = []
+
+    def fake_hybrid_retrieve(
+        question: str,
+        *,
+        n_results: int,
+        where: dict[str, Any] | None = None,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        calls.append({"n_results": n_results, "where": where})
+        return []
+
+    monkeypatch.setattr(engine, "_hybrid_retrieve", fake_hybrid_retrieve)
+
+    assert engine._tiered_retrieve("question") == []
+    assert calls == [
+        {"n_results": 20, "where": {"summary_level": 1}},
+        {"n_results": 20, "where": {"summary_level": 2}},
+        {"n_results": 20, "where": {"summary_level": 3}},
+        {"n_results": 40, "where": {"summary_level": 4}},
+    ]
+
+
+def test_tier_two_fanout_retrieves_child_raw_evidence(monkeypatch):
+    engine = make_engine()
+    calls: list[dict[str, Any]] = []
+    tier_two_summary = (
+        "episode summary",
+        {
+            "summary_level": 2,
+            "parent_episode_id": "103|Main|第3話『テスト』",
+        },
+    )
+    child = raw_node(
+        "child scene",
+        scene_start=2,
+        parent_part_id="103|Main|第3話『テスト』|2",
+    )
+
+    def fake_hybrid_retrieve(
+        question: str,
+        *,
+        n_results: int,
+        where: dict[str, Any] | None = None,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        calls.append({"n_results": n_results, "where": where})
+        return [child]
+
+    monkeypatch.setattr(engine, "_hybrid_retrieve", fake_hybrid_retrieve)
+
+    expanded = engine._expand_summaries_to_raw_scenes("question", [tier_two_summary])
+
+    assert expanded == [child]
+    assert calls == [
+        {
+            "n_results": 30,
+            "where": {
+                "$and": [
+                    {"summary_level": 4},
+                    {"parent_episode_id": "103|Main|第3話『テスト』"},
+                ]
+            },
+        }
+    ]
+
+
+def test_summary_fanout_preserves_coalesced_child_spans(monkeypatch):
+    engine = make_engine()
+    tier_one_summary = (
+        "year summary",
+        {
+            "summary_level": 1,
+            "parent_year_id": "103",
+        },
+    )
+    coalesced_child = raw_node(
+        "coalesced child scene span",
+        scene_start=4,
+        scene_end=7,
+        parent_part_id="103|Main|第3話『テスト』|2",
+    )
+
+    monkeypatch.setattr(
+        engine,
+        "_hybrid_retrieve",
+        lambda question, **kwargs: [coalesced_child],
+    )
+
+    expanded = engine._expand_summaries_to_raw_scenes("question", [tier_one_summary])
+
+    assert expanded == [coalesced_child]
+    assert engine._scene_span(expanded[0][1]) == (4, 7)
 
 
 def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
@@ -192,7 +328,7 @@ def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
     class FakeCollection:
         def query(self, **kwargs: Any) -> dict[str, list[list[Any]]]:
             query_calls.append(kwargs)
-            if len(query_calls) == 1:
+            if kwargs.get("where") == {"summary_level": 3}:
                 return {
                     "documents": [["part summary"]],
                     "metadatas": [
@@ -208,25 +344,33 @@ def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
                         ]
                     ],
                 }
-            if len(query_calls) == 2:
-                return {"documents": [[]], "metadatas": [[]]}
+            if kwargs.get("where") == {
+                "$and": [
+                    {"summary_level": 4},
+                    {"parent_part_id": "103|Main|第3話『テスト』|2"},
+                ]
+            }:
+                return {
+                    "documents": [["花帆: raw scene"]],
+                    "metadatas": [
+                        [
+                            {
+                                "arc_id": "103",
+                                "story_type": "Main",
+                                "episode_name": "第3話『テスト』",
+                                "part_name": "2",
+                                "summary_level": 4,
+                                "file_path": "missing.md",
+                                "scene_index": 4,
+                                "canonical_story_order": 30,
+                                "parent_part_id": "103|Main|第3話『テスト』|2",
+                            }
+                        ]
+                    ],
+                }
             return {
-                "documents": [["花帆: raw scene"]],
-                "metadatas": [
-                    [
-                        {
-                            "arc_id": "103",
-                            "story_type": "Main",
-                            "episode_name": "第3話『テスト』",
-                            "part_name": "2",
-                            "summary_level": 4,
-                            "file_path": "missing.md",
-                            "scene_index": 4,
-                            "canonical_story_order": 30,
-                            "parent_part_id": "103|Main|第3話『テスト』|2",
-                        }
-                    ]
-                ],
+                "documents": [[]],
+                "metadatas": [[]],
             }
 
     class FakeAgent:
@@ -245,8 +389,8 @@ def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
     answer = engine.query("What happened?")
 
     assert answer == "answered from raw scene"
-    assert len(query_calls) == 3
-    assert query_calls[2]["where"] == {
+    assert len(query_calls) == 5
+    assert query_calls[4]["where"] == {
         "$and": [
             {"summary_level": 4},
             {"parent_part_id": "103|Main|第3話『テスト』|2"},
@@ -265,17 +409,22 @@ def test_query_reports_insufficient_source_context_without_raw_evidence(monkeypa
     class FakeCollection:
         def query(self, **kwargs: Any) -> dict[str, list[list[Any]]]:
             query_calls.append(kwargs)
+            if kwargs.get("where") == {"summary_level": 3}:
+                return {
+                    "documents": [["part summary"]],
+                    "metadatas": [
+                        [
+                            {
+                                "arc_id": "103",
+                                "summary_level": 3,
+                                "parent_part_id": "103|Main|第3話『テスト』|2",
+                            }
+                        ]
+                    ],
+                }
             return {
-                "documents": [["part summary"]],
-                "metadatas": [
-                    [
-                        {
-                            "arc_id": "103",
-                            "summary_level": 3,
-                            "parent_part_id": "103|Main|第3話『テスト』|2",
-                        }
-                    ]
-                ],
+                "documents": [[]],
+                "metadatas": [[]],
             }
 
     def fake_create_text_agent(system_prompt: str) -> Any:
@@ -290,7 +439,7 @@ def test_query_reports_insufficient_source_context_without_raw_evidence(monkeypa
     answer = engine.query("What happened?")
 
     assert answer == INSUFFICIENT_SOURCE_CONTEXT
-    assert len(query_calls) == 3
+    assert len(query_calls) == 5
     assert agent_called is False
 
 

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -189,8 +189,10 @@ def test_query_uses_configured_candidate_counts(monkeypatch):
         *,
         n_results: int,
         where: dict[str, Any] | None = None,
+        query_embedding: list[float] | None = None,
     ) -> list[tuple[str, dict[str, Any]]]:
         calls.append({"n_results": n_results, "where": where})
+        assert query_embedding == [0.1]
         if where == {"summary_level": 3}:
             return [summary_node]
         if where == {"summary_level": 4}:
@@ -205,6 +207,7 @@ def test_query_uses_configured_candidate_counts(monkeypatch):
         return []
 
     monkeypatch.setattr(engine, "_hybrid_retrieve", fake_hybrid_retrieve)
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
     monkeypatch.setattr(engine, "_answer_from_raw_evidence", lambda question, nodes: "answered")
 
     assert engine.query("What happened?") == "answered"
@@ -234,11 +237,14 @@ def test_tiered_retrieve_dispatches_each_summary_tier_and_raw(monkeypatch):
         *,
         n_results: int,
         where: dict[str, Any] | None = None,
+        query_embedding: list[float] | None = None,
     ) -> list[tuple[str, dict[str, Any]]]:
         calls.append({"n_results": n_results, "where": where})
+        assert query_embedding == [0.1]
         return []
 
     monkeypatch.setattr(engine, "_hybrid_retrieve", fake_hybrid_retrieve)
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
 
     assert engine._tiered_retrieve("question") == []
     assert calls == [
@@ -270,11 +276,14 @@ def test_tier_two_fanout_retrieves_child_raw_evidence(monkeypatch):
         *,
         n_results: int,
         where: dict[str, Any] | None = None,
+        query_embedding: list[float] | None = None,
     ) -> list[tuple[str, dict[str, Any]]]:
         calls.append({"n_results": n_results, "where": where})
+        assert query_embedding == [0.1]
         return [child]
 
     monkeypatch.setattr(engine, "_hybrid_retrieve", fake_hybrid_retrieve)
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
 
     expanded = engine._expand_summaries_to_raw_scenes("question", [tier_two_summary])
 
@@ -313,6 +322,7 @@ def test_summary_fanout_preserves_coalesced_child_spans(monkeypatch):
         "_hybrid_retrieve",
         lambda question, **kwargs: [coalesced_child],
     )
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
 
     expanded = engine._expand_summaries_to_raw_scenes("question", [tier_one_summary])
 
@@ -323,6 +333,7 @@ def test_summary_fanout_preserves_coalesced_child_spans(monkeypatch):
 def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
     engine = make_engine()
     query_calls: list[dict[str, Any]] = []
+    embedding_calls: list[list[str]] = []
     agent_prompts: list[str] = []
 
     class FakeCollection:
@@ -382,13 +393,18 @@ def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
 
             return Result()
 
-    monkeypatch.setattr(query_engine, "embed_texts", lambda texts, *, task_type: [[0.1]])
+    def fake_embed_texts(texts: list[str], *, task_type: str) -> list[list[float]]:
+        embedding_calls.append(texts)
+        return [[0.1]]
+
+    monkeypatch.setattr(query_engine, "embed_texts", fake_embed_texts)
     monkeypatch.setattr(query_engine, "create_text_agent", lambda system_prompt: FakeAgent())
     engine.collection = FakeCollection()
 
     answer = engine.query("What happened?")
 
     assert answer == "answered from raw scene"
+    assert embedding_calls == [["What happened?"]]
     assert len(query_calls) == 5
     assert query_calls[4]["where"] == {
         "$and": [
@@ -404,6 +420,7 @@ def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
 def test_query_reports_insufficient_source_context_without_raw_evidence(monkeypatch):
     engine = make_engine()
     query_calls: list[dict[str, Any]] = []
+    embedding_calls: list[list[str]] = []
     agent_called = False
 
     class FakeCollection:
@@ -432,13 +449,18 @@ def test_query_reports_insufficient_source_context_without_raw_evidence(monkeypa
         agent_called = True
         return object()
 
-    monkeypatch.setattr(query_engine, "embed_texts", lambda texts, *, task_type: [[0.1]])
+    def fake_embed_texts(texts: list[str], *, task_type: str) -> list[list[float]]:
+        embedding_calls.append(texts)
+        return [[0.1]]
+
+    monkeypatch.setattr(query_engine, "embed_texts", fake_embed_texts)
     monkeypatch.setattr(query_engine, "create_text_agent", fake_create_text_agent)
     engine.collection = FakeCollection()
 
     answer = engine.query("What happened?")
 
     assert answer == INSUFFICIENT_SOURCE_CONTEXT
+    assert embedding_calls == [["What happened?"]]
     assert len(query_calls) == 5
     assert agent_called is False
 
@@ -499,6 +521,7 @@ def test_query_caps_final_raw_evidence_to_configured_top_k(monkeypatch):
     captured_counts = []
 
     monkeypatch.setattr(engine, "_hybrid_retrieve", lambda question, **kwargs: raw_nodes)
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
 
     def fake_answer(question: str, nodes: list[tuple[str, dict[str, Any]]]) -> str:
         captured_counts.append(len(nodes))


### PR DESCRIPTION
## Summary
- Add configurable Reciprocal Rank Fusion for dense, lexical, tiered, and child fan-out retrieval lists
- Dispatch query retrieval across summary tiers plus raw evidence instead of one flat search
- Fan out summary hits to child raw evidence and fuse them with direct raw hits before existing neighbor expansion and deterministic pre-rank
- Reuse a single query embedding across filtered dense retrievals to avoid repeated embedding API calls

## Verification
- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`

Closes #6