### PR TITLE
Tighten summary index labels

### DIFF
--- a/src/linkura_story_indexer/indexer/summarizer.py
+++ b/src/linkura_story_indexer/indexer/summarizer.py
@@ -161,7 +161,7 @@ Overview:
 Part Index:
 - Part 1: central part event, conflict, or outcome in one line.
 - Part 2: central part event, conflict, or outcome in one line.
-- Interlude: stable English label for a non-numbered interlude, special, ending, or other non-numbered part.
+- Interlude: brief recap of the interlude beat in one line.
 
 Episode Arc:
 - Setup: ...

--- a/src/linkura_story_indexer/indexer/summarizer.py
+++ b/src/linkura_story_indexer/indexer/summarizer.py
@@ -14,7 +14,7 @@ from .manifest import (
     stable_hash,
 )
 
-SUMMARIZATION_PROMPT_VERSION = "2"
+SUMMARIZATION_PROMPT_VERSION = "3"
 
 PART_SUMMARY_SECTIONS = (
     "Overview",
@@ -25,6 +25,7 @@ PART_SUMMARY_SECTIONS = (
 )
 EPISODE_SUMMARY_SECTIONS = (
     "Overview",
+    "Part Index",
     "Episode Arc",
     "Character Developments",
     "Relationship / Unit Developments",
@@ -157,6 +158,11 @@ Important Terms:
 Overview:
 [A detailed prose recap of the whole episode. Preserve the current useful length. Focus on the episode's central conflict, progression, turning points, and resolution. Do not compress into a short abstract.]
 
+Part Index:
+- Part 1: central part event, conflict, or outcome in one line.
+- Part 2: central part event, conflict, or outcome in one line.
+- Interlude: stable English label for a non-numbered interlude, special, ending, or other non-numbered part.
+
 Episode Arc:
 - Setup: ...
 - Escalation: ...
@@ -176,7 +182,12 @@ Continuity Facts:
 - Promises, conflicts, decisions, outcomes, new goals, event results.
 
 Important Terms:
-- Characters, units, songs, events, locations, apps, competitions, aliases central to this episode."""
+- Characters, units, songs, events, locations, apps, competitions, aliases central to this episode.
+
+Episode Part Index label rules:
+- Use `Part N:` for numbered parts.
+- Use stable English labels for non-numbered parts or interludes, such as `Interlude:` or `Ending:`.
+- Do not use raw Japanese part titles as Part Index bullet labels when a generic label is available."""
 
     if level_name == "Year":
         return """Required Year summary format:
@@ -185,8 +196,8 @@ Overview:
 [A detailed prose summary of the year's overall narrative movement, club status changes, competitions, graduations/transitions, and recurring themes. Keep episode boundaries clear; do not force unrelated episodes into larger arcs.]
 
 Episode Index:
-- Episode Name: central conflict and outcome in one line, about 20-30 words.
-- Episode Name: central conflict and outcome in one line, about 20-30 words.
+- Episode 1: central conflict and outcome in one line, about 20-30 words.
+- Episode 2: central conflict and outcome in one line, about 20-30 words.
 
 Character Trajectories:
 - Character Name: year-long growth, setbacks, role changes, relationships, goals.
@@ -199,7 +210,13 @@ Continuity Facts:
 - Year-level or cross-episode facts only: final states, competition results, graduations/transitions, promises, unresolved threads, and rare genuine multi-episode arcs.
 
 Important Terms:
-- Up to 15 major recurring or year-routing terms."""
+- Up to 15 major recurring or year-routing terms.
+
+Year Episode Index label rules:
+- Use `Episode N:` for numbered main episodes.
+- Use stable English labels for non-numbered special entries, such as `Interlude:` or `Special:`.
+- Do not use raw Japanese episode titles as Episode Index bullet labels.
+- Japanese or official episode titles and aliases may still be preserved in prose or Important Terms when retrieval-useful."""
 
     raise ValueError(f"Unsupported summary level: {level_name}")
 

--- a/tests/test_ingestion_manifest.py
+++ b/tests/test_ingestion_manifest.py
@@ -231,6 +231,53 @@ def test_summary_prompt_includes_required_tier_sections(
     assert "Do not use Markdown headings, bold text, numbered lists, tables, or extra sections." in prompt
 
 
+def test_summarization_prompt_version_is_current() -> None:
+    assert SUMMARIZATION_PROMPT_VERSION == "3"
+
+
+def test_episode_prompt_requires_part_index_with_stable_labels() -> None:
+    _, prompt = HierarchicalSummarizer()._build_summary_prompt(
+        "part summaries",
+        level_name="Episode",
+    )
+
+    assert EPISODE_SUMMARY_SECTIONS == (
+        "Overview",
+        "Part Index",
+        "Episode Arc",
+        "Character Developments",
+        "Relationship / Unit Developments",
+        "Continuity Facts",
+        "Important Terms",
+    )
+    assert prompt.index("Overview:") < prompt.index("Part Index:")
+    assert prompt.index("Part Index:") < prompt.index("Episode Arc:")
+    assert "- Part 1:" in prompt
+    assert "- Part 2:" in prompt
+    assert "Use `Part N:` for numbered parts." in prompt
+    assert "Use stable English labels for non-numbered parts or interludes" in prompt
+    assert "such as `Interlude:` or `Ending:`" in prompt
+    assert "Do not use raw Japanese part titles as Part Index bullet labels" in prompt
+    assert "when a generic label is available." in prompt
+
+
+def test_year_prompt_requires_stable_episode_index_labels() -> None:
+    _, prompt = HierarchicalSummarizer()._build_summary_prompt(
+        "episode summaries",
+        level_name="Year",
+    )
+
+    assert "- Episode 1:" in prompt
+    assert "- Episode 2:" in prompt
+    assert "Use `Episode N:` for numbered main episodes." in prompt
+    assert "Use stable English labels for non-numbered special entries" in prompt
+    assert "Do not use raw Japanese episode titles as Episode Index bullet labels." in prompt
+    assert (
+        "Japanese or official episode titles and aliases may still be preserved in prose "
+        "or Important Terms when retrieval-useful."
+    ) in prompt
+
+
 @pytest.mark.parametrize(
     ("level_name", "input_phrase"),
     [

--- a/tests/test_summary_export.py
+++ b/tests/test_summary_export.py
@@ -9,12 +9,12 @@ from linkura_story_indexer.summary_export import (
 )
 
 
-def _summary(*, label: str = "Part") -> str:
+def _summary(*, label: str = "Part", include_part_index: bool = True) -> str:
     list_label = "Key Events" if label == "Part" else "Episode Arc"
     if label == "Year":
         list_label = "Episode Index"
     part_index = ""
-    if label == "Episode":
+    if label == "Episode" and include_part_index:
         part_index = """
 Part Index:
 - Part 1: First indexed part.
@@ -121,6 +121,31 @@ def test_build_summary_reader_data_parses_sections_and_orders_tree(tmp_path: Pat
         record["summaryId"] == "103|Main|Episode A|A" and "kaho hinoshita" in record["text"]
         for record in data["search"]
     )
+
+
+def test_build_summary_reader_data_tolerates_legacy_episode_without_part_index(
+    tmp_path: Path,
+) -> None:
+    story_order = load_story_order(_story_order(tmp_path))
+    cache = {
+        "EPISODE|103|Main|Episode A": {
+            "schema_version": "1",
+            "fingerprint": "episode",
+            "summary": _summary(label="Episode", include_part_index=False),
+            "inputs": {"level": "episode"},
+        },
+    }
+
+    data = build_summary_reader_data(cache, story_order=story_order)
+    episode_summary = data["summaries"]["EPISODE|103|Main|Episode A"]
+
+    assert episode_summary["sectionOrder"] == [
+        "Overview",
+        "Episode Arc",
+        "Continuity Facts",
+        "Important Terms",
+    ]
+    assert "Part Index" not in episode_summary["sections"]
 
 
 def test_export_summary_reader_writes_static_site(tmp_path: Path) -> None:

--- a/tests/test_summary_export.py
+++ b/tests/test_summary_export.py
@@ -13,9 +13,16 @@ def _summary(*, label: str = "Part") -> str:
     list_label = "Key Events" if label == "Part" else "Episode Arc"
     if label == "Year":
         list_label = "Episode Index"
+    part_index = ""
+    if label == "Episode":
+        part_index = """
+Part Index:
+- Part 1: First indexed part.
+"""
     return f"""Overview:
 {label} overview.
 
+{part_index}
 {list_label}:
 - First item.
 
@@ -103,6 +110,13 @@ def test_build_summary_reader_data_parses_sections_and_orders_tree(tmp_path: Pat
     assert part_summary["sections"]["Overview"] == "Part overview."
     assert part_summary["importantTerms"] == ["Kaho Hinoshita", "Hasunosora"]
     assert part_summary["meta"]["models"]["chat"] == "chat"
+    episode_summary = data["summaries"]["EPISODE|103|Main|Episode A"]
+    assert episode_summary["sectionOrder"][:3] == [
+        "Overview",
+        "Part Index",
+        "Episode Arc",
+    ]
+    assert episode_summary["sections"]["Part Index"] == "- Part 1: First indexed part."
     assert any(
         record["summaryId"] == "103|Main|Episode A|A" and "kaho hinoshita" in record["text"]
         for record in data["search"]


### PR DESCRIPTION
## Summary
- bump the summary prompt version to invalidate cached summaries
- add an Episode-level Part Index section
- tighten Episode and Year prompt guidance to use stable generic index labels instead of raw Japanese titles
- note: the prompt-version bump invalidates existing summary cache entries, so operators should expect re-summarization cost on the next run

## Review follow-up
- tightened the Episode `Interlude:` example so it reads as an example output, not policy
- added a defensive export test for legacy Episode summaries that omit `Part Index`

## Tests
- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`