### PR TITLE
Handle multi-speaker dialogue labels

### DIFF
--- a/src/linkura_story_indexer/indexer/manifest.py
+++ b/src/linkura_story_indexer/indexer/manifest.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 MANIFEST_SCHEMA_VERSION = "1"
 SUMMARY_CACHE_SCHEMA_VERSION = "1"
-RAW_EVIDENCE_SCHEMA_VERSION = "2"
+RAW_EVIDENCE_SCHEMA_VERSION = "3"
 
 
 class ChunkerConfig(BaseModel):

--- a/src/linkura_story_indexer/indexer/parser.py
+++ b/src/linkura_story_indexer/indexer/parser.py
@@ -1,10 +1,16 @@
+import html
 import re
 
 from ..models.story import DialogueTurn, NarrativeBeat
 
-PARSER_VERSION = "2"
+PARSER_VERSION = "3"
 UNKNOWN_SPEAKER = "UNKNOWN"
+SPEAKER_KIND_COLLECTIVE = "collective"
+SPEAKER_KIND_NAMED = "named"
+SPEAKER_KIND_UNKNOWN = "unknown"
+COLLECTIVE_SPEAKERS = {"全員"}
 _QUOTE_RE = re.compile(r"(「[^」]+」|『[^』]+』|“[^”]+”|\"[^\"]+\")")
+_SPEAKER_SEPARATOR_RE = re.compile(r"\s*(?:＆|&)\s*")
 
 
 class StoryParser:
@@ -29,15 +35,39 @@ class StoryParser:
         return "", ""
 
     @staticmethod
+    def parse_speaker_label(speaker: str) -> tuple[list[str], str]:
+        """Returns queryable speaker tokens and the speaker kind for a raw label."""
+        normalized = html.unescape(speaker).strip()
+        if not normalized:
+            return [], ""
+        if normalized == UNKNOWN_SPEAKER:
+            return [UNKNOWN_SPEAKER], SPEAKER_KIND_UNKNOWN
+        if normalized in COLLECTIVE_SPEAKERS:
+            return [normalized], SPEAKER_KIND_COLLECTIVE
+
+        tokens: list[str] = []
+        seen = set()
+        for token in _SPEAKER_SEPARATOR_RE.split(normalized):
+            token = token.strip()
+            if not token or token in seen:
+                continue
+            tokens.append(token)
+            seen.add(token)
+        return tokens or [normalized], SPEAKER_KIND_NAMED
+
+    @staticmethod
     def detect_speakers(content: str) -> list[str]:
         """Returns unique script speakers in first-seen order."""
         speakers = []
         seen = set()
         for line in content.splitlines():
             speaker, _ = StoryParser.parse_script_line(line)
-            if speaker and speaker not in seen:
-                speakers.append(speaker)
-                seen.add(speaker)
+            speaker_tokens, _ = StoryParser.parse_speaker_label(speaker)
+            for speaker_token in speaker_tokens:
+                if speaker_token in seen:
+                    continue
+                speakers.append(speaker_token)
+                seen.add(speaker_token)
         return speakers
 
     @staticmethod
@@ -46,10 +76,14 @@ class StoryParser:
         speakers = []
         seen = set()
         for turn in turns:
-            if turn.speaker in seen:
-                continue
-            speakers.append(turn.speaker)
-            seen.add(turn.speaker)
+            speaker_tokens = turn.speaker_tokens
+            if not speaker_tokens:
+                speaker_tokens, _ = StoryParser.parse_speaker_label(turn.speaker)
+            for speaker in speaker_tokens:
+                if speaker in seen:
+                    continue
+                speakers.append(speaker)
+                seen.add(speaker)
         return speakers
 
     @staticmethod
@@ -64,6 +98,7 @@ class StoryParser:
             if not speaker:
                 speaker = UNKNOWN_SPEAKER
                 text = stripped
