### PR TITLE
Raw-first query retrieval

### DIFF
--- a/src/linkura_story_indexer/query/analysis.py
+++ b/src/linkura_story_indexer/query/analysis.py
@@ -49,7 +49,7 @@ class QueryAnalysis:
         )
 
 
-_ARC_RE = re.compile(r"\b\d{3}\b")
+_ARC_RE = re.compile(r"\b(?P<arc>\d{3})(?:st|nd|rd|th)?\b", re.IGNORECASE)
 _EPISODE_RE = re.compile(r"(?:episode|ep\.?|第)\s*(\d+)", re.IGNORECASE)
 _TEMPORAL_EPISODE_RE = re.compile(
     r"\b(?P<operator>before|prior to|as of|until|through|after|since)\s+"
@@ -58,7 +58,7 @@ _TEMPORAL_EPISODE_RE = re.compile(
 )
 _TEMPORAL_ARC_RE = re.compile(
     r"\b(?P<operator>before|prior to|as of|until|through|after|since)\s+"
-    r"(?:year|arc)?\s*(?P<arc>\d{3})\b",
+    r"(?:year|arc)?\s*(?P<arc>\d{3})(?:st|nd|rd|th)?\b",
     re.IGNORECASE,
 )
 _SCENE_RE = re.compile(
@@ -87,7 +87,9 @@ def analyze_query(
     character_names = _extract_character_names(question, glossary)
 
     return QueryAnalysis(
-        arc_ids=tuple(_ordered_unique(_ARC_RE.findall(question))),
+        arc_ids=tuple(
+            _ordered_unique([match.group("arc") for match in _ARC_RE.finditer(question)])
+        ),
         story_type=story_type,
         episode_number=episode_number,
         part_name=part_name,

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -98,7 +98,15 @@ class StoryQueryEngine:
         if not self.state_ledger:
             return set()
         ledger_arc_ids = self._state_ledger_available_arc_ids()
-        return {arc_id for arc_id in re.findall(r"\b\d{3}\b", question) if arc_id in ledger_arc_ids}
+        return {
+            match.group("arc")
+            for match in re.finditer(
+                r"\b(?P<arc>\d{3})(?:st|nd|rd|th)?\b",
+                question,
+                re.IGNORECASE,
+            )
+            if match.group("arc") in ledger_arc_ids
+        }
 
     def _state_ledger_arc_ids(self, question: str, retrieved_arc_ids: set[str]) -> set[str]:
         explicit_arc_ids = self._question_arc_ids(question)
@@ -1180,37 +1188,27 @@ class StoryQueryEngine:
         ]
 
     def query(self, question: str) -> str:
-        """Executes the Hierarchical RAG query flow."""
-        safe_print("Searching vector index by summary tiers and raw evidence...")
+        """Executes the raw-first RAG query flow."""
+        safe_print("Searching raw source evidence...")
         analysis = analyze_query(question, self.glossary)
         structured_answer = self._structured_answer(question, analysis)
         if structured_answer is not None:
             return structured_answer
         expanded_question = self._expanded_question(question)
         query_embedding = self._query_embedding(expanded_question)
-        retrieved_nodes = self._tiered_retrieve(
+        retrieved_nodes = self._raw_only_retrieve(
             expanded_question,
             query_embedding=query_embedding,
             analysis=analysis,
         )
 
         if not retrieved_nodes:
-            safe_print("Tiered retrieval returned no hits.")
+            safe_print("Raw evidence retrieval returned no hits.")
 
-        direct_raw_nodes = self._raw_evidence_nodes(retrieved_nodes)
-        raw_ranked_lists = [direct_raw_nodes] if direct_raw_nodes else []
-        if retrieved_nodes:
-            safe_print("Expanding summary hits to child raw scenes...")
-            child_raw_nodes = self._expand_summaries_to_raw_scenes(
-                expanded_question,
-                retrieved_nodes,
-                query_embedding=query_embedding,
-                analysis=analysis,
-            )
-            if child_raw_nodes:
-                raw_ranked_lists.append(child_raw_nodes)
-
-        raw_nodes = self._filter_raw_nodes_by_analysis(self._rrf_fuse(raw_ranked_lists), analysis)
+        raw_nodes = self._filter_raw_nodes_by_analysis(
+            self._raw_evidence_nodes(retrieved_nodes),
+            analysis,
+        )
 
         if not raw_nodes:
             return INSUFFICIENT_SOURCE_CONTEXT
@@ -1243,4 +1241,4 @@ class StoryQueryEngine:
             return INSUFFICIENT_SOURCE_CONTEXT
 
         safe_print("Building answer context from raw source scenes...")
-        return self._answer_from_raw_evidence(question, final_raw_nodes)
+        return self._answer_from_raw_evidence(question, final_raw_nodes, analysis)

--- a/tests/test_query_analysis.py
+++ b/tests/test_query_analysis.py
@@ -31,6 +31,12 @@ def test_query_analysis_extracts_arc_constraint() -> None:
     assert analysis.intent_bucket == SUMMARY_INTENT
 
 
+def test_query_analysis_extracts_ordinal_arc_constraint() -> None:
+    analysis = analyze_query("What happened at the end of the 105th term?")
+
+    assert analysis.arc_ids == ("105",)
+
+
 def test_query_analysis_extracts_part_scene_constraint_as_zero_based() -> None:
     analysis = analyze_query("What happens in ABYSS scene 2?")
 

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -261,16 +261,7 @@ def test_query_uses_configured_candidate_counts(monkeypatch):
         final_top_k=5,
     )
     calls: list[dict[str, Any]] = []
-
-    summary_node = (
-        "part summary",
-        {
-            "arc_id": "103",
-            "summary_level": 3,
-            "parent_part_id": "103|Main|第3話『テスト』|2",
-        },
-    )
-    raw_child = raw_node("花帆: raw scene", scene_start=4)
+    raw_hit = raw_node("花帆: raw scene", scene_start=4)
 
     def fake_hybrid_retrieve(
         question: str,
@@ -281,39 +272,20 @@ def test_query_uses_configured_candidate_counts(monkeypatch):
     ) -> list[tuple[str, dict[str, Any]]]:
         calls.append({"n_results": n_results, "where": where})
         assert query_embedding == [0.1]
-        if where == {"summary_level": 3}:
-            return [summary_node]
         if where == {"summary_level": 4}:
-            return []
-        if where == {
-            "$and": [
-                {"summary_level": 4},
-                {"parent_part_id": "103|Main|第3話『テスト』|2"},
-            ]
-        }:
-            return [raw_child]
+            return [raw_hit]
         return []
 
     monkeypatch.setattr(engine, "_hybrid_retrieve", fake_hybrid_retrieve)
     monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
-    monkeypatch.setattr(engine, "_answer_from_raw_evidence", lambda question, nodes: "answered")
+    monkeypatch.setattr(
+        engine,
+        "_answer_from_raw_evidence",
+        lambda question, nodes, analysis: "answered",
+    )
 
     assert engine.query("What happened?") == "answered"
-    assert calls == [
-        {"n_results": 21, "where": {"summary_level": 1}},
-        {"n_results": 21, "where": {"summary_level": 2}},
-        {"n_results": 21, "where": {"summary_level": 3}},
-        {"n_results": 41, "where": {"summary_level": 4}},
-        {
-            "n_results": 31,
-            "where": {
-                "$and": [
-                    {"summary_level": 4},
-                    {"parent_part_id": "103|Main|第3話『テスト』|2"},
-                ]
-            },
-        },
-    ]
+    assert calls == [{"n_results": 41, "where": {"summary_level": 4}}]
 
 
 def test_tiered_retrieve_dispatches_each_summary_tier_and_raw(monkeypatch):
@@ -550,7 +522,7 @@ def test_summary_fanout_preserves_coalesced_child_spans(monkeypatch):
     assert engine._scene_span(expanded[0][1]) == (4, 7)
 
 
-def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
+def test_query_uses_only_raw_retrieval_for_scoped_question(monkeypatch):
     engine = make_engine()
     query_calls: list[dict[str, Any]] = []
     embedding_calls: list[list[str]] = []
@@ -559,42 +531,28 @@ def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
     class FakeCollection:
         def query(self, **kwargs: Any) -> dict[str, list[list[Any]]]:
             query_calls.append(kwargs)
-            if kwargs.get("where") == {"summary_level": 3}:
-                return {
-                    "documents": [["part summary"]],
-                    "metadatas": [
-                        [
-                            {
-                                "arc_id": "103",
-                                "story_type": "Main",
-                                "episode_name": "第3話『テスト』",
-                                "part_name": "2",
-                                "summary_level": 3,
-                                "parent_part_id": "103|Main|第3話『テスト』|2",
-                            }
-                        ]
-                    ],
-                }
             if kwargs.get("where") == {
                 "$and": [
                     {"summary_level": 4},
-                    {"parent_part_id": "103|Main|第3話『テスト』|2"},
+                    {"arc_id": "105"},
                 ]
             }:
                 return {
-                    "documents": [["花帆: raw scene"]],
+                    "documents": [["花帆 reached the end of the term in the raw scene."]],
                     "metadatas": [
                         [
                             {
-                                "arc_id": "103",
+                                "arc_id": "105",
                                 "story_type": "Main",
-                                "episode_name": "第3話『テスト』",
+                                "episode_name": "第12話『テスト』",
                                 "part_name": "2",
                                 "summary_level": 4,
                                 "file_path": "missing.md",
                                 "scene_index": 4,
-                                "canonical_story_order": 30,
-                                "parent_part_id": "103|Main|第3話『テスト』|2",
+                                "scene_start": 4,
+                                "scene_end": 4,
+                                "canonical_story_order": 1050,
+                                "parent_part_id": "105|Main|第12話『テスト』|2",
                             }
                         ]
                     ],
@@ -621,20 +579,21 @@ def test_query_expands_summary_hits_to_raw_scenes(monkeypatch):
     monkeypatch.setattr(query_engine, "create_text_agent", lambda system_prompt: FakeAgent())
     engine.collection = FakeCollection()
 
-    answer = engine.query("What happened?")
+    answer = engine.query("what happened to kaho at the end of the 105th term?")
 
     assert answer == "answered from raw scene"
-    assert embedding_calls == [["What happened?"]]
-    assert len(query_calls) == 5
-    assert query_calls[4]["where"] == {
+    assert embedding_calls == [["what happened to kaho at the end of the 105th term?"]]
+    assert len(query_calls) == 1
+    assert query_calls[0]["where"] == {
         "$and": [
             {"summary_level": 4},
-            {"parent_part_id": "103|Main|第3話『テスト』|2"},
+            {"arc_id": "105"},
         ]
     }
+    assert query_calls[0]["where"]["$and"][0] == {"summary_level": 4}
     assert "SUMMARY:" not in agent_prompts[0]
-    assert "花帆: raw scene" in agent_prompts[0]
-    assert "103 · Episode 3 · Part 2 · Scene 5" in agent_prompts[0]
+    assert "花帆 reached the end of the term in the raw scene." in agent_prompts[0]
+    assert "105 · Episode 12 · Part 2 · Scene 5" in agent_prompts[0]
 
 
 def test_query_reports_insufficient_source_context_without_raw_evidence(monkeypatch):
@@ -646,19 +605,6 @@ def test_query_reports_insufficient_source_context_without_raw_evidence(monkeypa
     class FakeCollection:
         def query(self, **kwargs: Any) -> dict[str, list[list[Any]]]:
             query_calls.append(kwargs)
-            if kwargs.get("where") == {"summary_level": 3}:
-                return {
-                    "documents": [["part summary"]],
-                    "metadatas": [
-                        [
-                            {
-                                "arc_id": "103",
-                                "summary_level": 3,
-                                "parent_part_id": "103|Main|第3話『テスト』|2",
-                            }
-                        ]
-                    ],
-                }
             return {
                 "documents": [[]],
                 "metadatas": [[]],
@@ -681,7 +627,8 @@ def test_query_reports_insufficient_source_context_without_raw_evidence(monkeypa
 
     assert answer == INSUFFICIENT_SOURCE_CONTEXT
     assert embedding_calls == [["What happened?"]]
-    assert len(query_calls) == 5
+    assert len(query_calls) == 1
+    assert query_calls[0]["where"] == {"summary_level": 4}
     assert agent_called is False
 
 
@@ -796,7 +743,11 @@ def test_query_caps_final_raw_evidence_to_configured_top_k(monkeypatch):
     monkeypatch.setattr(engine, "_hybrid_retrieve", lambda question, **kwargs: raw_nodes)
     monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
 
-    def fake_answer(question: str, nodes: list[tuple[str, dict[str, Any]]]) -> str:
+    def fake_answer(
+        question: str,
+        nodes: list[tuple[str, dict[str, Any]]],
+        analysis: Any,
+    ) -> str:
         captured_counts.append(len(nodes))
         return "answered"
 


### PR DESCRIPTION
## Summary

- Switch `StoryQueryEngine.query()` to a raw-first retrieval path using one raw hybrid retrieval pass.
- Remove summary-tier retrieval and summary fanout from the default query path while keeping summary helper methods intact.
- Keep final answer synthesis raw-source-only and preserve raw citation behavior.
- Add ordinal arc parsing for scoped queries like `105th term`.

## Verification

- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`

Closes #45