### PR TITLE
Add summary embedding metadata headers

### DIFF
--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -141,9 +141,39 @@ def _embedding_document_title(node: StoryNode) -> str:
     return " | ".join(str(part) for part in location if part)
 
 
+def _summary_tier(node: StoryNode) -> str:
+    if node.summary_level == 1:
+        return "Year"
+    if node.summary_level == 2:
+        return "Episode"
+    if node.summary_level == 3:
+        return "Part"
+    return f"Level {node.summary_level}"
+
+
+def _summary_location_header(node: StoryNode) -> str:
+    meta = node.metadata
+    episode_name = meta.episode_name if node.summary_level in {2, 3} else "ALL_EPISODES"
+    part_name = meta.part_name if node.summary_level == 3 else "ALL_PARTS"
+    return "\n".join(
+        [
+            f"Year: {meta.arc_id}",
+            f"Story type: {meta.story_type}",
+            f"Episode: {episode_name}",
+            f"Part: {part_name}",
+            f"Summary level: {node.summary_level}",
+            f"Summary tier: {_summary_tier(node)}",
+            "",
+        ]
+    )
+
+
 def _embedding_document(node: StoryNode, glossary: dict | None = None) -> EmbeddingDocument:
     if node.summary_level != 4:
-        return EmbeddingDocument(text=node.text, title=_embedding_document_title(node))
+        return EmbeddingDocument(
+            text=f"{_summary_location_header(node)}{node.text}",
+            title=_embedding_document_title(node),
+        )
 
     meta = node.metadata
     speakers = ", ".join(meta.detected_speakers) if meta.detected_speakers else "none"
@@ -169,18 +199,7 @@ def _embedding_document(node: StoryNode, glossary: dict | None = None) -> Embedd
 def _lexical_document(node: StoryNode, glossary: dict | None = None) -> str:
     embedding_document = _embedding_document(node, glossary)
     if node.summary_level != 4:
-        meta = node.metadata
-        header = "\n".join(
-            [
-                f"Year: {meta.arc_id}",
-                f"Story type: {meta.story_type}",
-                f"Episode: {meta.episode_name}",
-                f"Part: {meta.part_name}",
-                f"Summary level: {node.summary_level}",
-                "",
-            ]
-        )
-        return f"{header}{node.text}"
+        return embedding_document.text
     return embedding_document.text
 
 

--- a/tests/test_ingest_raw_scenes.py
+++ b/tests/test_ingest_raw_scenes.py
@@ -4,6 +4,7 @@ from typing import Any
 from linkura_story_indexer import cli
 from linkura_story_indexer.database import RETRIEVAL_DOCUMENT, EmbeddingInput
 from linkura_story_indexer.indexer.processor import StoryProcessor
+from linkura_story_indexer.models.story import StoryMetadata, StoryNode
 
 
 class FakeCollection:
@@ -37,6 +38,59 @@ def _write_story_file(root: Path, relative_path: str, content: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     return path
+
+
+def _summary_node(*, summary_level: int, text: str = "Summary text") -> StoryNode:
+    return StoryNode(
+        text=text,
+        metadata=StoryMetadata(
+            arc_id="103",
+            story_type="Main",
+            episode_name="第1話『花咲きたい！』",
+            part_name="1",
+            file_path="story/103/第1話『花咲きたい！』/1.md",
+            parent_year_id="103",
+            parent_episode_id="103|Main|第1話『花咲きたい！』",
+            parent_part_id="103|Main|第1話『花咲きたい！』|1",
+        ),
+        summary_level=summary_level,
+    )
+
+
+def test_part_summary_embedding_document_includes_location_and_tier_header() -> None:
+    embedding_document = cli._embedding_document(_summary_node(summary_level=3))
+
+    assert embedding_document.text.startswith(
+        "\n".join(
+            [
+                "Year: 103",
+                "Story type: Main",
+                "Episode: 第1話『花咲きたい！』",
+                "Part: 1",
+                "Summary level: 3",
+                "Summary tier: Part",
+                "Summary text",
+            ]
+        )
+    )
+
+
+def test_episode_summary_embedding_document_uses_all_parts_header() -> None:
+    embedding_document = cli._embedding_document(_summary_node(summary_level=2))
+
+    assert "Episode: 第1話『花咲きたい！』" in embedding_document.text
+    assert "Part: ALL_PARTS" in embedding_document.text
+    assert "Summary level: 2" in embedding_document.text
+    assert "Summary tier: Episode" in embedding_document.text
+
+
+def test_year_summary_embedding_document_uses_all_episode_and_part_header() -> None:
+    embedding_document = cli._embedding_document(_summary_node(summary_level=1))
+
+    assert "Episode: ALL_EPISODES" in embedding_document.text
+    assert "Part: ALL_PARTS" in embedding_document.text
+    assert "Summary level: 1" in embedding_document.text
+    assert "Summary tier: Year" in embedding_document.text
 
 
 def test_raw_scene_upsert_indexes_every_scene_with_required_metadata(

--- a/tests/test_lexical.py
+++ b/tests/test_lexical.py
@@ -158,3 +158,36 @@ def test_upsert_story_nodes_writes_matching_lexical_records(tmp_path: Path, monk
     assert lexical_index.search("Kaho", n_results=5) == [
         ("花帆: こんにちは", collection_records[record_id]["metadata"])
     ]
+
+
+def test_summary_lexical_document_includes_location_and_tier_header() -> None:
+    node = StoryNode(
+        text="花帆 and さやか talk about blooming.",
+        metadata=StoryMetadata(
+            arc_id="103",
+            story_type="Main",
+            episode_name="第1話『花咲きたい！』",
+            part_name="1",
+            file_path="story/103/第1話『花咲きたい！』/1.md",
+            parent_year_id="103",
+            parent_episode_id="103|Main|第1話『花咲きたい！』",
+            parent_part_id="103|Main|第1話『花咲きたい！』|1",
+        ),
+        summary_level=3,
+    )
+
+    lexical_document = cli._lexical_document(node)
+
+    assert lexical_document.startswith(
+        "\n".join(
+            [
+                "Year: 103",
+                "Story type: Main",
+                "Episode: 第1話『花咲きたい！』",
+                "Part: 1",
+                "Summary level: 3",
+                "Summary tier: Part",
+                "花帆 and さやか talk about blooming.",
+            ]
+        )
+    )


### PR DESCRIPTION
## Summary

- Add compact location metadata headers to summary embedding input text for Year, Episode, and Part summaries.
- Share the summary header helper with lexical summary documents and add `Summary tier`.
- Keep raw scene embedding behavior and stored Chroma documents unchanged.

## Verification

- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`

Closes #38