### PR TITLE
Add query analysis and temporal metadata filters

### DIFF
--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 
 import typer
@@ -50,6 +51,15 @@ def _story_order_key(node: StoryNode) -> tuple:
 def _assign_canonical_story_order(nodes: list[StoryNode]) -> None:
     for order, node in enumerate(sorted(nodes, key=_story_order_key), start=1):
         node.metadata.canonical_story_order = order
+        node.metadata.story_order = order
+
+
+def _episode_number(node: StoryNode) -> int:
+    for value in (node.metadata.episode_name, node.metadata.part_name):
+        match = re.search(r"第(\d+)話", value)
+        if match:
+            return int(match.group(1))
+    return 0
 
 
 def _translation_aliases(node: StoryNode, glossary: dict | None) -> list[str]:
@@ -136,6 +146,10 @@ def _lexical_document(node: StoryNode, glossary: dict | None = None) -> str:
 
 def _metadata_for_node(node: StoryNode) -> dict:
     metadata = node.metadata.model_dump()
+    if not metadata.get("story_order"):
+        metadata["story_order"] = metadata.get("canonical_story_order", 0)
+    if not metadata.get("episode_number"):
+        metadata["episode_number"] = _episode_number(node)
     metadata["detected_speakers"] = "|".join(node.metadata.detected_speakers)
     metadata["summary_level"] = node.summary_level
     return metadata

