### PR TITLE
Implement ingestion manifest and stale-vector pruning

### DIFF
--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -1,6 +1,7 @@
 import json
 import re
 from pathlib import Path
+from typing import Any
 
 import typer
 from rich.console import Console
@@ -10,13 +11,34 @@ from .database import (
     RETRIEVAL_DOCUMENT,
     EmbeddingDocument,
     embed_texts,
+    get_chat_model_name,
     get_chroma_collection,
+    get_embedding_model_name,
     initialize_settings,
 )
-from .indexer.chunker import build_retrieval_chunks
+from .indexer.chunker import (
+    CHUNKER_VERSION,
+    MAX_CHUNK_CHARS,
+    MIN_USEFUL_CHARS,
+    TARGET_CHUNK_CHARS,
+    build_retrieval_chunks,
+)
 from .indexer.extractor import StateExtractor
+from .indexer.manifest import (
+    RAW_EVIDENCE_SCHEMA_VERSION,
+    SUMMARY_CACHE_SCHEMA_VERSION,
+    ChunkerConfig,
+    IngestionManifest,
+    SummaryCacheContext,
+    VectorIds,
+    hash_files,
+    hash_json_file,
+    utc_timestamp,
+    write_manifest,
+)
+from .indexer.parser import PARSER_VERSION
 from .indexer.processor import StoryProcessor
-from .indexer.summarizer import HierarchicalSummarizer
+from .indexer.summarizer import SUMMARIZATION_PROMPT_VERSION, HierarchicalSummarizer
 from .lexical import LexicalIndex, get_lexical_db_path, glossary_alias_groups
 from .models.story import StoryNode
 from .query.engine import StoryQueryEngine
@@ -155,15 +177,49 @@ def _metadata_for_node(node: StoryNode) -> dict:
     return metadata
 
 
+def _collection_ids(collection: Any) -> set[str]:
+    try:
+        records = collection.get(include=[])
+    except TypeError:
+        records = collection.get()
+    ids = records.get("ids", []) if isinstance(records, dict) else []
+    return {str(record_id) for record_id in ids}
+
+
+def _delete_collection_ids(collection: Any, ids: set[str]) -> None:
+    if not ids:
+        return
+    sorted_ids = sorted(ids)
+    batch_size = 500
+    for start in range(0, len(sorted_ids), batch_size):
+        collection.delete(ids=sorted_ids[start : start + batch_size])
+
+
+def _prune_stale_records(
+    *,
+    emitted_ids: set[str],
+    lexical_index: LexicalIndex | None,
+) -> int:
+    collection = get_chroma_collection()
+    stale_ids = _collection_ids(collection) - emitted_ids
+    _delete_collection_ids(collection, stale_ids)
+    if lexical_index is not None:
+        lexical_stale_ids = lexical_index.list_ids() - emitted_ids
+        lexical_index.delete_records(lexical_stale_ids)
+        stale_ids |= lexical_stale_ids
+    return len(stale_ids)
+
+
 def _upsert_story_nodes(
     nodes: list[StoryNode],
     *,
     progress_label: str,
     glossary: dict | None = None,
     lexical_index: LexicalIndex | None = None,
-) -> None:
+) -> list[str]:
     collection = get_chroma_collection()
     batch_size = 32
+    emitted_ids = []
 
     with Progress() as progress:
         task = progress.add_task(progress_label, total=len(nodes))