+            speaker_tokens, speaker_kind = StoryParser.parse_speaker_label(speaker)
             turn_index = len(turns)
             turn_id = f"turn:{scene_id}:{turn_index}" if scene_id else ""
             turns.append(
@@ -72,6 +107,8 @@ class StoryParser:
                     scene_id=scene_id,
                     turn_index=turn_index,
                     speaker=speaker,
+                    speaker_tokens=speaker_tokens,
+                    speaker_kind=speaker_kind,
                     text=text,
                     line_start=line_number,
                     line_end=line_number,
@@ -108,12 +145,15 @@ class StoryParser:
 
                 turn_index = len(turns)
                 turn_id = f"turn:{scene_id}:{turn_index}" if scene_id else ""
+                speaker_tokens, speaker_kind = StoryParser.parse_speaker_label(UNKNOWN_SPEAKER)
                 turns.append(
                     DialogueTurn(
                         turn_id=turn_id,
                         scene_id=scene_id,
                         turn_index=turn_index,
                         speaker=UNKNOWN_SPEAKER,
+                        speaker_tokens=speaker_tokens,
+                        speaker_kind=speaker_kind,
                         text=match.group(0),
                         line_start=line_number,
                         line_end=line_number,

--- a/src/linkura_story_indexer/indexer/source_store.py
+++ b/src/linkura_story_indexer/indexer/source_store.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from ..models.story import DialogueTurn, NarrativeBeat, StoryNode
+from .parser import SPEAKER_KIND_NAMED, StoryParser
 
 DEFAULT_SOURCE_DB_PATH = "./source_records.db"
 
@@ -28,6 +29,12 @@ def _chunk_id(node: StoryNode) -> str:
 def _metadata_order(metadata: dict[str, Any]) -> int:
     order = metadata.get("story_order", metadata.get("canonical_story_order"))
     return int(order) if isinstance(order, int) else 0
+
+
+def _turn_speaker_tokens(turn: DialogueTurn) -> tuple[list[str], str]:
+    if turn.speaker_tokens:
+        return turn.speaker_tokens, turn.speaker_kind or SPEAKER_KIND_NAMED
+    return StoryParser.parse_speaker_label(turn.speaker)
 
 
 class SourceRecordStore:
@@ -85,6 +92,16 @@ class SourceRecordStore:
             )
             connection.execute(
                 """
+                CREATE TABLE IF NOT EXISTS dialogue_turn_speakers (
+                    turn_id TEXT NOT NULL,
+                    speaker TEXT NOT NULL,
+                    speaker_kind TEXT NOT NULL,
+                    PRIMARY KEY (turn_id, speaker)
+                )
+                """
+            )
+            connection.execute(
+                """
                 CREATE TABLE IF NOT EXISTS retrieval_chunk_sources (
                     chunk_id TEXT NOT NULL,
                     scene_id TEXT NOT NULL,
@@ -107,10 +124,48 @@ class SourceRecordStore:
                 )
                 """
             )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_dialogue_turn_speakers_speaker
+                ON dialogue_turn_speakers (speaker)
+                """
+            )
+            self._backfill_turn_speakers(connection)
+
+    def _backfill_turn_speakers(self, connection: sqlite3.Connection) -> None:
+        rows = connection.execute(
+            """
+            SELECT
+                t.turn_id,
+                t.scene_id,
+                t.turn_index,
+                t.speaker,
+                t.text,
+                t.line_start,
+                t.line_end
+            FROM dialogue_turns AS t
+            LEFT JOIN dialogue_turn_speakers AS ts ON ts.turn_id = t.turn_id
+            WHERE ts.turn_id IS NULL
+            """
+        ).fetchall()
+        for row in rows:
+            self._upsert_turn_speakers(
+                connection,
+                DialogueTurn(
+                    turn_id=str(row["turn_id"]),
+                    scene_id=str(row["scene_id"]),
+                    turn_index=int(row["turn_index"]),
+                    speaker=str(row["speaker"]),
+                    text=str(row["text"]),
+                    line_start=int(row["line_start"]),
+                    line_end=int(row["line_end"]),
+                ),
+            )
 
     def replace_all(self, raw_nodes: list[StoryNode], retrieval_chunks: list[StoryNode]) -> None:
         with self._connect() as connection:
             connection.execute("DELETE FROM source_scenes")
+            connection.execute("DELETE FROM dialogue_turn_speakers")
             connection.execute("DELETE FROM dialogue_turns")
             connection.execute("DELETE FROM narrative_beats")
             connection.execute("DELETE FROM retrieval_chunk_sources")
@@ -181,6 +236,25 @@ class SourceRecordStore:
                     turn.line_start,
                     turn.line_end,
                 ),
+            )
+            self._upsert_turn_speakers(connection, turn)
+
+    def _upsert_turn_speakers(
+        self,
+        connection: sqlite3.Connection,
+        turn: DialogueTurn,
+    ) -> None:
+        connection.execute("DELETE FROM dialogue_turn_speakers WHERE turn_id = ?", (turn.turn_id,))
+        speaker_tokens, speaker_kind = _turn_speaker_tokens(turn)
+        for speaker in speaker_tokens:
+            connection.execute(
+                """
+                INSERT INTO dialogue_turn_speakers (turn_id, speaker, speaker_kind)
+                VALUES (?, ?, ?)
+                ON CONFLICT(turn_id, speaker) DO UPDATE SET
+                    speaker_kind = excluded.speaker_kind
+                """,
+                (turn.turn_id, speaker, speaker_kind),
             )
 
     def _upsert_beats(
@@ -351,7 +425,8 @@ class SourceRecordStore:
                 SELECT DISTINCT r.chunk_id
                 FROM retrieval_chunk_sources AS r
                 JOIN dialogue_turns AS t ON t.scene_id = r.scene_id
-                WHERE t.speaker = ?
+                JOIN dialogue_turn_speakers AS ts ON ts.turn_id = t.turn_id
+                WHERE ts.speaker = ?
                 ORDER BY r.chunk_id
                 """,
                 (speaker,),
@@ -386,7 +461,7 @@ class SourceRecordStore:
         *,
         parent_part_id: str | None = None,
     ) -> int:
-        filters = ["t.speaker = ?"]
+        filters = ["ts.speaker = ?"]
         params: list[Any] = [speaker]
         if parent_part_id is not None:
             filters.append("s.parent_part_id = ?")
@@ -395,8 +470,9 @@ class SourceRecordStore:
         with self._connect() as connection:
             row = connection.execute(
                 f"""
-                SELECT COUNT(*) AS count
+                SELECT COUNT(DISTINCT t.turn_id) AS count
                 FROM dialogue_turns AS t
+                JOIN dialogue_turn_speakers AS ts ON ts.turn_id = t.turn_id
                 JOIN source_scenes AS s ON s.scene_id = t.scene_id
                 WHERE {where}
                 """,

--- a/src/linkura_story_indexer/models/story.py
+++ b/src/linkura_story_indexer/models/story.py
@@ -5,7 +5,15 @@ class DialogueTurn(BaseModel):
     turn_id: str = Field("", description="Stable identifier for this dialogue turn")
     scene_id: str = Field("", description="Stable source scene identifier")
     turn_index: int = Field(0, description="Ordered index within the source scene")
-    speaker: str = Field(..., description="Speaker name, or UNKNOWN when not explicit")
+    speaker: str = Field(..., description="Raw speaker label, or UNKNOWN when not explicit")
+    speaker_tokens: list[str] = Field(
+        default_factory=list,
+        description="Queryable speaker tokens parsed from the raw speaker label",
+    )
+    speaker_kind: str = Field(
+        "",
+        description="Speaker label kind, such as named, collective, or unknown",
+    )
     text: str = Field(..., description="Dialogue text")
     line_start: int = Field(0, description="Zero-based source line where this turn starts")
     line_end: int = Field(0, description="Zero-based source line where this turn ends")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,6 +30,25 @@ def test_script_scene_parser_preserves_ordered_turns_and_unknown_lines():
     assert [turn.turn_id for turn in turns] == ["turn:scene:test:0:0", "turn:scene:test:0:1"]
 
 
+def test_script_scene_parser_splits_composite_speaker_labels() -> None:
+    turns = StoryParser.parse_script_scene(
+        "梢＆慈: おお……。\n瑠璃乃&amp;姫芽: で、バズ曲ってなんだ？？？？？？\n全員: おー！！",
+        scene_id="scene:test:composite",
+    )
+
+    assert [(turn.speaker, turn.text) for turn in turns] == [
+        ("梢＆慈", "おお……。"),
+        ("瑠璃乃&amp;姫芽", "で、バズ曲ってなんだ？？？？？？"),
+        ("全員", "おー！！"),
+    ]
+    assert [turn.speaker_tokens for turn in turns] == [
+        ["梢", "慈"],
+        ["瑠璃乃", "姫芽"],
+        ["全員"],
+    ]
+    assert [turn.speaker_kind for turn in turns] == ["named", "named", "collective"]
+
+
 def test_prose_scene_parser_separates_quoted_dialogue_from_narrative():
     turns, beats = StoryParser.parse_prose_scene(
         "泉は笑った。「行こう」それから走った。",
@@ -43,16 +62,16 @@ def test_prose_scene_parser_separates_quoted_dialogue_from_narrative():
 def test_processed_scene_metadata_speakers_match_structured_turn_union(tmp_path: Path):
     path = tmp_path / "story" / "103" / "第1話『花咲きたい！』" / "1.md"
     path.parent.mkdir(parents=True)
-    path.write_text("花帆: こんにちは\nさやか: どうしたの？", encoding="utf-8")
+    path.write_text("花帆: こんにちは\n梢＆慈: おお……。", encoding="utf-8")
 
     node = StoryProcessor.process_file(path)[0]
 
-    assert node.metadata.speakers == ["花帆", "さやか"]
-    assert node.metadata.detected_speakers == ["花帆", "さやか"]
+    assert node.metadata.speakers == ["花帆", "梢", "慈"]
+    assert node.metadata.detected_speakers == ["花帆", "梢", "慈"]
     assert node.metadata.source_scene_ids == [
         "scene:103|Main|第1話『花咲きたい！』|1:0"
     ]
-    assert [turn.speaker for turn in node.dialogue_turns] == ["花帆", "さやか"]
+    assert [turn.speaker for turn in node.dialogue_turns] == ["花帆", "梢＆慈"]
 
 def test_hierarchy_extraction():
     # Main story test

--- a/tests/test_source_store.py
+++ b/tests/test_source_store.py
@@ -1,3 +1,4 @@
+import sqlite3
 from pathlib import Path
 
 from linkura_story_indexer.indexer.chunker import build_retrieval_chunks
@@ -41,3 +42,128 @@ def test_source_store_persists_turns_beats_and_chunk_speaker_mapping(tmp_path: P
     ]
     assert store.turns_matching_text("行こう")[0]["speaker"] == "UNKNOWN"
     assert store.count_turns("花帆") == 1
+
+
+def test_source_store_queries_composite_speaker_tokens_without_dup_turns(tmp_path: Path) -> None:
+    story_root = tmp_path / "story"
+    script_path = _write_story_file(
+        story_root,
+        "103/第1話『花咲きたい！』/1.md",
+        "\n---\n".join(
+            [
+                "花帆: こんにちは",
+                "梢＆慈: おお……。",
+                "瑠璃乃&amp;姫芽: で、バズ曲ってなんだ？？？？？？",
+                "全員: おー！！",
+            ]
+        ),
+    )
+    raw_nodes = StoryProcessor.process_file(script_path)
+    chunks = build_retrieval_chunks(raw_nodes, min_chars=1, target_chars=500, max_chars=500)
+    db_path = tmp_path / "source.db"
+    store = SourceRecordStore(db_path)
+
+    store.replace_all(raw_nodes, chunks)
+
+    assert raw_nodes[1].dialogue_turns[0].speaker == "梢＆慈"
+    assert raw_nodes[1].dialogue_turns[0].speaker_tokens == ["梢", "慈"]
+    assert raw_nodes[2].dialogue_turns[0].speaker_tokens == ["瑠璃乃", "姫芽"]
+    assert raw_nodes[3].dialogue_turns[0].speaker_tokens == ["全員"]
+    assert raw_nodes[3].dialogue_turns[0].speaker_kind == "collective"
+
+    expected_chunk_ids = ["chunk:103|Main|第1話『花咲きたい！』|1:0-3"]
+    assert store.chunk_ids_for_speaker("梢") == expected_chunk_ids
+    assert store.chunk_ids_for_speaker("慈") == expected_chunk_ids
+    assert store.chunk_ids_for_speaker("瑠璃乃") == expected_chunk_ids
+    assert store.chunk_ids_for_speaker("姫芽") == expected_chunk_ids
+    assert store.chunk_ids_for_speaker("全員") == expected_chunk_ids
+    assert store.count_turns("梢") == 1
+    assert store.count_turns("慈") == 1
+    assert store.count_turns("全員") == 1
+    assert store.count_turns("花帆") == 1
+
+    with sqlite3.connect(db_path) as connection:
+        dialogue_turn_count = connection.execute(
+            "SELECT COUNT(*) FROM dialogue_turns WHERE speaker = ?",
+            ("梢＆慈",),
+        ).fetchone()[0]
+        mapped_speakers = connection.execute(
+            """
+            SELECT speaker
+            FROM dialogue_turn_speakers
+            WHERE turn_id = ?
+            ORDER BY speaker
+            """,
+            (raw_nodes[1].dialogue_turns[0].turn_id,),
+        ).fetchall()
+
+    assert dialogue_turn_count == 1
+    assert [row[0] for row in mapped_speakers] == ["慈", "梢"]
+
+
+def test_source_store_backfills_speaker_mapping_for_existing_turns(tmp_path: Path) -> None:
+    db_path = tmp_path / "source.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE source_scenes (
+                scene_id TEXT PRIMARY KEY,
+                file_path TEXT NOT NULL,
+                parent_part_id TEXT NOT NULL,
+                scene_index INTEGER NOT NULL,
+                text TEXT NOT NULL,
+                metadata_json TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE dialogue_turns (
+                turn_id TEXT PRIMARY KEY,
+                scene_id TEXT NOT NULL,
+                turn_index INTEGER NOT NULL,
+                speaker TEXT NOT NULL,
+                text TEXT NOT NULL,
+                line_start INTEGER NOT NULL,
+                line_end INTEGER NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE retrieval_chunk_sources (
+                chunk_id TEXT NOT NULL,
+                scene_id TEXT NOT NULL,
+                scene_index INTEGER NOT NULL,
+                PRIMARY KEY (chunk_id, scene_id)
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_scenes (
+                scene_id, file_path, parent_part_id, scene_index, text, metadata_json
+            )
+            VALUES ('scene:legacy:0', 'story.md', 'part:legacy', 0, '梢＆慈: おお……。', '{}')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO dialogue_turns (
+                turn_id, scene_id, turn_index, speaker, text, line_start, line_end
+            )
+            VALUES ('turn:legacy:0', 'scene:legacy:0', 0, '梢＆慈', 'おお……。', 0, 0)
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO retrieval_chunk_sources (chunk_id, scene_id, scene_index)
+            VALUES ('chunk:legacy:0-0', 'scene:legacy:0', 0)
+            """
+        )
+
+    store = SourceRecordStore(db_path)
+
+    assert store.chunk_ids_for_speaker("梢") == ["chunk:legacy:0-0"]
+    assert store.chunk_ids_for_speaker("慈") == ["chunk:legacy:0-0"]
+    assert store.count_turns("梢") == 1


### PR DESCRIPTION
## Summary
- Preserve raw composite speaker labels while adding queryable speaker tokens to dialogue turns
- Store normalized speaker-token associations in `dialogue_turn_speakers` and update speaker count/chunk lookups to use the mapping table
- Treat `全員` as a collective speaker token without expanding it to named characters
- Backfill speaker mappings for existing source DBs and bump parser/raw evidence schema versions

## Tests
- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`

Closes #36