--- a/src/linkura_story_indexer/lexical.py
+++ b/src/linkura_story_indexer/lexical.py
@@ -109,7 +109,40 @@ def _metadata_matches_where(metadata: dict[str, Any], where: dict[str, Any] | No
     for key, expected in where.items():
         if key == "$and":
             continue
-        if metadata.get(key) != expected:
+        actual = metadata.get(key)
+        if key == "story_order" and actual is None:
+            actual = metadata.get("canonical_story_order")
+        if isinstance(expected, dict):
+            if not _metadata_matches_operator(actual, expected):
+                return False
+            continue
+        if actual != expected:
+            return False
+    return True
+
+
+def _metadata_matches_operator(actual: Any, expected: dict[str, Any]) -> bool:
+    for operator, value in expected.items():
+        if operator == "$eq":
+            if actual != value:
+                return False
+            continue
+        if operator == "$in":
+            if not isinstance(value, list) or actual not in value:
+                return False
+            continue
+
+        if not isinstance(actual, (int, float)) or not isinstance(value, (int, float)):
+            return False
+        if operator == "$lt" and not actual < value:
+            return False
+        if operator == "$lte" and not actual <= value:
+            return False
+        if operator == "$gt" and not actual > value:
+            return False
+        if operator == "$gte" and not actual >= value:
+            return False
+        if operator not in {"$lt", "$lte", "$gt", "$gte"}:
             return False
     return True
 

--- a/src/linkura_story_indexer/models/story.py
+++ b/src/linkura_story_indexer/models/story.py
@@ -13,6 +13,8 @@ class StoryMetadata(BaseModel):
     source_scene_count: int = Field(1, description="Number of source scenes covered by this node")
     is_prose: bool = Field(False, description="True if the content is prose/narrative, False if script")
     canonical_story_order: int = Field(0, description="Global chronological order for this story node")
+    story_order: int = Field(0, description="Alias for canonical_story_order used by query filters")
+    episode_number: int = Field(0, description="Numeric episode/part number when one is available")
     parent_year_id: str = Field("", description="Stable parent year identifier")
     parent_episode_id: str = Field("", description="Stable parent episode identifier")
     parent_part_id: str = Field("", description="Stable parent part identifier")

--- a/src/linkura_story_indexer/query/analysis.py
+++ b/src/linkura_story_indexer/query/analysis.py
@@ -1,0 +1,243 @@
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from ..lexical import glossary_alias_groups
+
+SUMMARY_INTENT = "summary"
+EXACT_EVIDENCE_INTENT = "exact_evidence"
+COMPARISON_INTENT = "comparison"
+CHRONOLOGY_INTENT = "chronology"
+QUANTITATIVE_INTENT = "quantitative"
+
+
+@dataclass(frozen=True)
+class SceneConstraint:
+    start: int
+    end: int
+    part_name: str | None = None
+
+
+@dataclass(frozen=True)
+class TemporalConstraint:
+    operator: str
+    episode_number: int | None = None
+    arc_id: str | None = None
+    phrase: str = ""
+
+
+@dataclass(frozen=True)
+class QueryAnalysis:
+    arc_ids: tuple[str, ...] = ()
+    story_type: str | None = None
+    episode_number: int | None = None
+    part_name: str | None = None
+    scene_constraint: SceneConstraint | None = None
+    semantic_boundary: str | None = None
+    temporal_constraint: TemporalConstraint | None = None
+    character_names: tuple[str, ...] = ()
+    intent_bucket: str = EXACT_EVIDENCE_INTENT
+
+    @property
+    def has_scope(self) -> bool:
+        return bool(
+            self.arc_ids
+            or self.story_type
+            or self.episode_number is not None
+            or self.part_name
+            or self.temporal_constraint
+        )
+
+
+_ARC_RE = re.compile(r"\b\d{3}\b")
+_EPISODE_RE = re.compile(r"(?:episode|ep\.?|第)\s*(\d+)", re.IGNORECASE)
+_TEMPORAL_EPISODE_RE = re.compile(
+    r"\b(?P<operator>before|prior to|as of|until|through|after|since)\s+"
+    r"(?:episode|ep\.?|第)\s*(?P<episode>\d+)",
+    re.IGNORECASE,
+)
+_TEMPORAL_ARC_RE = re.compile(
+    r"\b(?P<operator>before|prior to|as of|until|through|after|since)\s+"
+    r"(?:year|arc)?\s*(?P<arc>\d{3})\b",
+    re.IGNORECASE,
+)
+_SCENE_RE = re.compile(
+    r"\b(?:(?P<part>[A-Za-z][A-Za-z0-9_.-]*)\s+)?scenes?\s+"
+    r"(?P<start>\d+)(?:\s*[-–]\s*(?P<end>\d+))?",
+    re.IGNORECASE,
+)
+_SEMANTIC_BOUNDARY_RE = re.compile(
+    r"\b(?:scenes?\s+)?(?P<operator>before|after)\s+(?P<boundary>.+)",
+    re.IGNORECASE,
+)
+
+
+def analyze_query(
+    question: str,
+    glossary: dict[str, dict[str, str]] | None = None,
+) -> QueryAnalysis:
+    question_lower = question.casefold()
+    temporal_constraint = _extract_temporal_constraint(question)
+    scene_constraint = _extract_scene_constraint(question)
+    semantic_boundary = _extract_semantic_boundary(question, scene_constraint, temporal_constraint)
+
+    part_name = scene_constraint.part_name if scene_constraint else None
+    story_type = _extract_story_type(question_lower)
+    episode_number = _extract_episode_number(question, temporal_constraint)
+    character_names = _extract_character_names(question, glossary)
+
+    return QueryAnalysis(
+        arc_ids=tuple(_ordered_unique(_ARC_RE.findall(question))),
+        story_type=story_type,
+        episode_number=episode_number,
+        part_name=part_name,
+        scene_constraint=scene_constraint,
+        semantic_boundary=semantic_boundary,
+        temporal_constraint=temporal_constraint,
+        character_names=tuple(character_names),
+        intent_bucket=_intent_bucket(question_lower, scene_constraint, semantic_boundary),
+    )
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    unique = []
+    seen = set()
+    for value in values:
+        if value in seen:
+            continue
+        unique.append(value)
+        seen.add(value)
+    return unique
+
+
+def _normalized_temporal_operator(operator: str) -> str:
+    normalized = operator.casefold()
+    if normalized in {"before", "prior to"}:
+        return "before"
+    if normalized in {"as of", "until", "through"}:
+        return "as_of"
+    return "after"
+
+
+def _extract_temporal_constraint(question: str) -> TemporalConstraint | None:
+    match = _TEMPORAL_EPISODE_RE.search(question)
+    if match:
+        return TemporalConstraint(
+            operator=_normalized_temporal_operator(match.group("operator")),
+            episode_number=int(match.group("episode")),
+            phrase=match.group(0),
+        )
+
+    match = _TEMPORAL_ARC_RE.search(question)
+    if match:
+        return TemporalConstraint(
+            operator=_normalized_temporal_operator(match.group("operator")),
+            arc_id=match.group("arc"),
+            phrase=match.group(0),
+        )
+
+    if re.search(r"\bas of (?:this|that) point\b", question, re.IGNORECASE):
+        return TemporalConstraint(operator="as_of", phrase="as of this point")
+
+    return None
+
+
+def _extract_scene_constraint(question: str) -> SceneConstraint | None:
+    match = _SCENE_RE.search(question)
+    if not match:
+        return None
+
+    start = max(int(match.group("start")) - 1, 0)
+    end = max(int(match.group("end") or match.group("start")) - 1, start)
+    return SceneConstraint(
+        start=start,
+        end=end,
+        part_name=match.group("part"),
+    )
+
+
+def _extract_semantic_boundary(
+    question: str,
+    scene_constraint: SceneConstraint | None,
+    temporal_constraint: TemporalConstraint | None,
+) -> str | None:
+    if scene_constraint is not None or temporal_constraint is not None:
+        return None
+
+    match = _SEMANTIC_BOUNDARY_RE.search(question)
+    if not match:
+        return None
+
+    boundary = match.group("boundary").strip(" ?.")
+    if not boundary:
+        return None
+    return boundary
+
+
+def _extract_story_type(question_lower: str) -> str | None:
+    if "side story" in question_lower or "side stories" in question_lower:
+        return "Side"
+    if "main story" in question_lower or "main stories" in question_lower:
+        return "Main"
+    return None
+
+
+def _extract_episode_number(
+    question: str,
+    temporal_constraint: TemporalConstraint | None,
+) -> int | None:
+    match = _EPISODE_RE.search(question)
+    if not match:
+        return None
+    episode_number = int(match.group(1))
+    if (
+        temporal_constraint is not None
+        and temporal_constraint.episode_number == episode_number
+        and temporal_constraint.phrase
+    ):
+        return None
+    return episode_number
+
+
+def _extract_character_names(
+    question: str,
+    glossary: dict[str, dict[str, str]] | None,
+) -> list[str]:
+    question_lower = question.casefold()
+    names = []
+    for aliases in glossary_alias_groups(glossary):
+        if any(alias in question or alias.casefold() in question_lower for alias in aliases):
+            names.extend(aliases)
+    return _ordered_unique(names)
+
+
+def _intent_bucket(
+    question_lower: str,
+    scene_constraint: SceneConstraint | None,
+    semantic_boundary: str | None,
+) -> str:
+    if re.search(r"\b(how many|count|number of|total)\b", question_lower):
+        return QUANTITATIVE_INTENT
+    if re.search(r"\b(compare|contrast|difference|versus| vs )\b", question_lower):
+        return COMPARISON_INTENT
+    if scene_constraint is not None or re.search(r"\b(quote|exact|evidence|scene)\b", question_lower):
+        return EXACT_EVIDENCE_INTENT
+    if semantic_boundary is not None or re.search(r"\b(when|first|before|after|chronology)\b", question_lower):
+        return CHRONOLOGY_INTENT
+    if re.search(r"\b(summary|summarize|overview|recap|what happen(?:s|ed)?)\b", question_lower):
+        return SUMMARY_INTENT
+    return EXACT_EVIDENCE_INTENT
+
+
+def analysis_debug_dict(analysis: QueryAnalysis) -> dict[str, Any]:
+    return {
+        "arc_ids": list(analysis.arc_ids),
+        "story_type": analysis.story_type,
+        "episode_number": analysis.episode_number,
+        "part_name": analysis.part_name,
+        "scene_constraint": analysis.scene_constraint,
+        "semantic_boundary": analysis.semantic_boundary,
+        "temporal_constraint": analysis.temporal_constraint,
+        "character_names": list(analysis.character_names),
+        "intent_bucket": analysis.intent_bucket,
+    }

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -9,6 +9,14 @@ from ..console import safe_print
 from ..database import RETRIEVAL_QUERY, create_text_agent, embed_texts, get_chroma_collection
 from ..indexer.parser import StoryParser
 from ..lexical import LexicalIndex, expand_query_with_glossary
+from .analysis import (
+    CHRONOLOGY_INTENT,
+    EXACT_EVIDENCE_INTENT,
+    QUANTITATIVE_INTENT,
+    SUMMARY_INTENT,
+    QueryAnalysis,
+    analyze_query,
+)
 
 ROUTING_CANDIDATE_COUNT = 20
 RAW_CANDIDATE_COUNT = 40
@@ -234,6 +242,171 @@ class StoryQueryEngine:
 
         return self._results_to_nodes(results)
 
+    def _and_where(self, filters: list[dict[str, Any]]) -> dict[str, Any] | None:
+        cleaned = [item for item in filters if item]
+        if not cleaned:
+            return None
+        if len(cleaned) == 1:
+            return cleaned[0]
+        return {"$and": cleaned}
+
+    def _where_for_analysis(
+        self,
+        analysis: QueryAnalysis | None,
+        *,
+        summary_level: int,
+        include_scene_constraint: bool = False,
+    ) -> dict[str, Any]:
+        filters: list[dict[str, Any]] = [{"summary_level": summary_level}]
+        if analysis is None:
+            return filters[0]
+
+        if len(analysis.arc_ids) == 1:
+            filters.append({"arc_id": analysis.arc_ids[0]})
+        elif len(analysis.arc_ids) > 1:
+            filters.append({"arc_id": {"$in": list(analysis.arc_ids)}})
+
+        if summary_level != 1 and analysis.story_type:
+            filters.append({"story_type": analysis.story_type})
+        if summary_level in {2, 3, 4} and analysis.episode_number is not None:
+            filters.append({"episode_number": analysis.episode_number})
+        if summary_level in {3, 4} and analysis.part_name:
+            filters.append({"part_name": analysis.part_name})
+
+        temporal_filter = self._temporal_story_order_filter(analysis)
+        if temporal_filter is not None:
+            filters.append(temporal_filter)
+
+        if include_scene_constraint and summary_level == 4 and analysis.scene_constraint is not None:
+            scene = analysis.scene_constraint
+            filters.append({"scene_start": {"$lte": scene.end}})
+            filters.append({"scene_end": {"$gte": scene.start}})
+
+        return self._and_where(filters) or {"summary_level": summary_level}
+
+    def _combine_where(self, *filters: dict[str, Any] | None) -> dict[str, Any] | None:
+        flattened: list[dict[str, Any]] = []
+        for item in filters:
+            if not item:
+                continue
+            if set(item.keys()) == {"$and"} and isinstance(item.get("$and"), list):
+                flattened.extend(
+                    sub_item for sub_item in item["$and"] if isinstance(sub_item, dict)
+                )
+            else:
+                flattened.append(item)
+        return self._and_where(flattened)
+
+    def _metadata_value(self, metadata: dict[str, Any], key: str) -> Any:
+        if key == "story_order":
+            return metadata.get("story_order", metadata.get("canonical_story_order"))
+        return metadata.get(key)
+
+    def _metadata_matches_filter(self, metadata: dict[str, Any], where: dict[str, Any]) -> bool:
+        and_filters = where.get("$and")
+        if isinstance(and_filters, list):
+            return all(
+                isinstance(item, dict) and self._metadata_matches_filter(metadata, item)
+                for item in and_filters
+            )
+
+        for key, expected in where.items():
+            if key == "$and":
+                continue
+            actual = self._metadata_value(metadata, key)
+            if isinstance(expected, dict):
+                if not self._metadata_matches_operator(actual, expected):
+                    return False
+                continue
+            if actual != expected:
+                return False
+        return True
+
+    def _metadata_matches_operator(self, actual: Any, expected: dict[str, Any]) -> bool:
+        for operator, value in expected.items():
+            if operator == "$eq":
+                if actual != value:
+                    return False
+                continue
+            if operator == "$in":
+                if not isinstance(value, list) or actual not in value:
+                    return False
+                continue
+            if not isinstance(actual, (int, float)) or not isinstance(value, (int, float)):
+                return False
+            if operator == "$lt" and not actual < value:
+                return False
+            if operator == "$lte" and not actual <= value:
+                return False
+            if operator == "$gt" and not actual > value:
+                return False
+            if operator == "$gte" and not actual >= value:
+                return False
+            if operator not in {"$lt", "$lte", "$gt", "$gte"}:
+                return False
+        return True
+
+    def _temporal_story_order_filter(
+        self,
+        analysis: QueryAnalysis,
+    ) -> dict[str, Any] | None:
+        constraint = analysis.temporal_constraint
+        if constraint is None:
+            return None
+
+        story_order = self._resolve_temporal_story_order(analysis)
+        if story_order is None:
+            return None
+
+        if constraint.operator == "before":
+            return {"story_order": {"$lt": story_order}}
+        if constraint.operator == "after":
+            return {"story_order": {"$gt": story_order}}
+        return {"story_order": {"$lte": story_order}}
+
+    def _resolve_temporal_story_order(self, analysis: QueryAnalysis) -> int | None:
+        constraint = analysis.temporal_constraint
+        if constraint is None:
+            return None
+
+        filters: list[dict[str, Any]] = [{"summary_level": 4}]
+        if constraint.episode_number is not None:
+            filters.append({"episode_number": constraint.episode_number})
+        if constraint.arc_id is not None:
+            filters.append({"arc_id": constraint.arc_id})
+        if len(analysis.arc_ids) == 1 and constraint.arc_id is None:
+            filters.append({"arc_id": analysis.arc_ids[0]})
+        if analysis.story_type:
+            filters.append({"story_type": analysis.story_type})
+
+        where = self._and_where(filters)
+        if where is None or where == {"summary_level": 4}:
+            return None
+
+        collection_get = getattr(getattr(self, "collection", None), "get", None)
+        if not callable(collection_get):
+            return None
+
+        try:
+            results = collection_get(where=where, include=["metadatas"])
+        except (TypeError, ValueError):
+            return None
+
+        if not isinstance(results, dict):
+            return None
+        orders = [
+            int(order)
+            for metadata in results.get("metadatas", [])
+            if isinstance(metadata, dict)
+            for order in [metadata.get("story_order", metadata.get("canonical_story_order"))]
+            if isinstance(order, int)
+        ]
+        if not orders:
+            return None
+        if constraint.operator == "before":
+            return min(orders)
+        return max(orders)
+
     def _results_to_nodes(self, results: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
         documents = results.get("documents") or [[]]
         metadatas = results.get("metadatas") or [[]]
@@ -354,58 +527,73 @@ class StoryQueryEngine:
         question: str,
         *,
         query_embedding: list[float] | None = None,
+        analysis: QueryAnalysis | None = None,
     ) -> list[Node]:
         if query_embedding is None:
             query_embedding = self._query_embedding(question)
         config = self._config()
-        ranked_lists = [
-            self._hybrid_retrieve(
-                question,
-                n_results=config.routing_candidate_count,
-                where={"summary_level": summary_level},
-                query_embedding=query_embedding,
+        summary_levels = self._summary_levels_for_analysis(analysis)
+        ranked_lists = []
+        for summary_level in summary_levels:
+            ranked_lists.append(
+                self._hybrid_retrieve(
+                    question,
+                    n_results=config.routing_candidate_count,
+                    where=self._where_for_analysis(analysis, summary_level=summary_level),
+                    query_embedding=query_embedding,
+                )
             )
-            for summary_level in (1, 2, 3)
-        ]
         ranked_lists.append(
             self._hybrid_retrieve(
                 question,
                 n_results=config.raw_candidate_count,
-                where={"summary_level": 4},
+                where=self._where_for_analysis(
+                    analysis,
+                    summary_level=4,
+                    include_scene_constraint=True,
+                ),
                 query_embedding=query_embedding,
             )
         )
         return self._rrf_fuse(ranked_lists)
 
-    def _raw_scene_filter_for_summary(self, metadata: dict[str, Any]) -> dict[str, Any] | None:
+    def _summary_levels_for_analysis(self, analysis: QueryAnalysis | None) -> tuple[int, ...]:
+        if analysis is None:
+            return (1, 2, 3)
+        if analysis.scene_constraint is not None or analysis.intent_bucket in {
+            EXACT_EVIDENCE_INTENT,
+            QUANTITATIVE_INTENT,
+        }:
+            return (3,)
+        if analysis.intent_bucket == SUMMARY_INTENT:
+            return (1, 2, 3)
+        if analysis.intent_bucket == CHRONOLOGY_INTENT:
+            return (2, 3)
+        return (1, 2, 3)
+
+    def _raw_scene_filter_for_summary(
+        self,
+        metadata: dict[str, Any],
+        analysis: QueryAnalysis | None = None,
+    ) -> dict[str, Any] | None:
         level = metadata.get("summary_level")
+        analysis_filter = self._where_for_analysis(
+            analysis,
+            summary_level=4,
+            include_scene_constraint=True,
+        )
         if level == 1:
             parent_year_id = metadata.get("parent_year_id") or metadata.get("arc_id")
             if isinstance(parent_year_id, str) and parent_year_id:
-                return {
-                    "$and": [
-                        {"summary_level": 4},
-                        {"parent_year_id": parent_year_id},
-                    ]
-                }
+                return self._combine_where(analysis_filter, {"parent_year_id": parent_year_id})
         if level == 2:
             parent_episode_id = metadata.get("parent_episode_id")
             if isinstance(parent_episode_id, str) and parent_episode_id:
-                return {
-                    "$and": [
-                        {"summary_level": 4},
-                        {"parent_episode_id": parent_episode_id},
-                    ]
-                }
+                return self._combine_where(analysis_filter, {"parent_episode_id": parent_episode_id})
         if level == 3:
             parent_part_id = metadata.get("parent_part_id")
             if isinstance(parent_part_id, str) and parent_part_id:
-                return {
-                    "$and": [
-                        {"summary_level": 4},
-                        {"parent_part_id": parent_part_id},
-                    ]
-                }
+                return self._combine_where(analysis_filter, {"parent_part_id": parent_part_id})
         return None
 
     def _expand_summaries_to_raw_scenes(
@@ -414,13 +602,14 @@ class StoryQueryEngine:
         summaries: list[Node],
         *,
         query_embedding: list[float] | None = None,
+        analysis: QueryAnalysis | None = None,
     ) -> list[Node]:
         if query_embedding is None:
             query_embedding = self._query_embedding(question)
         child_ranked_lists: list[list[Node]] = []
 
         for _, metadata in summaries:
-            raw_filter = self._raw_scene_filter_for_summary(metadata)
+            raw_filter = self._raw_scene_filter_for_summary(metadata, analysis)
             if raw_filter is None:
                 continue
 
@@ -756,22 +945,97 @@ class StoryQueryEngine:
         question: str,
         *,
         query_embedding: list[float] | None = None,
+        analysis: QueryAnalysis | None = None,
     ) -> list[Node]:
         return self._hybrid_retrieve(
             question,
             n_results=self._config().raw_candidate_count,
-            where={"summary_level": 4},
+            where=self._where_for_analysis(
+                analysis,
+                summary_level=4,
+                include_scene_constraint=True,
+            ),
             query_embedding=query_embedding,
         )
+
+    def _filter_raw_nodes_by_analysis(
+        self,
+        nodes: list[Node],
+        analysis: QueryAnalysis,
+    ) -> list[Node]:
+        raw_filter = self._where_for_analysis(
+            analysis,
+            summary_level=4,
+            include_scene_constraint=True,
+        )
+        filtered = [
+            (document, metadata)
+            for document, metadata in nodes
+            if self._metadata_matches_filter(metadata, raw_filter)
+        ]
+        if analysis.scene_constraint is None:
+            return filtered
+
+        scene = analysis.scene_constraint
+        return [
+            (document, metadata)
+            for document, metadata in filtered
+            if (span := self._scene_span(metadata)) is not None
+            and span[0] <= scene.end
+            and span[1] >= scene.start
+        ]
+
+    def _story_order(self, metadata: dict[str, Any]) -> int | None:
+        order = metadata.get("story_order", metadata.get("canonical_story_order"))
+        return order if isinstance(order, int) else None
+
+    def _filter_before_semantic_boundary(
+        self,
+        question: str,
+        expanded_question: str,
+        raw_nodes: list[Node],
+        seed_nodes: list[Node],
+        analysis: QueryAnalysis,
+    ) -> list[Node]:
+        if analysis.semantic_boundary is None:
+            return raw_nodes
+
+        boundary_ranked_nodes = self._rank_raw_candidates(
+            analysis.semantic_boundary,
+            expanded_question,
+            raw_nodes,
+            seed_nodes,
+        )
+        if not boundary_ranked_nodes:
+            return []
+
+        _, boundary_metadata = boundary_ranked_nodes[0]
+        boundary_order = self._story_order(boundary_metadata)
+        if boundary_order is None:
+            return raw_nodes
+
+        if re.search(r"\bafter\b", question, re.IGNORECASE):
+            return [
+                node
+                for node in raw_nodes
+                if (order := self._story_order(node[1])) is not None and order > boundary_order
+            ]
+        return [
+            node
+            for node in raw_nodes
+            if (order := self._story_order(node[1])) is not None and order < boundary_order
+        ]
 
     def query(self, question: str) -> str:
         """Executes the Hierarchical RAG query flow."""
         safe_print("Searching vector index by summary tiers and raw evidence...")
+        analysis = analyze_query(question, self.glossary)
         expanded_question = self._expanded_question(question)
         query_embedding = self._query_embedding(expanded_question)
         retrieved_nodes = self._tiered_retrieve(
             expanded_question,
             query_embedding=query_embedding,
+            analysis=analysis,
         )
 
         if not retrieved_nodes:
@@ -785,11 +1049,12 @@ class StoryQueryEngine:
                 expanded_question,
                 retrieved_nodes,
                 query_embedding=query_embedding,
+                analysis=analysis,
             )
             if child_raw_nodes:
                 raw_ranked_lists.append(child_raw_nodes)
 