@@ -174,6 +230,7 @@ def _upsert_story_nodes(
             lexical_documents = [_lexical_document(node, glossary) for node in batch]
             metadatas = [_metadata_for_node(node) for node in batch]
             ids = [_node_id(node) for node in batch]
+            emitted_ids.extend(ids)
 
             collection.upsert(
                 ids=ids,
@@ -189,6 +246,7 @@ def _upsert_story_nodes(
                     search_texts=lexical_documents,
                 )
             progress.update(task, advance=len(batch))
+    return emitted_ids
 
 @app.command()
 def hello():
@@ -237,7 +295,12 @@ def extract_state(cache_file: str = typer.Option("summaries_cache.json", help="P
     extractor.extract_from_cache(output_file=output_file)
 
 @app.command()
-def ingest(story_dir: str = typer.Option("story", help="Directory containing story files")):
+def ingest(
+    story_dir: str = typer.Option("story", help="Directory containing story files"),
+    cache_file: str = typer.Option("summaries_cache.json", help="Path to the summaries cache file"),
+    manifest_file: str = typer.Option("ingestion_manifest.json", help="Path to the ingestion manifest"),
+    prune: bool = typer.Option(True, "--prune/--no-prune", help="Delete indexed records not emitted by this run"),
+):
     """Walks the story directory, generates hierarchical summaries, and indexes them into ChromaDB."""
     initialize_settings()
     
@@ -246,7 +309,8 @@ def ingest(story_dir: str = typer.Option("story", help="Directory containing sto
         console.print(f"[red]Error: Directory {story_dir} not found.[/red]")
         raise typer.Exit(1)
         
-    md_files = list(story_path.rglob("*.md"))
+    md_files = sorted(story_path.rglob("*.md"), key=lambda path: str(path))
+    source_file_hashes = hash_files(md_files)
     console.print(f"Found {len(md_files)} markdown files. Parsing scenes...")
     story_order = load_story_order(story_root=story_path)
 
@@ -269,30 +333,71 @@ def ingest(story_dir: str = typer.Option("story", help="Directory containing sto
     
     glossary = None
     glossary_path = Path("glossary.json")
+    glossary_hash = hash_json_file(glossary_path)
     if glossary_path.exists():
         with open(glossary_path, encoding="utf-8") as f:
             glossary = json.load(f)
             console.print("Loaded glossary for translation invariants.")
 
     # Generate Tier 1-3 hierarchical summaries
-    summarizer = HierarchicalSummarizer(glossary=glossary, story_order=story_order)
-    summary_nodes = summarizer.summarize_hierarchy(raw_nodes)
+    chat_model = get_chat_model_name()
+    embedding_model = get_embedding_model_name()
+    cache_context = SummaryCacheContext(
+        source_file_hashes=source_file_hashes,
+        parser_version=PARSER_VERSION,
+        summarization_prompt_version=SUMMARIZATION_PROMPT_VERSION,
+        glossary_hash=glossary_hash,
+        chat_model=chat_model,
+        embedding_model=embedding_model,
+        summary_cache_schema_version=SUMMARY_CACHE_SCHEMA_VERSION,
+    )
+    summarizer = HierarchicalSummarizer(
+        glossary=glossary,
+        story_order=story_order,
+        cache_context=cache_context,
+    )
+    summary_nodes = summarizer.summarize_hierarchy(raw_nodes, cache_file=cache_file)
     
     console.print(f"Generated {len(summary_nodes)} hierarchical summaries. Upserting to Vector DB...")
     lexical_index = LexicalIndex(get_lexical_db_path())
     
-    _upsert_story_nodes(
+    raw_ids = _upsert_story_nodes(
         retrieval_chunks,
         progress_label="[green]Embedding raw retrieval chunks...",
         glossary=glossary,
         lexical_index=lexical_index,
     )
-    _upsert_story_nodes(
+    summary_ids = _upsert_story_nodes(
         summary_nodes,
         progress_label="[green]Embedding summaries...",
         glossary=glossary,
         lexical_index=lexical_index,
     )
+
+    emitted_ids = {*raw_ids, *summary_ids}
+    if prune:
+        pruned_count = _prune_stale_records(emitted_ids=emitted_ids, lexical_index=lexical_index)
+        console.print(f"Pruned {pruned_count} stale vector/lexical records.")
+
+    manifest = IngestionManifest(
+        timestamp=utc_timestamp(),
+        source_file_hashes=source_file_hashes,
+        parser_version=PARSER_VERSION,
+        chunker_version=CHUNKER_VERSION,
+        chunker_config=ChunkerConfig(
+            min_chars=MIN_USEFUL_CHARS,
+            target_chars=TARGET_CHUNK_CHARS,
+            max_chars=MAX_CHUNK_CHARS,
+        ),
+        summarization_prompt_version=SUMMARIZATION_PROMPT_VERSION,
+        glossary_hash=glossary_hash,
+        chat_model=chat_model,
+        embedding_model=embedding_model,
+        raw_evidence_schema_version=RAW_EVIDENCE_SCHEMA_VERSION,
+        summary_cache_schema_version=SUMMARY_CACHE_SCHEMA_VERSION,
+        vector_ids=VectorIds(raw=sorted(raw_ids), summaries=sorted(summary_ids)),
+    )
+    write_manifest(manifest_file, manifest)
     
     console.print("[bold green]Hierarchical Ingestion complete![/bold green]")
 

--- a/src/linkura_story_indexer/indexer/chunker.py
+++ b/src/linkura_story_indexer/indexer/chunker.py
@@ -2,6 +2,7 @@ from itertools import groupby
 
 from ..models.story import StoryNode
 
+CHUNKER_VERSION = "1"
 MIN_USEFUL_CHARS = 500
 TARGET_CHUNK_CHARS = 1200
 MAX_CHUNK_CHARS = 1800

--- a/src/linkura_story_indexer/indexer/manifest.py
+++ b/src/linkura_story_indexer/indexer/manifest.py
@@ -1,0 +1,90 @@
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+MANIFEST_SCHEMA_VERSION = "1"
+SUMMARY_CACHE_SCHEMA_VERSION = "1"
+RAW_EVIDENCE_SCHEMA_VERSION = "1"
+
+
+class ChunkerConfig(BaseModel):
+    min_chars: int
+    target_chars: int
+    max_chars: int
+
+
+class VectorIds(BaseModel):
+    raw: list[str] = Field(default_factory=list)
+    summaries: list[str] = Field(default_factory=list)
+
+
+class IngestionManifest(BaseModel):
+    schema_version: str = MANIFEST_SCHEMA_VERSION
+    timestamp: str
+    source_file_hashes: dict[str, str]
+    parser_version: str
+    chunker_version: str
+    chunker_config: ChunkerConfig
+    summarization_prompt_version: str
+    glossary_hash: str
+    chat_model: str
+    embedding_model: str
+    raw_evidence_schema_version: str = RAW_EVIDENCE_SCHEMA_VERSION
+    summary_cache_schema_version: str = SUMMARY_CACHE_SCHEMA_VERSION
+    vector_ids: VectorIds = Field(default_factory=VectorIds)
+
+
+class SummaryCacheContext(BaseModel):
+    source_file_hashes: dict[str, str] = Field(default_factory=dict)
+    parser_version: str
+    summarization_prompt_version: str
+    glossary_hash: str
+    chat_model: str
+    embedding_model: str
+    summary_cache_schema_version: str = SUMMARY_CACHE_SCHEMA_VERSION
+
+
+def utc_timestamp() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def stable_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def stable_hash(value: Any) -> str:
+    return hashlib.sha256(stable_json(value).encode("utf-8")).hexdigest()
+
+
+def hash_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def hash_files(paths: list[Path]) -> dict[str, str]:
+    return {str(path): hash_file(path) for path in sorted(paths, key=lambda item: str(item))}
+
+
+def hash_json_file(path: Path) -> str:
+    if not path.exists():
+        return stable_hash(None)
+    with path.open(encoding="utf-8") as file:
+        return stable_hash(json.load(file))
+
+
+def write_manifest(path: str | Path, manifest: IngestionManifest) -> None:
+    Path(path).write_text(
+        manifest.model_dump_json(indent=2),
+        encoding="utf-8",
+    )

--- a/src/linkura_story_indexer/indexer/parser.py
+++ b/src/linkura_story_indexer/indexer/parser.py
@@ -1,5 +1,7 @@
 import re
 
+PARSER_VERSION = "1"
+
 
 class StoryParser:
     """Parses story files into scenes and identifies dialogue/prose."""

--- a/src/linkura_story_indexer/indexer/summarizer.py
+++ b/src/linkura_story_indexer/indexer/summarizer.py
@@ -1,23 +1,82 @@
 import json
 import os
 from collections import defaultdict
+from typing import Any
 
 from ..console import safe_print
 from ..database import create_text_agent
 from ..models.story import StoryNode
 from ..story_order import StoryOrder, default_story_order
+from .manifest import (
+    SUMMARY_CACHE_SCHEMA_VERSION,
+    SummaryCacheContext,
+    hash_text,
+    stable_hash,
+)
+
+SUMMARIZATION_PROMPT_VERSION = "1"
 
 
 def episode_sort_key(ep_key_tuple: tuple) -> tuple:
     arc_id, story_type, episode_name = ep_key_tuple
     return default_story_order().chronological_episode_key(arc_id, story_type, episode_name)
 
+
+def _load_cache(cache_file: str) -> dict[str, Any]:
+    if not os.path.exists(cache_file):
+        return {}
+    with open(cache_file, encoding="utf-8") as file:
+        loaded = json.load(file)
+    if not isinstance(loaded, dict):
+        return {}
+    return loaded
+
+
+def _save_cache(cache_file: str, cache: dict[str, Any]) -> None:
+    with open(cache_file, "w", encoding="utf-8") as file:
+        json.dump(cache, file, ensure_ascii=False, indent=2)
+
+
+def _cached_summary(cache: dict[str, Any], cache_key: str, fingerprint: str) -> str | None:
+    entry = cache.get(cache_key)
+    if not isinstance(entry, dict):
+        return None
+    if entry.get("fingerprint") != fingerprint:
+        return None
+    summary = entry.get("summary")
+    if not isinstance(summary, str):
+        return None
+    return summary
+
+
+def _store_cached_summary(
+    cache: dict[str, Any],
+    cache_key: str,
+    *,
+    summary: str,
+    fingerprint: str,
+    inputs: dict[str, Any],
+) -> None:
+    cache[cache_key] = {
+        "schema_version": SUMMARY_CACHE_SCHEMA_VERSION,
+        "fingerprint": fingerprint,
+        "summary": summary,
+        "inputs": inputs,
+    }
+
+
 class HierarchicalSummarizer:
     """Generates rolling summaries for stories to build the RAG hierarchy."""
 
-    def __init__(self, glossary: dict | None = None, story_order: StoryOrder | None = None):
+    def __init__(
+        self,
+        glossary: dict | None = None,
+        story_order: StoryOrder | None = None,
+        cache_context: SummaryCacheContext | None = None,
+    ):
         self.glossary = glossary
         self.story_order = story_order or default_story_order()
+        self.cache_context = cache_context
 
     def _generate_rolling_summary(self, current_text: str, prev_summary: str | None = None, level_name: str = "Part") -> str:
         """Calls the LLM to generate a summary using previous context to prevent drift."""
@@ -46,6 +105,72 @@ class HierarchicalSummarizer:
 
         result = create_text_agent(system_content).run_sync(prompt)
         return result.output.strip()
+
+    def _base_fingerprint_inputs(self, level: str) -> dict[str, Any]:
+        if self.cache_context is None:
+            return {
+                "level": level,
+                "summary_cache_schema_version": SUMMARY_CACHE_SCHEMA_VERSION,
+                "summarization_prompt_version": SUMMARIZATION_PROMPT_VERSION,
+                "glossary_hash": stable_hash(self.glossary),
+                "chat_model": "unconfigured",
+                "embedding_model": "unconfigured",
+                "parser_version": "unconfigured",
+            }
+        return {
+            "level": level,
+            "summary_cache_schema_version": self.cache_context.summary_cache_schema_version,
+            "summarization_prompt_version": self.cache_context.summarization_prompt_version,
+            "glossary_hash": self.cache_context.glossary_hash,
+            "chat_model": self.cache_context.chat_model,
+            "embedding_model": self.cache_context.embedding_model,
+            "parser_version": self.cache_context.parser_version,
+        }
+
+    def _source_file_hashes_for_nodes(self, nodes: list[StoryNode]) -> dict[str, str]:
+        grouped_text: dict[str, list[str]] = defaultdict(list)
+        for node in nodes:
+            grouped_text[node.metadata.file_path].append(node.text)
+
+        hashes = {}
+        for file_path, texts in sorted(grouped_text.items()):
+            if (
+                self.cache_context is not None
+                and file_path in self.cache_context.source_file_hashes
+            ):
+                hashes[file_path] = self.cache_context.source_file_hashes[file_path]
+            else:
+                hashes[file_path] = hash_text("\n\n---\n\n".join(texts))
+        return hashes
+
+    def _part_cache_inputs(
+        self,
+        *,
+        scenes: list[StoryNode],
+        part_text: str,
+        prev_summary: str | None,
+    ) -> dict[str, Any]:
+        return {
+            **self._base_fingerprint_inputs("part"),
+            "source_file_hashes": self._source_file_hashes_for_nodes(scenes),
+            "source_text_hash": hash_text(part_text),
+            "previous_summary_hash": hash_text(prev_summary) if prev_summary else "",
+        }
+
+    def _aggregate_cache_inputs(
+        self,
+        *,
+        level: str,
+        child_nodes: list[StoryNode],
+        combined_text: str,
+        prev_summary: str | None,
+    ) -> dict[str, Any]:
+        return {
+            **self._base_fingerprint_inputs(level),
+            "child_summary_hashes": [hash_text(node.text) for node in child_nodes],
+            "combined_text_hash": hash_text(combined_text),
+            "previous_summary_hash": hash_text(prev_summary) if prev_summary else "",
+        }
 
     def summarize_hierarchy(self, raw_nodes: list[StoryNode], cache_file: str = "summaries_cache.json") -> list[StoryNode]:
         """
@@ -78,10 +203,7 @@ class HierarchicalSummarizer:
         Tier 3 (Part) summaries using a rolling context window.
         Uses a local cache file to resume if processing fails halfway.
         """
-        cache: dict[str, str] = {}
-        if os.path.exists(cache_file):
-            with open(cache_file, encoding="utf-8") as f:
-                cache = json.load(f)
+        cache = _load_cache(cache_file)
 
         # Group by (arc_id, story_type, episode_name)
         episodes: dict[tuple, dict[str, list[StoryNode]]] = defaultdict(lambda: defaultdict(list))
@@ -123,13 +245,20 @@ class HierarchicalSummarizer:
                 base_meta = scenes[0].metadata.model_copy(deep=True)
                 base_meta.scene_index = -1 # Indicates it covers the whole part
 
-                if cache_key in cache:
+                # Gemini 3 has a massive context window, so we can concatenate the whole part
+                part_text = "\n\n---\n\n".join([n.text for n in scenes])
+                cache_inputs = self._part_cache_inputs(
+                    scenes=scenes,
+                    part_text=part_text,
+                    prev_summary=prev_summary,
+                )
+                fingerprint = stable_hash(cache_inputs)
+                cached = _cached_summary(cache, cache_key, fingerprint)
+
+                if cached is not None:
                     safe_print(f"Loading cached summary for {cache_key}...")
-                    current_summary = cache[cache_key]
+                    current_summary = cached
                 else:
-                    # Gemini 3 has a massive context window, so we can concatenate the whole part
-                    part_text = "\n\n---\n\n".join([n.text for n in scenes])
-                    
                     safe_print(f"Summarizing {cache_key}...")
                     
                     # Generate summary with rolling context
@@ -140,9 +269,14 @@ class HierarchicalSummarizer:
                     )
                     
                     # Save to cache
-                    cache[cache_key] = current_summary
-                    with open(cache_file, "w", encoding="utf-8") as f:
-                        json.dump(cache, f, ensure_ascii=False, indent=2)
+                    _store_cached_summary(
+                        cache,
+                        cache_key,
+                        summary=current_summary,
+                        fingerprint=fingerprint,
+                        inputs=cache_inputs,
+                    )
+                    _save_cache(cache_file, cache)
 
                 summary_node = StoryNode(
                     text=current_summary,
@@ -158,10 +292,7 @@ class HierarchicalSummarizer:
 
     def summarize_episodes(self, part_nodes: list[StoryNode], cache_file: str = "summaries_cache.json") -> list[StoryNode]:
         """Aggregates Tier 3 Part Summaries into Tier 2 Episode Summaries."""
-        cache: dict[str, str] = {}
-        if os.path.exists(cache_file):
-            with open(cache_file, encoding="utf-8") as f:
-                cache = json.load(f)
+        cache = _load_cache(cache_file)
 
         # Group by (arc_id, story_type, episode_name)
         episodes: dict[tuple, list[StoryNode]] = defaultdict(list)
@@ -194,11 +325,20 @@ class HierarchicalSummarizer:
             base_meta = parts[0].metadata.model_copy(deep=True)
             base_meta.part_name = "ALL_PARTS" # Represents the whole episode
 
-            if cache_key in cache:
+            combined_text = "\n\n---\n\n".join([f"Part: {n.metadata.part_name}\n{n.text}" for n in parts])
+            cache_inputs = self._aggregate_cache_inputs(
+                level="episode",
+                child_nodes=parts,
+                combined_text=combined_text,
+                prev_summary=prev_summary,
+            )
+            fingerprint = stable_hash(cache_inputs)
+            cached = _cached_summary(cache, cache_key, fingerprint)
+
+            if cached is not None:
                 safe_print(f"Loading cached episode summary for {cache_key}...")
-                current_summary = cache[cache_key]
+                current_summary = cached
             else:
-                combined_text = "\n\n---\n\n".join([f"Part: {n.metadata.part_name}\n{n.text}" for n in parts])
                 safe_print(f"Summarizing Episode: {cache_key}...")
                 
                 current_summary = self._generate_rolling_summary(
@@ -207,9 +347,14 @@ class HierarchicalSummarizer:
                     level_name="Episode"
                 )
                 
-                cache[cache_key] = current_summary
-                with open(cache_file, "w", encoding="utf-8") as f:
-                    json.dump(cache, f, ensure_ascii=False, indent=2)
+                _store_cached_summary(
+                    cache,
+                    cache_key,
+                    summary=current_summary,
+                    fingerprint=fingerprint,
+                    inputs=cache_inputs,
+                )
+                _save_cache(cache_file, cache)
 
             summary_nodes.append(StoryNode(
                 text=current_summary,
@@ -223,10 +368,7 @@ class HierarchicalSummarizer:
 
     def summarize_years(self, episode_nodes: list[StoryNode], cache_file: str = "summaries_cache.json") -> list[StoryNode]:
         """Aggregates Tier 2 Episode Summaries into Tier 1 Year Summaries."""
-        cache: dict[str, str] = {}
-        if os.path.exists(cache_file):
-            with open(cache_file, encoding="utf-8") as f:
-                cache = json.load(f)
+        cache = _load_cache(cache_file)
 
         # Group by arc_id (Year)
         years: dict[str, list[StoryNode]] = defaultdict(list)
@@ -266,11 +408,20 @@ class HierarchicalSummarizer:
             base_meta.episode_name = "ALL_EPISODES"
             base_meta.part_name = "ALL_PARTS"
 
-            if cache_key in cache:
+            combined_text = "\n\n---\n\n".join([f"Episode: {n.metadata.episode_name}\n{n.text}" for n in episodes])
+            cache_inputs = self._aggregate_cache_inputs(
+                level="year",
+                child_nodes=episodes,
+                combined_text=combined_text,
+                prev_summary=prev_summary,
+            )
+            fingerprint = stable_hash(cache_inputs)
+            cached = _cached_summary(cache, cache_key, fingerprint)
+
+            if cached is not None:
                 safe_print(f"Loading cached year summary for {cache_key}...")
-                current_summary = cache[cache_key]
+                current_summary = cached
             else:
-                combined_text = "\n\n---\n\n".join([f"Episode: {n.metadata.episode_name}\n{n.text}" for n in episodes])
                 safe_print(f"Summarizing Year: {cache_key}...")
                 
                 current_summary = self._generate_rolling_summary(
@@ -279,9 +430,14 @@ class HierarchicalSummarizer:
                     level_name="Year"
                 )
                 
-                cache[cache_key] = current_summary
-                with open(cache_file, "w", encoding="utf-8") as f:
-                    json.dump(cache, f, ensure_ascii=False, indent=2)
+                _store_cached_summary(
+                    cache,
+                    cache_key,
+                    summary=current_summary,
+                    fingerprint=fingerprint,
+                    inputs=cache_inputs,
+                )
+                _save_cache(cache_file, cache)
 
             summary_nodes.append(StoryNode(
                 text=current_summary,

--- a/src/linkura_story_indexer/lexical.py
+++ b/src/linkura_story_indexer/lexical.py
@@ -217,6 +217,21 @@ class LexicalIndex:
                     (record_id, search_text),
                 )
 
+    def list_ids(self) -> set[str]:
+        with self._connect() as connection:
+            rows = connection.execute("SELECT id FROM lexical_records").fetchall()
+        return {str(row["id"]) for row in rows}
+
+    def delete_records(self, ids: Iterable[str]) -> None:
+        sorted_ids = sorted(set(ids))
+        if not sorted_ids:
+            return
+
+        with self._connect() as connection:
+            for record_id in sorted_ids:
+                connection.execute("DELETE FROM lexical_records WHERE id = ?", (record_id,))
+                connection.execute("DELETE FROM lexical_records_fts WHERE id = ?", (record_id,))
+
     def search(
         self,
         query: str,

--- a/tests/test_ingestion_manifest.py
+++ b/tests/test_ingestion_manifest.py
@@ -1,0 +1,371 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from linkura_story_indexer import cli
+from linkura_story_indexer.indexer.chunker import (
+    CHUNKER_VERSION,
+    MAX_CHUNK_CHARS,
+    MIN_USEFUL_CHARS,
+    TARGET_CHUNK_CHARS,
+    build_retrieval_chunks,
+)
+from linkura_story_indexer.indexer.manifest import (
+    RAW_EVIDENCE_SCHEMA_VERSION,
+    SUMMARY_CACHE_SCHEMA_VERSION,
+    ChunkerConfig,
+    IngestionManifest,
+    SummaryCacheContext,
+    VectorIds,
+    stable_hash,
+)
+from linkura_story_indexer.indexer.parser import PARSER_VERSION
+from linkura_story_indexer.indexer.processor import StoryProcessor
+from linkura_story_indexer.indexer.summarizer import (
+    SUMMARIZATION_PROMPT_VERSION,
+    HierarchicalSummarizer,
+)
+from linkura_story_indexer.lexical import LexicalIndex
+
+
+def _write_story_file(root: Path, relative_path: str, content: str) -> Path:
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _cache_context(path: Path, **overrides: Any) -> SummaryCacheContext:
+    values = {
+        "source_file_hashes": {str(path): "source-hash-1"},
+        "parser_version": PARSER_VERSION,
+        "summarization_prompt_version": SUMMARIZATION_PROMPT_VERSION,
+        "glossary_hash": "glossary-hash-1",
+        "chat_model": "chat-model-1",
+        "embedding_model": "embedding-model-1",
+        "summary_cache_schema_version": SUMMARY_CACHE_SCHEMA_VERSION,
+    }
+    values.update(overrides)
+    return SummaryCacheContext(**values)
+
+
+def test_manifest_serializes_required_fields_with_expected_types() -> None:
+    manifest = IngestionManifest(
+        timestamp="2026-04-27T12:00:00+00:00",
+        source_file_hashes={"story/103/part.md": "abc123"},
+        parser_version=PARSER_VERSION,
+        chunker_version=CHUNKER_VERSION,
+        chunker_config=ChunkerConfig(
+            min_chars=MIN_USEFUL_CHARS,
+            target_chars=TARGET_CHUNK_CHARS,
+            max_chars=MAX_CHUNK_CHARS,
+        ),
+        summarization_prompt_version=SUMMARIZATION_PROMPT_VERSION,
+        glossary_hash="glossary-hash",
+        chat_model="chat-model",
+        embedding_model="embedding-model",
+        raw_evidence_schema_version=RAW_EVIDENCE_SCHEMA_VERSION,
+        summary_cache_schema_version=SUMMARY_CACHE_SCHEMA_VERSION,
+        vector_ids=VectorIds(raw=["chunk:part:0-1"], summaries=["summary:part:part"]),
+    )
+
+    data = json.loads(manifest.model_dump_json())
+
+    assert data["schema_version"] == "1"
+    assert isinstance(data["timestamp"], str)
+    assert isinstance(data["source_file_hashes"], dict)
+    assert isinstance(data["parser_version"], str)
+    assert isinstance(data["chunker_version"], str)
+    assert data["chunker_config"] == {
+        "min_chars": MIN_USEFUL_CHARS,
+        "target_chars": TARGET_CHUNK_CHARS,
+        "max_chars": MAX_CHUNK_CHARS,
+    }
+    assert isinstance(data["summarization_prompt_version"], str)
+    assert isinstance(data["glossary_hash"], str)
+    assert isinstance(data["chat_model"], str)
+    assert isinstance(data["embedding_model"], str)
+    assert isinstance(data["raw_evidence_schema_version"], str)
+    assert isinstance(data["summary_cache_schema_version"], str)
+    assert data["vector_ids"]["raw"] == ["chunk:part:0-1"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_file_hashes", None),
+        ("parser_version", "parser-version-2"),
+        ("summarization_prompt_version", "prompt-version-2"),
+        ("glossary_hash", "glossary-hash-2"),
+        ("chat_model", "chat-model-2"),
+        ("embedding_model", "embedding-model-2"),
+        ("summary_cache_schema_version", "summary-schema-2"),
+    ],
+)
+def test_summary_cache_invalidates_when_tracked_input_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str | None,
+) -> None:
+    story_root = tmp_path / "story"
+    path = _write_story_file(
+        story_root,
+        "103/第1話『花咲きたい！』/1.md",
+        "花帆: こんにちは\n---\nさやか: どうしたの？",
+    )
+    raw_nodes = StoryProcessor.process_file(path)
+    cache_file = tmp_path / "summaries_cache.json"
+    calls: list[str] = []
+
+    def fake_generate(
+        self: HierarchicalSummarizer,
+        current_text: str,
+        prev_summary: str | None = None,
+        level_name: str = "Part",
+    ) -> str:
+        calls.append(current_text)
+        return f"{level_name} summary {len(calls)}"
+
+    monkeypatch.setattr(HierarchicalSummarizer, "_generate_rolling_summary", fake_generate)
+
+    context = _cache_context(path)
+    HierarchicalSummarizer(cache_context=context).summarize_parts(
+        raw_nodes,
+        cache_file=str(cache_file),
+    )
+    HierarchicalSummarizer(cache_context=context).summarize_parts(
+        raw_nodes,
+        cache_file=str(cache_file),
+    )
+
+    assert len(calls) == 1
+
+    if field == "source_file_hashes":
+        changed_context = context.model_copy(
+            update={"source_file_hashes": {str(path): "source-hash-2"}}
+        )
+    else:
+        changed_context = context.model_copy(update={field: value})
+
+    HierarchicalSummarizer(cache_context=changed_context).summarize_parts(
+        raw_nodes,
+        cache_file=str(cache_file),
+    )
+
+    assert len(calls) == 2
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("parser_version", "parser-version-2"),
+        ("chunker_version", "chunker-version-2"),
+        ("chunker_config", {"min_chars": 1, "target_chars": 2, "max_chars": 3}),
+        ("embedding_model", "embedding-model-2"),
+        ("raw_evidence_schema_version", "raw-schema-2"),
+    ],
+)
+def test_raw_evidence_fingerprint_changes_for_tracked_inputs(field: str, value: Any) -> None:
+    baseline = {
+        "parser_version": PARSER_VERSION,
+        "chunker_version": CHUNKER_VERSION,
+        "chunker_config": {
+            "min_chars": MIN_USEFUL_CHARS,
+            "target_chars": TARGET_CHUNK_CHARS,
+            "max_chars": MAX_CHUNK_CHARS,
+        },
+        "embedding_model": "embedding-model-1",
+        "raw_evidence_schema_version": RAW_EVIDENCE_SCHEMA_VERSION,
+    }
+    changed = {**baseline, field: value}
+
+    assert stable_hash(changed) != stable_hash(baseline)
+
+
+class FakePrunableCollection:
+    def __init__(self) -> None:
+        self.ids = {"chunk:stale:0-0", "chunk:current:0-0"}
+        self.deleted: list[str] = []
+
+    def get(self, include: list[str]) -> dict[str, list[str]]:
+        assert include == []
+        return {"ids": sorted(self.ids)}
+
+    def delete(self, *, ids: list[str]) -> None:
+        self.deleted.extend(ids)
+        self.ids -= set(ids)
+
+
+class FakeIngestCollection:
+    def __init__(self) -> None:
+        self.records: dict[str, dict[str, Any]] = {}
+
+    def upsert(
+        self,
+        *,
+        ids: list[str],
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+        embeddings: list[list[float]],
+    ) -> None:
+        for record_id, document, metadata, embedding in zip(
+            ids,
+            documents,
+            metadatas,
+            embeddings,
+            strict=True,
+        ):
+            self.records[record_id] = {
+                "document": document,
+                "metadata": metadata,
+                "embedding": embedding,
+            }
+
+    def get(self, include: list[str]) -> dict[str, list[str]]:
+        assert include == []
+        return {"ids": sorted(self.records)}
+
+    def delete(self, *, ids: list[str]) -> None:
+        for record_id in ids:
+            self.records.pop(record_id, None)
+
+
+def test_pruning_deletes_records_not_emitted_by_current_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collection = FakePrunableCollection()
+    lexical_index = LexicalIndex(tmp_path / "lexical.db")
+    metadata = {
+        "arc_id": "103",
+        "story_type": "Main",
+        "episode_name": "第1話『花咲きたい！』",
+        "part_name": "1",
+        "file_path": "story/103/第1話『花咲きたい！』/1.md",
+        "summary_level": 4,
+    }
+    lexical_index.upsert_records(
+        ids=["chunk:stale:0-0", "chunk:current:0-0", "chunk:lexical-only:0-0"],
+        documents=["old", "current", "lexical old"],
+        metadatas=[metadata, metadata, metadata],
+    )
+
+    monkeypatch.setattr(cli, "get_chroma_collection", lambda: collection)
+
+    pruned_count = cli._prune_stale_records(
+        emitted_ids={"chunk:current:0-0"},
+        lexical_index=lexical_index,
+    )
+
+    assert pruned_count == 2
+    assert collection.deleted == ["chunk:stale:0-0"]
+    assert collection.ids == {"chunk:current:0-0"}
+    assert lexical_index.list_ids() == {"chunk:current:0-0"}
+
+
+def test_reingest_after_rename_prunes_old_file_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    story_root = tmp_path / "story"
+    old_path = _write_story_file(
+        story_root,
+        "103/第1話『花咲きたい！』/1.md",
+        "花帆: こんにちは\n---\nさやか: どうしたの？",
+    )
+    collection = FakeIngestCollection()
+    lexical_index = LexicalIndex(tmp_path / "lexical.db")
+
+    monkeypatch.setattr(cli, "get_chroma_collection", lambda: collection)
+    monkeypatch.setattr(cli, "embed_texts", lambda texts, *, task_type: [[1.0] for _ in texts])
+
+    first_nodes = build_retrieval_chunks(StoryProcessor.process_file(old_path))
+    first_ids = set(
+        cli._upsert_story_nodes(
+            first_nodes,
+            progress_label="Embedding first run",
+            lexical_index=lexical_index,
+        )
+    )
+    cli._prune_stale_records(emitted_ids=first_ids, lexical_index=lexical_index)
+
+    old_content = old_path.read_text(encoding="utf-8")
+    old_path.unlink()
+    new_path = _write_story_file(
+        story_root,
+        "103/第1話『花咲きたい！』/2.md",
+        old_content,
+    )
+
+    second_nodes = build_retrieval_chunks(StoryProcessor.process_file(new_path))
+    second_ids = set(
+        cli._upsert_story_nodes(
+            second_nodes,
+            progress_label="Embedding second run",
+            lexical_index=lexical_index,
+        )
+    )
+    cli._prune_stale_records(emitted_ids=second_ids, lexical_index=lexical_index)
+
+    assert set(collection.records) == second_ids
+    assert all(
+        record["metadata"]["file_path"] == str(new_path)
+        for record in collection.records.values()
+    )
+    assert all(
+        record["metadata"]["file_path"] != str(old_path)
+        for record in collection.records.values()
+    )
+
+
+def test_reingest_after_rechunk_prunes_old_chunk_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    story_root = tmp_path / "story"
+    path = _write_story_file(
+        story_root,
+        "103/第1話『花咲きたい！』/1.md",
+        "\n---\n".join(
+            [
+                "花帆: aaaaaaaaaa",
+                "さやか: bbbbbbbbbb",
+                "花帆: cccccccccc",
+                "さやか: dddddddddd",
+                "花帆: eeeeeeeeee",
+            ]
+        ),
+    )
+    collection = FakeIngestCollection()
+    lexical_index = LexicalIndex(tmp_path / "lexical.db")
+
+    monkeypatch.setattr(cli, "get_chroma_collection", lambda: collection)
+    monkeypatch.setattr(cli, "embed_texts", lambda texts, *, task_type: [[1.0] for _ in texts])
+
+    raw_nodes = StoryProcessor.process_file(path)
+    first_chunks = build_retrieval_chunks(raw_nodes, min_chars=35, target_chars=55, max_chars=80)
+    first_ids = set(
+        cli._upsert_story_nodes(
+            first_chunks,
+            progress_label="Embedding first chunks",
+            lexical_index=lexical_index,
+        )
+    )
+    cli._prune_stale_records(emitted_ids=first_ids, lexical_index=lexical_index)
+
+    second_chunks = build_retrieval_chunks(raw_nodes, min_chars=1, target_chars=500, max_chars=500)
+    second_ids = set(
+        cli._upsert_story_nodes(
+            second_chunks,
+            progress_label="Embedding second chunks",
+            lexical_index=lexical_index,
+        )
+    )
+    cli._prune_stale_records(emitted_ids=second_ids, lexical_index=lexical_index)
+
+    assert first_ids != second_ids
+    assert set(collection.records) == second_ids
+    assert first_ids.isdisjoint(collection.records)


### PR DESCRIPTION
## Summary
- Add ingestion manifest serialization with source hashes, parser/chunker/prompt/schema versions, glossary hash, model names, timestamp, and emitted vector IDs
- Fingerprint summary cache entries so tracked input changes invalidate stale summaries
- Track emitted ingest IDs and prune stale Chroma plus lexical records by default, with `--no-prune` opt-out
- Add tests for manifest shape, cache invalidation triggers, raw evidence fingerprint inputs, stale pruning, rename pruning, and re-chunk pruning

Closes #9.

## Validation
- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`