-        raw_nodes = self._rrf_fuse(raw_ranked_lists)
+        raw_nodes = self._filter_raw_nodes_by_analysis(self._rrf_fuse(raw_ranked_lists), analysis)
 
         if not raw_nodes:
             return INSUFFICIENT_SOURCE_CONTEXT
@@ -800,13 +1065,23 @@ class StoryQueryEngine:
             raw_nodes,
             query_embedding=query_embedding,
         )
+        expanded_raw_nodes = self._filter_raw_nodes_by_analysis(expanded_raw_nodes, analysis)
+        expanded_raw_nodes = self._filter_before_semantic_boundary(
+            question,
+            expanded_question,
+            expanded_raw_nodes,
+            raw_nodes,
+            analysis,
+        )
         ranked_raw_nodes = self._rank_raw_candidates(
             question,
             expanded_question,
             expanded_raw_nodes,
             raw_nodes,
         )
-        final_raw_nodes = ranked_raw_nodes[: self._config().final_top_k]
+        final_raw_nodes = self._filter_raw_nodes_by_analysis(ranked_raw_nodes, analysis)[
+            : self._config().final_top_k
+        ]
 
         if not final_raw_nodes:
             return INSUFFICIENT_SOURCE_CONTEXT

--- a/tests/test_ingest_raw_scenes.py
+++ b/tests/test_ingest_raw_scenes.py
@@ -95,6 +95,8 @@ def test_raw_scene_upsert_indexes_every_scene_with_required_metadata(
         "scene_end",
         "source_scene_count",
         "canonical_story_order",
+        "story_order",
+        "episode_number",
         "parent_year_id",
         "parent_episode_id",
         "parent_part_id",
@@ -111,6 +113,8 @@ def test_raw_scene_upsert_indexes_every_scene_with_required_metadata(
         assert isinstance(metadata["scene_end"], int)
         assert isinstance(metadata["source_scene_count"], int)
         assert isinstance(metadata["canonical_story_order"], int)
+        assert isinstance(metadata["story_order"], int)
+        assert isinstance(metadata["episode_number"], int)
         assert isinstance(metadata["detected_speakers"], str)
         assert isinstance(metadata["is_prose"], bool)
         assert metadata["summary_level"] == 4
@@ -193,3 +197,37 @@ def test_upsert_raw_scenes_is_idempotent(tmp_path: Path, monkeypatch) -> None:
 
     assert first_count == 2
     assert len(collection.records) == first_count
+
+
+def test_canonical_story_order_slots_side_stories_between_104_and_105(tmp_path: Path) -> None:
+    story_root = tmp_path / "story"
+    main_104_path = _write_story_file(
+        story_root,
+        "104/第1話『未来への歌』/1.md",
+        "104 main",
+    )
+    side_103_path = _write_story_file(
+        story_root,
+        "103/～Shades of Stars～/第1話.md",
+        "103 side",
+    )
+    main_105_path = _write_story_file(
+        story_root,
+        "105/第1話『Brand New Stories!!』/1.md",
+        "105 main",
+    )
+    raw_nodes = [
+        *StoryProcessor.process_file(main_105_path),
+        *StoryProcessor.process_file(side_103_path),
+        *StoryProcessor.process_file(main_104_path),
+    ]
+
+    cli._assign_canonical_story_order(raw_nodes)
+
+    order_by_label = {
+        f"{node.metadata.arc_id}|{node.metadata.story_type}": node.metadata.story_order
+        for node in raw_nodes
+    }
+
+    assert order_by_label["104|Main"] < order_by_label["103|Side"]
+    assert order_by_label["103|Side"] < order_by_label["105|Main"]

--- a/tests/test_lexical.py
+++ b/tests/test_lexical.py
@@ -91,6 +91,26 @@ def test_lexical_search_honors_chroma_style_where_filter(tmp_path: Path) -> None
     assert results == [("花帆: two", _metadata(parent_part_id="part-two"))]
 
 
+def test_lexical_search_honors_numeric_story_order_filter(tmp_path: Path) -> None:
+    index = LexicalIndex(tmp_path / "lexical.db")
+    index.upsert_records(
+        ids=["chunk:one:0-0", "chunk:two:0-0"],
+        documents=["花帆: before", "花帆: after"],
+        metadatas=[
+            _metadata(canonical_story_order=10),
+            _metadata(canonical_story_order=20),
+        ],
+    )
+
+    results = index.search(
+        "花帆",
+        n_results=5,
+        where={"$and": [{"summary_level": 4}, {"story_order": {"$lt": 15}}]},
+    )
+
+    assert results == [("花帆: before", _metadata(canonical_story_order=10))]
+
+
 def test_upsert_story_nodes_writes_matching_lexical_records(tmp_path: Path, monkeypatch) -> None:
     collection_records: dict[str, dict[str, Any]] = {}
 

--- a/tests/test_query_analysis.py
+++ b/tests/test_query_analysis.py
@@ -1,0 +1,65 @@
+from linkura_story_indexer.query.analysis import (
+    CHRONOLOGY_INTENT,
+    EXACT_EVIDENCE_INTENT,
+    QUANTITATIVE_INTENT,
+    SUMMARY_INTENT,
+    analyze_query,
+)
+
+
+def test_query_analysis_extracts_temporal_episode_constraint() -> None:
+    analysis = analyze_query("What did Kaho know before episode 12?")
+
+    assert analysis.temporal_constraint is not None
+    assert analysis.temporal_constraint.operator == "before"
+    assert analysis.temporal_constraint.episode_number == 12
+    assert analysis.episode_number is None
+    assert analysis.intent_bucket == CHRONOLOGY_INTENT
+
+
+def test_query_analysis_extracts_side_story_constraint() -> None:
+    analysis = analyze_query("What happens in the side stories?")
+
+    assert analysis.story_type == "Side"
+    assert analysis.intent_bucket == SUMMARY_INTENT
+
+
+def test_query_analysis_extracts_arc_constraint() -> None:
+    analysis = analyze_query("What happens in 103?")
+
+    assert analysis.arc_ids == ("103",)
+    assert analysis.intent_bucket == SUMMARY_INTENT
+
+
+def test_query_analysis_extracts_part_scene_constraint_as_zero_based() -> None:
+    analysis = analyze_query("What happens in ABYSS scene 2?")
+
+    assert analysis.part_name == "ABYSS"
+    assert analysis.scene_constraint is not None
+    assert analysis.scene_constraint.start == 1
+    assert analysis.scene_constraint.end == 1
+    assert analysis.intent_bucket == EXACT_EVIDENCE_INTENT
+
+
+def test_query_analysis_extracts_scene_range_as_zero_based() -> None:
+    analysis = analyze_query("Summarize scenes 3-7.")
+
+    assert analysis.scene_constraint is not None
+    assert analysis.scene_constraint.start == 2
+    assert analysis.scene_constraint.end == 6
+
+
+def test_query_analysis_extracts_character_aliases_from_glossary() -> None:
+    analysis = analyze_query(
+        "What does Kaho do?",
+        {"characters": {"日野下花帆": "Kaho Hinoshita"}},
+    )
+
+    assert "Kaho Hinoshita" in analysis.character_names
+    assert "日野下花帆" in analysis.character_names
+
+
+def test_query_analysis_classifies_quantitative_intent() -> None:
+    analysis = analyze_query("How many times does Kaho speak in 103?")
+
+    assert analysis.intent_bucket == QUANTITATIVE_INTENT

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from linkura_story_indexer import database
 from linkura_story_indexer.query import engine as query_engine
+from linkura_story_indexer.query.analysis import analyze_query
 from linkura_story_indexer.query.engine import (
     INSUFFICIENT_SOURCE_CONTEXT,
     RetrievalConfig,
@@ -253,6 +254,138 @@ def test_tiered_retrieve_dispatches_each_summary_tier_and_raw(monkeypatch):
         {"n_results": 20, "where": {"summary_level": 3}},
         {"n_results": 40, "where": {"summary_level": 4}},
     ]
+
+
+def test_analysis_where_applies_side_story_filters_to_specific_tiers(monkeypatch):
+    engine = make_engine()
+    calls: list[dict[str, Any]] = []
+    analysis = analyze_query("What happens in the side stories?")
+
+    def fake_hybrid_retrieve(
+        question: str,
+        *,
+        n_results: int,
+        where: dict[str, Any] | None = None,
+        query_embedding: list[float] | None = None,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        calls.append({"n_results": n_results, "where": where})
+        assert query_embedding == [0.1]
+        return []
+
+    monkeypatch.setattr(engine, "_hybrid_retrieve", fake_hybrid_retrieve)
+
+    assert engine._tiered_retrieve("question", query_embedding=[0.1], analysis=analysis) == []
+    assert calls == [
+        {"n_results": 20, "where": {"summary_level": 1}},
+        {
+            "n_results": 20,
+            "where": {"$and": [{"summary_level": 2}, {"story_type": "Side"}]},
+        },
+        {
+            "n_results": 20,
+            "where": {"$and": [{"summary_level": 3}, {"story_type": "Side"}]},
+        },
+        {
+            "n_results": 40,
+            "where": {"$and": [{"summary_level": 4}, {"story_type": "Side"}]},
+        },
+    ]
+
+
+def test_explicit_scene_where_uses_zero_based_span_overlap() -> None:
+    engine = make_engine()
+    analysis = analyze_query("ABYSS scene 2")
+
+    where = engine._where_for_analysis(
+        analysis,
+        summary_level=4,
+        include_scene_constraint=True,
+    )
+
+    assert where == {
+        "$and": [
+            {"summary_level": 4},
+            {"part_name": "ABYSS"},
+            {"scene_start": {"$lte": 1}},
+            {"scene_end": {"$gte": 1}},
+        ]
+    }
+
+
+def test_scene_point_constraint_matches_containing_coalesced_chunk() -> None:
+    engine = make_engine()
+    analysis = analyze_query("scene 2")
+    nodes = [
+        raw_node("scene 1", scene_start=0, scene_end=0),
+        raw_node("scenes 2-4", scene_start=1, scene_end=3),
+        raw_node("scene 5", scene_start=4, scene_end=4),
+    ]
+
+    filtered = engine._filter_raw_nodes_by_analysis(nodes, analysis)
+
+    assert filtered == [nodes[1]]
+
+
+def test_scene_range_constraint_matches_overlapping_coalesced_chunks() -> None:
+    engine = make_engine()
+    analysis = analyze_query("scenes 3-7")
+    nodes = [
+        raw_node("scene 1", scene_start=0, scene_end=0),
+        raw_node("scenes 2-4", scene_start=1, scene_end=3),
+        raw_node("scenes 5-6", scene_start=4, scene_end=5),
+    ]
+
+    filtered = engine._filter_raw_nodes_by_analysis(nodes, analysis)
+
+    assert filtered == [nodes[1], nodes[2]]
+
+
+def test_temporal_filter_resolves_to_numeric_story_order() -> None:
+    engine = make_engine()
+
+    class FakeCollection:
+        def get(self, **kwargs: Any) -> dict[str, list[dict[str, Any]]]:
+            assert kwargs["where"] == {"$and": [{"summary_level": 4}, {"episode_number": 12}]}
+            return {"metadatas": [{"story_order": 120}, {"story_order": 125}]}
+
+    engine.collection = FakeCollection()
+    analysis = analyze_query("What did Kaho know before episode 12?")
+
+    where = engine._where_for_analysis(analysis, summary_level=4)
+
+    assert where == {
+        "$and": [
+            {"summary_level": 4},
+            {"story_order": {"$lt": 120}},
+        ]
+    }
+
+
+def test_semantic_boundary_keeps_prior_story_order(monkeypatch) -> None:
+    engine = make_engine()
+    analysis = analyze_query("scenes before Ruri falls asleep")
+    before = raw_node("before", scene_start=0)
+    boundary = raw_node("boundary", scene_start=1)
+    after = raw_node("after", scene_start=2)
+    before[1]["story_order"] = 10
+    boundary[1]["story_order"] = 20
+    after[1]["story_order"] = 30
+
+    monkeypatch.setattr(
+        engine,
+        "_rank_raw_candidates",
+        lambda question, expanded_question, raw_nodes, seed_nodes: [boundary],
+    )
+
+    filtered = engine._filter_before_semantic_boundary(
+        "scenes before Ruri falls asleep",
+        "expanded",
+        [before, boundary, after],
+        [boundary],
+        analysis,
+    )
+
+    assert filtered == [before]
 
 
 def test_tier_two_fanout_retrieves_child_raw_evidence(monkeypatch):


### PR DESCRIPTION
## Summary

- Add deterministic query analysis for arc/story type/episode/part/scene/temporal constraints, character aliases, semantic boundaries, and intent buckets.
- Apply analysis-derived Chroma/lexical filters through tiered retrieval, summary fanout, raw retrieval, scene-span post-filtering, and semantic boundary filtering.
- Add `story_order` and `episode_number` metadata while preserving `canonical_story_order`.
- Extend lexical metadata filtering to support Chroma-style numeric operators.
- Add unit coverage for query analysis, scene constraints, temporal filters, semantic boundaries, lexical numeric filters, and side-story interleaving.

## Verification

- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest` (`58 passed`)

Closes #7