### PR TITLE
Add retrieval evaluation harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ indexer query "What happened in the 105th term?" --no-analyze
 indexer chat --no-analyze
 ```
 
+## Retrieval Evaluation
+
+Run the checked-in retrieval golden set without answer generation:
+
+```powershell
+uv run indexer eval run --golden-set eval/golden_questions.json --mode raw --output runs/baseline.json
+```
+
+Use `--mode raw-analyze` to compare analyzer-derived filters, or
+`--mode raw-rerank` to exercise the placeholder reranker metric surface. Until
+the reranker lands, reranker metrics are emitted as unavailable.
+
 ## Index Rebuilds
 
 Raw evidence is embedded as coalesced retrieval chunks over adjacent source

--- a/eval/golden_questions.json
+++ b/eval/golden_questions.json
@@ -1,0 +1,456 @@
+{
+  "schema_version": "1",
+  "questions": [
+    {
+      "id": "q001_izumi_acting_past",
+      "question": "What was Izumi's acting background before she became a school idol?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第5話『眠れる海のお姫様！』",
+          "part_name": "ABYSS",
+          "file_path": "story/105/第5話『眠れる海のお姫様！』/ABYSS.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ],
+      "required_citation_labels": ["105 · Episode 5 · Part ABYSS · Scene 1"]
+    },
+    {
+      "id": "q002_izumi_school_idol_start",
+      "question": "Who tells Izumi they will start school idol Katsuragi Izumi?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第5話『眠れる海のお姫様！』",
+          "part_name": "ABYSS",
+          "file_path": "story/105/第5話『眠れる海のお姫様！』/ABYSS.md",
+          "scene_start": 31,
+          "scene_end": 31
+        }
+      ]
+    },
+    {
+      "id": "q003_light_part",
+      "question": "What happens in the LIGHT part of Sleeping Sea Princess?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第5話『眠れる海のお姫様！』",
+          "part_name": "LIGHT",
+          "file_path": "story/105/第5話『眠れる海のお姫様！』/LIGHT.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q004_brand_new_start",
+      "question": "How does Brand New Stories begin?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第1話『Brand New Stories!!』",
+          "part_name": "0",
+          "file_path": "story/105/第1話『Brand New Stories!!』/0.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q005_dream_match_opening",
+      "question": "What is the setup at the start of Dream Match?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第2話『Dream Match！』",
+          "part_name": "1",
+          "file_path": "story/105/第2話『Dream Match！』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q006_srk_part",
+      "question": "What happens in the S.R.K. side part of Stars Longing?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第3話『星に憧れて、花は舞う』",
+          "part_name": "S.R.K.1",
+          "file_path": "story/105/第3話『星に憧れて、花は舞う』/S.R.K.1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q007_solar_back",
+      "question": "What does the first part of 太陽を目指した背中 focus on?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第4話『太陽を目指した背中』",
+          "part_name": "1",
+          "file_path": "story/105/第4話『太陽を目指した背中』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q008_future_flower_bd",
+      "question": "What happens in the BD part of 未来への花?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第6話『未来への花』",
+          "part_name": "BD",
+          "file_path": "story/105/第6話『未来への花』/BD.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q009_wagamama_interlude",
+      "question": "What is covered in the interlude of わがまま色の存在証明?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第7話『わがまま色の存在証明』",
+          "part_name": "幕間",
+          "file_path": "story/105/第7話『わがまま色の存在証明』/幕間.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q010_venus_part",
+      "question": "What happens in the VENUS part of 今はまだ遥か幽かな光?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第8話『今はまだ遥か幽かな光』",
+          "part_name": "VENUS",
+          "file_path": "story/105/第8話『今はまだ遥か幽かな光』/VENUS.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q011_all_link_friend",
+      "question": "What happens in the FRIEND part of ALL Link to YOU?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第9話『ALL Link to YOU』",
+          "part_name": "FRIEND",
+          "file_path": "story/105/第9話『ALL Link to YOU』/FRIEND.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q012_yueni_ruri_opening",
+      "question": "How does ゆえに、ルリあり begin?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第10話『ゆえに、ルリあり。』",
+          "part_name": "1",
+          "file_path": "story/105/第10話『ゆえに、ルリあり。』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q013_tree_part",
+      "question": "What happens in the TREE part of みんなで、花咲きたい?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第11話『みんなで、花咲きたい！』",
+          "part_name": "TREE",
+          "file_path": "story/105/第11話『みんなで、花咲きたい！』/TREE.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q014_flower_part",
+      "question": "What happens in the FLOWER part of みんなで、花咲きたい?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第11話『みんなで、花咲きたい！』",
+          "part_name": "FLOWER",
+          "file_path": "story/105/第11話『みんなで、花咲きたい！』/FLOWER.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q015_coda1",
+      "question": "What happens in CODA1 of ずっと花咲く僕らの桜?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第12話『ずっと花咲く僕らの桜』",
+          "part_name": "CODA1",
+          "file_path": "story/105/第12話『ずっと花咲く僕らの桜』/CODA1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q016_period",
+      "question": "What happens in PERIOD of ずっと花咲く僕らの桜?",
+      "gold_sources": [
+        {
+          "arc_id": "105",
+          "story_type": "Main",
+          "episode_name": "第12話『ずっと花咲く僕らの桜』",
+          "part_name": "PERIOD",
+          "file_path": "story/105/第12話『ずっと花咲く僕らの桜』/PERIOD.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q017_kaho_first_story",
+      "question": "What happens at the beginning of 花咲きたい?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第1話『花咲きたい！』",
+          "part_name": "1",
+          "file_path": "story/103/第1話『花咲きたい！』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q018_damedame_opening",
+      "question": "How does ダメダメ世界一 begin?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第2話『ダメダメ⇒世界一！？』",
+          "part_name": "1",
+          "file_path": "story/103/第2話『ダメダメ⇒世界一！？』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q019_rain_wind_sun_interlude",
+      "question": "What happens in the interlude of 雨と、風と、太陽と?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第3話『雨と、風と、太陽と』",
+          "part_name": "幕間",
+          "file_path": "story/103/第3話『雨と、風と、太陽と』/幕間.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q020_school_idol_opening",
+      "question": "How does わたしのスクールアイドル begin?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第4話『わたしのスクールアイドル』",
+          "part_name": "1",
+          "file_path": "story/103/第4話『わたしのスクールアイドル』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q021_kao_wo_agete",
+      "question": "What is the opening situation of 顔を上げて?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第5話『顔を上げて』",
+          "part_name": "1",
+          "file_path": "story/103/第5話『顔を上げて』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q022_ice_interlude",
+      "question": "What is in the interlude of わがまま on the ICE?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第6話『わがままon the ICE!!』",
+          "part_name": "幕間",
+          "file_path": "story/103/第6話『わがままon the ICE!!』/幕間.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q023_senpai_kouhai",
+      "question": "How does センパイとコウハイ begin?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第7話『センパイとコウハイ』",
+          "part_name": "1",
+          "file_path": "story/103/第7話『センパイとコウハイ』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q024_ruri_escape",
+      "question": "What happens at the start of ルリ・エスケープ?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第9話『ルリ・エスケープ』",
+          "part_name": "1",
+          "file_path": "story/103/第9話『ルリ・エスケープ』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q025_rurimegu_fanfare",
+      "question": "How does ルリめぐ・ファンファーレ begin?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第10話『ルリめぐ・ファンファーレ』",
+          "part_name": "1",
+          "file_path": "story/103/第10話『ルリめぐ・ファンファーレ』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q026_expectations_interlude",
+      "question": "What is in the interlude of 期待はおもい?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第12話『期待はおもい！』",
+          "part_name": "幕間",
+          "file_path": "story/103/第12話『期待はおもい！』/幕間.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q027_chased_caught",
+      "question": "How does 追いついたよ begin?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第13話『追いついたよ』",
+          "part_name": "1",
+          "file_path": "story/103/第13話『追いついたよ』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q028_link_like",
+      "question": "What happens at the start of Link Like?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第14話『Link！Like！』",
+          "part_name": "1",
+          "file_path": "story/103/第14話『Link！Like！』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q029_special_thanks",
+      "question": "How does Special Thanks begin?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第16話『Special Thanks』",
+          "part_name": "1",
+          "file_path": "story/103/第16話『Special Thanks』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    },
+    {
+      "id": "q030_fourth_sakura",
+      "question": "How does いずれ会う四度目の桜 begin?",
+      "gold_sources": [
+        {
+          "arc_id": "103",
+          "story_type": "Main",
+          "episode_name": "第18話『いずれ会う四度目の桜』",
+          "part_name": "1",
+          "file_path": "story/103/第18話『いずれ会う四度目の桜』/1.md",
+          "scene_start": 0,
+          "scene_end": 0
+        }
+      ]
+    }
+  ]
+}

--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -1,7 +1,7 @@
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import typer
 from rich.console import Console
@@ -20,6 +20,10 @@ from .database import (
     initialize_ingest_settings,
     initialize_settings,
 )
+from .eval.io import load_eval_run, stable_json
+from .eval.metrics import diff_runs
+from .eval.models import EvalMode
+from .eval.runner import run_eval_from_file
 from .glossary_candidates import (
     DEFAULT_GLOSSARY_CANDIDATE_FILE,
     category_counts,
@@ -61,6 +65,8 @@ from .summary_export import (
 )
 
 app = typer.Typer()
+eval_app = typer.Typer(help="Run and compare retrieval evaluation harness outputs.")
+app.add_typer(eval_app, name="eval")
 console = Console()
 
 
@@ -398,6 +404,85 @@ def extract_glossary_candidates_command(
     console.print(f"Wrote {len(candidates)} glossary candidates to {output_file}.")
     if count_summary:
         console.print(f"By category: {count_summary}")
+
+
+def _eval_mode(value: str) -> EvalMode:
+    if value not in {"raw", "raw-analyze", "raw-rerank"}:
+        raise typer.BadParameter("mode must be one of: raw, raw-analyze, raw-rerank")
+    return cast(EvalMode, value)
+
+
+@eval_app.command("run")
+def eval_run_command(
+    golden_set: str = typer.Option(
+        "eval/golden_questions.json",
+        "--golden-set",
+        help="Path to the golden question set JSON.",
+    ),
+    mode: str = typer.Option(
+        "raw",
+        "--mode",
+        help="Evaluation mode: raw, raw-analyze, or raw-rerank.",
+    ),
+    output: str | None = typer.Option(
+        None,
+        "--output",
+        help="Path to write the complete eval run JSON.",
+    ),
+    inspect_query_id: str | None = typer.Option(
+        None,
+        "--inspect",
+        help="Print the full deterministic trace for one query id.",
+    ),
+    dump_traces_dir: str | None = typer.Option(
+        None,
+        "--dump-traces",
+        help="Directory to write one deterministic JSON trace per query.",
+    ),
+    answer_mode: bool = typer.Option(
+        False,
+        "--answer-mode/--retrieval-only",
+        help="Also synthesize answers and evaluate answer text when credentials are configured.",
+    ),
+):
+    """Runs the retrieval evaluation harness."""
+    try:
+        run = run_eval_from_file(
+            golden_set,
+            mode=_eval_mode(mode),
+            output_path=output,
+            inspect_query_id=inspect_query_id,
+            dump_traces_dir=dump_traces_dir,
+            answer_mode=answer_mode,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(1) from exc
+
+    if inspect_query_id is not None:
+        trace = next(trace for trace in run.traces if trace.query_id == inspect_query_id)
+        console.print(stable_json(trace))
+        return
+
+    console.print(stable_json(run.aggregate_metrics))
+    if output is not None:
+        console.print(f"[bold green]Wrote eval run to {output}[/bold green]")
+    if dump_traces_dir is not None:
+        console.print(f"[bold green]Wrote query traces to {dump_traces_dir}[/bold green]")
+
+
+@eval_app.command("diff")
+def eval_diff_command(
+    run_a: str = typer.Argument(..., help="Baseline eval run JSON."),
+    run_b: str = typer.Argument(..., help="Comparison eval run JSON."),
+):
+    """Diffs two retrieval evaluation run files."""
+    try:
+        diff = diff_runs(load_eval_run(run_a), load_eval_run(run_b))
+    except (FileNotFoundError, ValueError) as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(1) from exc
+    console.print(stable_json(diff))
 
 @app.command("export-summary-reader")
 def export_summary_reader_command(

--- a/src/linkura_story_indexer/eval/__init__.py
+++ b/src/linkura_story_indexer/eval/__init__.py
@@ -1,0 +1,2 @@
+"""Retrieval evaluation harness."""
+

--- a/src/linkura_story_indexer/eval/io.py
+++ b/src/linkura_story_indexer/eval/io.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from linkura_story_indexer.eval.models import EvalRun, GoldenSet, QueryTrace
+
+
+def stable_json(data: Any) -> str:
+    if isinstance(data, BaseModel):
+        data = data.model_dump(mode="json")
+    return json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def load_golden_set(path: str | Path) -> GoldenSet:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        data = {"schema_version": "1", "questions": data}
+    return GoldenSet.model_validate(data)
+
+
+def load_eval_run(path: str | Path) -> EvalRun:
+    return EvalRun.model_validate_json(Path(path).read_text(encoding="utf-8"))
+
+
+def write_eval_run(run: EvalRun, path: str | Path) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(stable_json(run), encoding="utf-8")
+
+
+def write_query_trace(trace: QueryTrace, path: str | Path) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(stable_json(trace), encoding="utf-8")

--- a/src/linkura_story_indexer/eval/metrics.py
+++ b/src/linkura_story_indexer/eval/metrics.py
@@ -1,0 +1,209 @@
+from collections.abc import Iterable
+from unicodedata import normalize
+
+from linkura_story_indexer.eval.models import (
+    AggregateMetrics,
+    EvalDiff,
+    EvalRun,
+    GoldenQuestion,
+    GoldSourceRankDelta,
+    QueryMetrics,
+    QueryTrace,
+    SourceIdentity,
+    StageName,
+)
+
+DEFAULT_RECALL_KS = (1, 3, 5, 8)
+
+
+def source_key(source: SourceIdentity) -> str:
+    return "|".join(
+        [
+            source.arc_id,
+            source.story_type,
+            source.episode_name,
+            source.part_name,
+            source.file_path,
+            str(source.scene_start),
+            str(source.scene_end),
+        ]
+    )
+
+
+def source_overlaps(candidate: SourceIdentity | None, gold: SourceIdentity) -> bool:
+    if candidate is None:
+        return False
+    candidate_path = normalize("NFC", candidate.file_path.replace("\\", "/"))
+    gold_path = normalize("NFC", gold.file_path.replace("\\", "/"))
+    return (
+        normalize("NFC", candidate.arc_id) == normalize("NFC", gold.arc_id)
+        and normalize("NFC", candidate.story_type) == normalize("NFC", gold.story_type)
+        and normalize("NFC", candidate.episode_name) == normalize("NFC", gold.episode_name)
+        and normalize("NFC", candidate.part_name) == normalize("NFC", gold.part_name)
+        and candidate_path == gold_path
+        and candidate.scene_start <= gold.scene_end
+        and candidate.scene_end >= gold.scene_start
+    )
+
+
+def _stage_sources(trace: QueryTrace, stage_name: StageName) -> list[SourceIdentity | None]:
+    stage = trace.stages.get(stage_name)
+    if stage is None or stage.candidates is None:
+        return []
+    return [candidate.source_span for candidate in stage.candidates]
+
+
+def _gold_ranks(trace: QueryTrace, question: GoldenQuestion) -> dict[str, int | None]:
+    final_stage = trace.stages.get("final_top_k")
+    candidates = final_stage.candidates if final_stage and final_stage.candidates else []
+    ranks: dict[str, int | None] = {}
+    for gold in question.gold_sources:
+        rank = None
+        for candidate in candidates:
+            if source_overlaps(candidate.source_span, gold):
+                rank = candidate.rank
+                break
+        ranks[source_key(gold)] = rank
+    return ranks
+
+
+def _any_gold_in_stage(trace: QueryTrace, question: GoldenQuestion, stage_name: StageName) -> bool:
+    return any(
+        source_overlaps(candidate_source, gold)
+        for candidate_source in _stage_sources(trace, stage_name)
+        for gold in question.gold_sources
+    )
+
+
+def _citation_correct(trace: QueryTrace, question: GoldenQuestion) -> bool | None:
+    if not question.required_citation_labels:
+        return None
+    text = "\n".join([*trace.final_citation_labels, trace.answer_text or ""])
+    return all(label in text for label in question.required_citation_labels)
+
+
+def _temporal_leakage(trace: QueryTrace, question: GoldenQuestion) -> bool | None:
+    constraint = question.temporal_constraint
+    if constraint is None:
+        return None
+    final_stage = trace.stages.get("final_top_k")
+    candidates = final_stage.candidates if final_stage and final_stage.candidates else []
+    for candidate in candidates:
+        order = candidate.metadata.get("story_order", candidate.metadata.get("canonical_story_order"))
+        if not isinstance(order, int):
+            continue
+        if constraint.max_story_order is not None and order > constraint.max_story_order:
+            return True
+        if constraint.min_story_order is not None and order < constraint.min_story_order:
+            return True
+    return False
+
+
+def _glossary_consistent(trace: QueryTrace, question: GoldenQuestion) -> bool | None:
+    expectation = question.glossary_expectations
+    if expectation is None:
+        return None
+    text = trace.answer_text or "\n".join(trace.final_citation_labels)
+    return all(term in text for term in expectation.required_terms) and not any(
+        term in text for term in expectation.forbidden_terms
+    )
+
+
+def _rate(values: Iterable[bool | None], *, invert: bool = False) -> float | None:
+    concrete = [value for value in values if value is not None]
+    if not concrete:
+        return None
+    hits = sum(1 for value in concrete if (not value if invert else value))
+    return hits / len(concrete)
+
+
+def evaluate_query(trace: QueryTrace, question: GoldenQuestion) -> QueryMetrics:
+    ranks = _gold_ranks(trace, question)
+    recall = {
+        f"recall@{k}": any(rank is not None and rank <= k for rank in ranks.values())
+        for k in DEFAULT_RECALL_KS
+    }
+    reranker_stage = trace.stages.get("reranker")
+    reranker_hit = None
+    if reranker_stage is not None and reranker_stage.candidates is not None:
+        reranker_hit = _any_gold_in_stage(trace, question, "reranker")
+    return QueryMetrics(
+        query_id=question.id,
+        gold_source_ranks=ranks,
+        recall_at_k=recall,
+        deterministic_ranking_hit=_any_gold_in_stage(trace, question, "deterministic_ranking"),
+        citation_correct=_citation_correct(trace, question),
+        temporal_leakage=_temporal_leakage(trace, question),
+        glossary_consistent=_glossary_consistent(trace, question),
+        reranker_hit=reranker_hit,
+    )
+
+
+def aggregate_metrics(query_metrics: list[QueryMetrics], traces: list[QueryTrace]) -> AggregateMetrics:
+    query_count = len(query_metrics)
+    recall_keys = sorted({key for metric in query_metrics for key in metric.recall_at_k})
+    recall_at_k = {
+        key: sum(1 for metric in query_metrics if metric.recall_at_k.get(key)) / query_count
+        if query_count
+        else 0.0
+        for key in recall_keys
+    }
+    unavailable_reasons = {}
+    if traces and all(
+        trace.stages.get("reranker") and trace.stages["reranker"].candidates is None
+        for trace in traces
+    ):
+        unavailable_reasons["reranker_hit_rate"] = "reranker stage unavailable; #23 has not landed"
+    reranker_hit_rate = _rate(metric.reranker_hit for metric in query_metrics)
+    return AggregateMetrics(
+        query_count=query_count,
+        recall_at_k=recall_at_k,
+        deterministic_ranking_hit_rate=(
+            sum(1 for metric in query_metrics if metric.deterministic_ranking_hit) / query_count
+            if query_count
+            else 0.0
+        ),
+        citation_correctness=_rate(metric.citation_correct for metric in query_metrics),
+        temporal_leakage_rate=_rate(metric.temporal_leakage for metric in query_metrics),
+        glossary_consistency=_rate(metric.glossary_consistent for metric in query_metrics),
+        reranker_hit_rate=reranker_hit_rate,
+        unavailable_reasons=unavailable_reasons,
+    )
+
+
+def diff_runs(before: EvalRun, after: EvalRun) -> EvalDiff:
+    deltas: dict[str, float | None] = {}
+    before_metrics = before.aggregate_metrics
+    after_metrics = after.aggregate_metrics
+    for key in sorted(set(before_metrics.recall_at_k) | set(after_metrics.recall_at_k)):
+        deltas[key] = after_metrics.recall_at_k.get(key, 0.0) - before_metrics.recall_at_k.get(key, 0.0)
+    for field in (
+        "deterministic_ranking_hit_rate",
+        "citation_correctness",
+        "temporal_leakage_rate",
+        "glossary_consistency",
+        "reranker_hit_rate",
+    ):
+        before_value = getattr(before_metrics, field)
+        after_value = getattr(after_metrics, field)
+        deltas[field] = None if before_value is None or after_value is None else after_value - before_value
+
+    after_by_id = {metric.query_id: metric for metric in after.query_metrics}
+    rank_deltas = []
+    for before_query in before.query_metrics:
+        after_query = after_by_id.get(before_query.query_id)
+        if after_query is None:
+            continue
+        for key, before_rank in before_query.gold_source_ranks.items():
+            after_rank = after_query.gold_source_ranks.get(key)
+            delta = None if before_rank is None or after_rank is None else after_rank - before_rank
+            rank_deltas.append(
+                GoldSourceRankDelta(
+                    query_id=before_query.query_id,
+                    source_key=key,
+                    before_rank=before_rank,
+                    after_rank=after_rank,
+                    delta=delta,
+                )
+            )
+    return EvalDiff(aggregate_deltas=deltas, rank_deltas=rank_deltas)

--- a/src/linkura_story_indexer/eval/models.py
+++ b/src/linkura_story_indexer/eval/models.py
@@ -1,0 +1,163 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+EvalMode = Literal["raw", "raw-analyze", "raw-rerank"]
+CandidateKind = Literal["raw_span", "summary", "summary_section", "reranker"]
+StageName = Literal[
+    "dense_raw",
+    "lexical_raw",
+    "rrf_fusion",
+    "raw_seed_filter",
+    "neighbor_expansion",
+    "analysis_filter",
+    "semantic_boundary_filter",
+    "deterministic_ranking",
+    "final_top_k",
+    "reranker",
+]
+NeighborProvenance = Literal["direct_hit", "neighbor_of"]
+
+
+class SourceIdentity(BaseModel):
+    arc_id: str
+    story_type: str
+    episode_name: str
+    part_name: str
+    file_path: str
+    scene_start: int
+    scene_end: int
+
+    @model_validator(mode="after")
+    def validate_span(self) -> "SourceIdentity":
+        if self.scene_start < 0:
+            raise ValueError("scene_start must be non-negative")
+        if self.scene_end < self.scene_start:
+            raise ValueError("scene_end must be greater than or equal to scene_start")
+        return self
+
+
+class TemporalConstraint(BaseModel):
+    max_story_order: int | None = None
+    min_story_order: int | None = None
+
+
+class GlossaryExpectation(BaseModel):
+    required_terms: list[str] = Field(default_factory=list)
+    forbidden_terms: list[str] = Field(default_factory=list)
+
+
+class GoldenQuestion(BaseModel):
+    id: str
+    question: str
+    gold_sources: list[SourceIdentity]
+    required_citation_labels: list[str] = Field(default_factory=list)
+    glossary_expectations: GlossaryExpectation | None = None
+    temporal_constraint: TemporalConstraint | None = None
+
+    @model_validator(mode="after")
+    def validate_gold_sources(self) -> "GoldenQuestion":
+        if not self.gold_sources:
+            raise ValueError("gold_sources must contain at least one source")
+        return self
+
+
+class GoldenSet(BaseModel):
+    schema_version: str = "1"
+    questions: list[GoldenQuestion]
+
+    @model_validator(mode="after")
+    def validate_unique_ids(self) -> "GoldenSet":
+        ids = [question.id for question in self.questions]
+        if len(ids) != len(set(ids)):
+            raise ValueError("golden question ids must be unique")
+        return self
+
+
+class RunConfig(BaseModel):
+    mode: EvalMode = "raw"
+    golden_set: str
+    top_k: int = 8
+    answer_mode: bool = False
+    reranker_enabled: bool = False
+
+
+class CandidateScores(BaseModel):
+    dense_rank: int | None = None
+    dense_distance: float | None = None
+    lexical_rank: int | None = None
+    lexical_score: float | None = None
+    rrf_score: float | None = None
+    deterministic_score: float | None = None
+
+
+class CandidateTrace(BaseModel):
+    node_id: str
+    rank: int
+    candidate_kind: CandidateKind = "raw_span"
+    text: str | None = None
+    scores: CandidateScores = Field(default_factory=CandidateScores)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    source_span: SourceIdentity | None = None
+    signal_breakdown: dict[str, Any] = Field(default_factory=dict)
+    provenance: NeighborProvenance | None = None
+    provenance_node_id: str | None = None
+
+
+class StageTrace(BaseModel):
+    name: StageName
+    candidates: list[CandidateTrace] | None = None
+    unavailable_reason: str | None = None
+
+
+class QueryTrace(BaseModel):
+    query_id: str
+    question: str
+    mode: EvalMode = "raw"
+    config: dict[str, Any] = Field(default_factory=dict)
+    stages: dict[StageName, StageTrace]
+    final_citation_labels: list[str] = Field(default_factory=list)
+    answer_text: str | None = None
+
+
+class QueryMetrics(BaseModel):
+    query_id: str
+    gold_source_ranks: dict[str, int | None] = Field(default_factory=dict)
+    recall_at_k: dict[str, bool] = Field(default_factory=dict)
+    deterministic_ranking_hit: bool = False
+    citation_correct: bool | None = None
+    temporal_leakage: bool | None = None
+    glossary_consistent: bool | None = None
+    reranker_hit: bool | None = None
+
+
+class AggregateMetrics(BaseModel):
+    query_count: int
+    recall_at_k: dict[str, float] = Field(default_factory=dict)
+    deterministic_ranking_hit_rate: float
+    citation_correctness: float | None = None
+    temporal_leakage_rate: float | None = None
+    glossary_consistency: float | None = None
+    reranker_hit_rate: float | None = None
+    unavailable_reasons: dict[str, str] = Field(default_factory=dict)
+
+
+class EvalRun(BaseModel):
+    schema_version: str = "1"
+    config: RunConfig
+    aggregate_metrics: AggregateMetrics
+    query_metrics: list[QueryMetrics]
+    traces: list[QueryTrace]
+
+
+class GoldSourceRankDelta(BaseModel):
+    query_id: str
+    source_key: str
+    before_rank: int | None = None
+    after_rank: int | None = None
+    delta: int | None = None
+
+
+class EvalDiff(BaseModel):
+    aggregate_deltas: dict[str, float | None] = Field(default_factory=dict)
+    rank_deltas: list[GoldSourceRankDelta] = Field(default_factory=list)

--- a/src/linkura_story_indexer/eval/runner.py
+++ b/src/linkura_story_indexer/eval/runner.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from typing import Protocol
+
+from linkura_story_indexer.eval.io import load_golden_set, write_eval_run, write_query_trace
+from linkura_story_indexer.eval.metrics import aggregate_metrics, evaluate_query
+from linkura_story_indexer.eval.models import EvalMode, EvalRun, GoldenSet, QueryTrace, RunConfig
+from linkura_story_indexer.query.engine import RetrievalConfig, StoryQueryEngine
+
+
+class TraceEngine(Protocol):
+    def retrieve_with_trace(
+        self,
+        question: str,
+        *,
+        query_id: str,
+        mode: EvalMode,
+        answer_mode: bool = False,
+    ) -> QueryTrace: ...
+
+
+def run_eval(
+    golden_set: GoldenSet,
+    *,
+    golden_set_path: str,
+    mode: EvalMode = "raw",
+    engine: TraceEngine | None = None,
+    answer_mode: bool = False,
+) -> EvalRun:
+    if engine is None:
+        engine = StoryQueryEngine(
+            retrieval_config=RetrievalConfig(enable_query_analysis=mode == "raw-analyze")
+        )
+
+    traces = [
+        engine.retrieve_with_trace(
+            question.question,
+            query_id=question.id,
+            mode=mode,
+            answer_mode=answer_mode,
+        )
+        for question in golden_set.questions
+    ]
+    query_metrics = [
+        evaluate_query(trace, question)
+        for trace, question in zip(traces, golden_set.questions, strict=True)
+    ]
+    return EvalRun(
+        config=RunConfig(
+            mode=mode,
+            golden_set=golden_set_path,
+            answer_mode=answer_mode,
+            reranker_enabled=mode == "raw-rerank",
+        ),
+        aggregate_metrics=aggregate_metrics(query_metrics, traces),
+        query_metrics=query_metrics,
+        traces=traces,
+    )
+
+
+def run_eval_from_file(
+    golden_set_path: str | Path,
+    *,
+    mode: EvalMode = "raw",
+    output_path: str | Path | None = None,
+    inspect_query_id: str | None = None,
+    dump_traces_dir: str | Path | None = None,
+    answer_mode: bool = False,
+) -> EvalRun:
+    golden_set = load_golden_set(golden_set_path)
+    run = run_eval(
+        golden_set,
+        golden_set_path=str(golden_set_path),
+        mode=mode,
+        answer_mode=answer_mode,
+    )
+    if output_path is not None:
+        write_eval_run(run, output_path)
+    if dump_traces_dir is not None:
+        directory = Path(dump_traces_dir)
+        for trace in run.traces:
+            write_query_trace(trace, directory / f"{trace.query_id}.json")
+    if inspect_query_id is not None and not any(
+        trace.query_id == inspect_query_id for trace in run.traces
+    ):
+        raise ValueError(f"Unknown query id: {inspect_query_id}")
+    return run

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -7,6 +7,15 @@ from typing import Any
 
 from ..console import safe_print
 from ..database import RETRIEVAL_QUERY, create_text_agent, embed_texts, get_chroma_collection
+from ..eval.models import (
+    CandidateScores,
+    CandidateTrace,
+    EvalMode,
+    QueryTrace,
+    SourceIdentity,
+    StageName,
+    StageTrace,
+)
 from ..indexer.parser import StoryParser
 from ..indexer.source_store import SourceRecordStore
 from ..lexical import LexicalIndex, expand_query_with_glossary
@@ -33,6 +42,7 @@ INSUFFICIENT_SOURCE_CONTEXT = (
 )
 
 Node = tuple[str, dict[str, Any]]
+ScoredRankedNode = tuple[Node, dict[str, Any], int]
 
 
 @dataclass(frozen=True)
@@ -534,6 +544,21 @@ class StoryQueryEngine:
             for document, metadata in zip(documents[0], metadatas[0], strict=False)
         ]
 
+    def _results_to_ranked_nodes(
+        self,
+        results: dict[str, Any],
+    ) -> list[tuple[Node, float | None]]:
+        documents = results.get("documents") or [[]]
+        metadatas = results.get("metadatas") or [[]]
+        distances = results.get("distances") or [[]]
+        output = []
+        for index, (document, metadata) in enumerate(
+            zip(documents[0], metadatas[0], strict=False)
+        ):
+            distance = distances[0][index] if distances and distances[0] and index < len(distances[0]) else None
+            output.append(((document, dict(metadata or {})), distance))
+        return output
+
     def _flat_results_to_nodes(self, results: dict[str, Any]) -> list[Node]:
         documents = results.get("documents") or []
         metadatas = results.get("metadatas") or []
@@ -553,6 +578,29 @@ class StoryQueryEngine:
         if lexical_index is None:
             return []
         return lexical_index.search(question, n_results=n_results, where=where)
+
+    def _retrieve_with_dense_scores(
+        self,
+        question: str,
+        *,
+        n_results: int,
+        where: dict[str, Any] | None,
+        query_embedding: list[float],
+    ) -> list[tuple[Node, float | None]]:
+        query_kwargs: dict[str, Any] = {
+            "query_embeddings": [query_embedding],
+            "n_results": n_results,
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if where:
+            query_kwargs["where"] = where
+
+        try:
+            results = self.collection.query(**query_kwargs)
+        except ValueError:
+            query_kwargs["include"] = ["documents", "metadatas"]
+            results = self.collection.query(**query_kwargs)
+        return self._results_to_ranked_nodes(results)
 
     def _node_key(self, document: str, metadata: dict[str, Any]) -> tuple[Any, ...]:
         scene_start = metadata.get("scene_start")
@@ -623,6 +671,39 @@ class StoryQueryEngine:
             key=lambda key: (-scores[key], first_seen[key]),
         )
         return [nodes_by_key[key] for key in ranked_keys]
+
+    def _rrf_fuse_with_scores(
+        self,
+        ranked_lists: list[list[Node]],
+        *,
+        k: int | None = None,
+    ) -> list[tuple[Node, float]]:
+        rrf_k = self._config().rrf_k if k is None else k
+        if rrf_k < 1:
+            raise ValueError("rrf k must be at least 1")
+
+        scores: dict[tuple[Any, ...], float] = {}
+        nodes_by_key: dict[tuple[Any, ...], Node] = {}
+        first_seen: dict[tuple[Any, ...], int] = {}
+        seen_order = 0
+
+        for ranked_list in ranked_lists:
+            seen_in_list: set[tuple[Any, ...]] = set()
+            for rank, (document, metadata) in enumerate(ranked_list, start=1):
+                key = self._node_key(document, metadata)
+                if key in seen_in_list:
+                    continue
+                seen_in_list.add(key)
+
+                if key not in nodes_by_key:
+                    nodes_by_key[key] = (document, metadata)
+                    first_seen[key] = seen_order
+                    seen_order += 1
+
+                scores[key] = scores.get(key, 0.0) + (1.0 / (rrf_k + rank))
+
+        ranked_keys = sorted(scores, key=lambda key: (-scores[key], first_seen[key]))
+        return [(nodes_by_key[key], scores[key]) for key in ranked_keys]
 
     def _hybrid_retrieve(
         self,
@@ -994,20 +1075,20 @@ class StoryQueryEngine:
                 score += 1
         return score
 
-    def _rank_raw_candidates(
+    def _score_raw_candidates(
         self,
         question: str,
         expanded_question: str,
         raw_nodes: list[Node],
         seed_nodes: list[Node],
-    ) -> list[Node]:
+    ) -> list[ScoredRankedNode]:
         terms = self._query_terms(expanded_question)
         seed_rank = {
             self._node_key(document, metadata): index
             for index, (document, metadata) in enumerate(seed_nodes)
         }
 
-        scored_nodes = []
+        scored_nodes: list[tuple[int, int, int, Node, dict[str, Any]]] = []
         for index, (document, metadata) in enumerate(raw_nodes):
             searchable = " ".join(
                 [
@@ -1027,26 +1108,54 @@ class StoryQueryEngine:
             )
             key = self._node_key(document, metadata)
             is_seed = key in seed_rank
+            metadata_match_score = self._metadata_match_score(question, metadata)
+            near_seed_score = self._near_seed_score(metadata, seed_nodes)
             score = (
                 matched_terms * 25
                 + speaker_matches * 30
-                + self._metadata_match_score(question, metadata) * 40
-                + self._near_seed_score(metadata, seed_nodes) * 10
+                + metadata_match_score * 40
+                + near_seed_score * 10
                 + (20 if is_seed else 0)
             )
+            signal_breakdown = {
+                "matched_terms": matched_terms,
+                "speaker_matches": speaker_matches,
+                "metadata_match_score": metadata_match_score,
+                "near_seed_score": near_seed_score,
+                "is_seed": is_seed,
+            }
             scored_nodes.append(
                 (
                     -score,
                     seed_rank.get(key, len(seed_rank) + index),
                     index,
-                    document,
-                    metadata,
+                    (document, metadata),
+                    signal_breakdown,
                 )
             )
 
         scored_nodes.sort()
-        ranked_nodes = [(document, metadata) for _, _, _, document, metadata in scored_nodes]
-        return ranked_nodes[: self._config().max_ranked_candidates]
+        return [
+            (node, signal_breakdown, -negative_score)
+            for negative_score, _, _, node, signal_breakdown in scored_nodes
+        ][: self._config().max_ranked_candidates]
+
+    def _rank_raw_candidates(
+        self,
+        question: str,
+        expanded_question: str,
+        raw_nodes: list[Node],
+        seed_nodes: list[Node],
+    ) -> list[Node]:
+        return [
+            node
+            for node, _, _ in self._score_raw_candidates(
+                question,
+                expanded_question,
+                raw_nodes,
+                seed_nodes,
+            )
+        ]
 
     def _build_context_chunks(self, raw_nodes: list[Node]) -> list[str]:
         context_chunks = []
@@ -1099,6 +1208,163 @@ class StoryQueryEngine:
         safe_print("Synthesizing final answer with Gemini...")
         result = create_text_agent(system_prompt).run_sync(user_prompt)
         return result.output.strip() or "No answer generated."
+
+    def _trace_node_id(self, document: str, metadata: dict[str, Any]) -> str:
+        chunk_id = metadata.get("chunk_id")
+        if isinstance(chunk_id, str) and chunk_id:
+            return chunk_id
+        file_path = metadata.get("file_path")
+        span = self._scene_span(metadata)
+        if isinstance(file_path, str) and span is not None:
+            return f"{file_path}:{span[0]}-{span[1]}"
+        key = self._node_key(document, metadata)
+        return json.dumps(key, ensure_ascii=False, sort_keys=True, default=str)
+
+    def _source_identity(self, metadata: dict[str, Any]) -> SourceIdentity | None:
+        span = self._scene_span(metadata)
+        if span is None:
+            return None
+        return SourceIdentity(
+            arc_id=str(metadata.get("arc_id", "")),
+            story_type=str(metadata.get("story_type", "")),
+            episode_name=str(metadata.get("episode_name", "")),
+            part_name=str(metadata.get("part_name", "")),
+            file_path=str(metadata.get("file_path", "")),
+            scene_start=span[0],
+            scene_end=span[1],
+        )
+
+    def _trace_candidate(
+        self,
+        node: Node,
+        *,
+        rank: int,
+        scores: CandidateScores | None = None,
+        signal_breakdown: dict[str, Any] | None = None,
+        provenance: str | None = None,
+        provenance_node_id: str | None = None,
+    ) -> CandidateTrace:
+        document, metadata = node
+        return CandidateTrace(
+            node_id=self._trace_node_id(document, metadata),
+            rank=rank,
+            candidate_kind="raw_span" if metadata.get("summary_level") == 4 else "summary",
+            text=document,
+            scores=scores or CandidateScores(),
+            metadata=dict(metadata),
+            source_span=self._source_identity(metadata),
+            signal_breakdown=signal_breakdown or {},
+            provenance=provenance,  # type: ignore[arg-type]
+            provenance_node_id=provenance_node_id,
+        )
+
+    def _trace_stage(
+        self,
+        name: StageName,
+        candidates: list[CandidateTrace] | None,
+        unavailable_reason: str | None = None,
+    ) -> StageTrace:
+        return StageTrace(
+            name=name,
+            candidates=candidates,
+            unavailable_reason=unavailable_reason,
+        )
+
+    def _neighbor_trace_provenance(
+        self,
+        node: Node,
+        seed_nodes: list[Node],
+    ) -> tuple[str | None, str | None]:
+        document, metadata = node
+        key = self._node_key(document, metadata)
+        seed_keys = {
+            self._node_key(seed_document, seed_metadata)
+            for seed_document, seed_metadata in seed_nodes
+        }
+        if key in seed_keys:
+            return "direct_hit", None
+
+        candidate_span = self._scene_span(metadata)
+        if candidate_span is None:
+            return None, None
+        window = self._config().neighbor_scene_window
+        for seed_document, seed_metadata in seed_nodes:
+            if self._raw_part_filter(metadata) != self._raw_part_filter(seed_metadata):
+                continue
+            seed_span = self._scene_span(seed_metadata)
+            if seed_span is None:
+                continue
+            if candidate_span[0] <= seed_span[1] + window and candidate_span[1] >= seed_span[0] - window:
+                return "neighbor_of", self._trace_node_id(seed_document, seed_metadata)
+        return None, None
+
+    def _hybrid_retrieve_trace(
+        self,
+        question: str,
+        *,
+        n_results: int,
+        where: dict[str, Any] | None,
+        query_embedding: list[float] | None,
+        dense_unavailable_reason: str | None = None,
+    ) -> tuple[list[Node], dict[StageName, StageTrace]]:
+        dense_nodes: list[Node] = []
+        dense_distances: dict[tuple[Any, ...], float | None] = {}
+        if query_embedding is None:
+            dense_unavailable_reason = dense_unavailable_reason or "query embedding unavailable"
+        else:
+            try:
+                dense_ranked_nodes = self._retrieve_with_dense_scores(
+                    question,
+                    n_results=n_results,
+                    where=where,
+                    query_embedding=query_embedding,
+                )
+                for node, distance in dense_ranked_nodes:
+                    dense_nodes.append(node)
+                    dense_distances[self._node_key(*node)] = distance
+            except Exception as exc:
+                dense_unavailable_reason = f"dense retrieval unavailable: {exc}"
+
+        lexical_nodes = self._lexical_retrieve(question, n_results=n_results, where=where)
+        fused_with_scores = self._rrf_fuse_with_scores([dense_nodes, lexical_nodes])[:n_results]
+        fused_nodes = [node for node, _ in fused_with_scores]
+
+        dense_candidates = [
+            self._trace_candidate(
+                node,
+                rank=rank,
+                scores=CandidateScores(
+                    dense_rank=rank,
+                    dense_distance=dense_distances.get(self._node_key(*node)),
+                ),
+            )
+            for rank, node in enumerate(dense_nodes, start=1)
+        ]
+        lexical_candidates = [
+            self._trace_candidate(
+                node,
+                rank=rank,
+                scores=CandidateScores(lexical_rank=rank),
+            )
+            for rank, node in enumerate(lexical_nodes, start=1)
+        ]
+        fused_candidates = [
+            self._trace_candidate(
+                node,
+                rank=rank,
+                scores=CandidateScores(rrf_score=score),
+            )
+            for rank, (node, score) in enumerate(fused_with_scores, start=1)
+        ]
+        return fused_nodes, {
+            "dense_raw": self._trace_stage(
+                "dense_raw",
+                None if dense_unavailable_reason else dense_candidates,
+                dense_unavailable_reason,
+            ),
+            "lexical_raw": self._trace_stage("lexical_raw", lexical_candidates),
+            "rrf_fusion": self._trace_stage("rrf_fusion", fused_candidates),
+        }
 
     def _raw_only_retrieve(
         self,
@@ -1185,6 +1451,173 @@ class StoryQueryEngine:
             for node in raw_nodes
             if (order := self._story_order(node[1])) is not None and order < boundary_order
         ]
+
+    def retrieve_with_trace(
+        self,
+        question: str,
+        *,
+        query_id: str = "ad-hoc",
+        mode: EvalMode = "raw",
+        answer_mode: bool = False,
+    ) -> QueryTrace:
+        """Executes the raw-first retrieval flow and returns deterministic stage traces."""
+        analysis = None
+        if mode == "raw-analyze" or self._config().enable_query_analysis:
+            analysis = analyze_query(question, self.glossary)
+
+        expanded_question = self._expanded_question(question)
+        query_embedding = None
+        dense_unavailable_reason = None
+        try:
+            query_embedding = self._query_embedding(expanded_question)
+        except Exception as exc:
+            dense_unavailable_reason = f"query embedding unavailable: {exc}"
+
+        raw_where = self._where_for_analysis(
+            analysis,
+            summary_level=4,
+            include_scene_constraint=True,
+        )
+        retrieved_nodes, stages = self._hybrid_retrieve_trace(
+            expanded_question,
+            n_results=self._config().raw_candidate_count,
+            where=raw_where,
+            query_embedding=query_embedding,
+            dense_unavailable_reason=dense_unavailable_reason,
+        )
+
+        raw_nodes = self._raw_evidence_nodes(retrieved_nodes)
+        stages["raw_seed_filter"] = self._trace_stage(
+            "raw_seed_filter",
+            [
+                self._trace_candidate(node, rank=rank)
+                for rank, node in enumerate(raw_nodes, start=1)
+            ],
+        )
+
+        analysis_filtered_nodes = raw_nodes
+        if analysis is not None:
+            analysis_filtered_nodes = self._filter_raw_nodes_by_analysis(raw_nodes, analysis)
+            stages["analysis_filter"] = self._trace_stage(
+                "analysis_filter",
+                [
+                    self._trace_candidate(node, rank=rank)
+                    for rank, node in enumerate(analysis_filtered_nodes, start=1)
+                ],
+            )
+        else:
+            stages["analysis_filter"] = self._trace_stage(
+                "analysis_filter",
+                None,
+                "query analysis disabled",
+            )
+
+        if analysis_filtered_nodes:
+            expanded_raw_nodes = self._expand_raw_neighbors(
+                expanded_question,
+                analysis_filtered_nodes,
+                query_embedding=query_embedding,
+            )
+        else:
+            expanded_raw_nodes = []
+        stages["neighbor_expansion"] = self._trace_stage(
+            "neighbor_expansion",
+            [
+                self._trace_candidate(
+                    node,
+                    rank=rank,
+                    provenance=provenance,
+                    provenance_node_id=provenance_node_id,
+                )
+                for rank, node in enumerate(expanded_raw_nodes, start=1)
+                for provenance, provenance_node_id in [
+                    self._neighbor_trace_provenance(node, analysis_filtered_nodes)
+                ]
+            ],
+        )
+
+        semantic_nodes = expanded_raw_nodes
+        semantic_reason = "query analysis disabled"
+        if analysis is not None:
+            semantic_reason = "semantic boundary not detected"
+            semantic_nodes = self._filter_raw_nodes_by_analysis(semantic_nodes, analysis)
+            if analysis.semantic_boundary is not None:
+                semantic_nodes = self._filter_before_semantic_boundary(
+                    question,
+                    expanded_question,
+                    semantic_nodes,
+                    analysis_filtered_nodes,
+                    analysis,
+                )
+                semantic_reason = ""
+        stages["semantic_boundary_filter"] = self._trace_stage(
+            "semantic_boundary_filter",
+            [
+                self._trace_candidate(node, rank=rank)
+                for rank, node in enumerate(semantic_nodes, start=1)
+            ]
+            if semantic_reason == ""
+            else None,
+            semantic_reason or None,
+        )
+
+        ranked_with_scores = self._score_raw_candidates(
+            question,
+            expanded_question,
+            semantic_nodes,
+            analysis_filtered_nodes,
+        )
+        deterministic_nodes = [node for node, _, _ in ranked_with_scores]
+        stages["deterministic_ranking"] = self._trace_stage(
+            "deterministic_ranking",
+            [
+                self._trace_candidate(
+                    node,
+                    rank=rank,
+                    scores=CandidateScores(deterministic_score=float(score)),
+                    signal_breakdown=signal_breakdown,
+                )
+                for rank, (node, signal_breakdown, score) in enumerate(
+                    ranked_with_scores,
+                    start=1,
+                )
+            ],
+        )
+
+        if analysis is not None:
+            final_raw_nodes = self._filter_raw_nodes_by_analysis(deterministic_nodes, analysis)[
+                : self._config().final_top_k
+            ]
+        else:
+            final_raw_nodes = deterministic_nodes[: self._config().final_top_k]
+        stages["final_top_k"] = self._trace_stage(
+            "final_top_k",
+            [
+                self._trace_candidate(node, rank=rank)
+                for rank, node in enumerate(final_raw_nodes, start=1)
+            ],
+        )
+        stages["reranker"] = self._trace_stage(
+            "reranker",
+            None,
+            "reranker stage unavailable; #23 has not landed",
+        )
+
+        answer_text = None
+        if answer_mode and final_raw_nodes:
+            answer_text = self._answer_from_raw_evidence(question, final_raw_nodes, analysis)
+
+        return QueryTrace(
+            query_id=query_id,
+            question=question,
+            mode=mode,
+            config=self._config().__dict__,
+            stages=stages,
+            final_citation_labels=[
+                self._citation_label(metadata) for _, metadata in final_raw_nodes
+            ],
+            answer_text=answer_text,
+        )
 
     def query(self, question: str) -> str:
         """Executes the raw-first RAG query flow."""

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,220 @@
+import json
+from pathlib import Path
+from typing import Any
+
+from linkura_story_indexer.eval.io import load_golden_set, stable_json
+from linkura_story_indexer.eval.metrics import aggregate_metrics, diff_runs, evaluate_query
+from linkura_story_indexer.eval.models import (
+    AggregateMetrics,
+    CandidateTrace,
+    EvalRun,
+    GoldenQuestion,
+    QueryMetrics,
+    QueryTrace,
+    RunConfig,
+    SourceIdentity,
+    StageTrace,
+    TemporalConstraint,
+)
+
+
+def source(
+    *,
+    scene_start: int = 0,
+    scene_end: int = 0,
+    file_path: str = "story/105/第5話『眠れる海のお姫様！』/ABYSS.md",
+) -> SourceIdentity:
+    return SourceIdentity(
+        arc_id="105",
+        story_type="Main",
+        episode_name="第5話『眠れる海のお姫様！』",
+        part_name="ABYSS",
+        file_path=file_path,
+        scene_start=scene_start,
+        scene_end=scene_end,
+    )
+
+
+def candidate(
+    rank: int,
+    candidate_source: SourceIdentity,
+    *,
+    story_order: int = 10,
+) -> CandidateTrace:
+    return CandidateTrace(
+        node_id=f"node-{rank}",
+        rank=rank,
+        metadata={"canonical_story_order": story_order},
+        source_span=candidate_source,
+    )
+
+
+def trace(
+    *,
+    final_candidates: list[CandidateTrace],
+    deterministic_candidates: list[CandidateTrace] | None = None,
+    citations: list[str] | None = None,
+    answer_text: str | None = None,
+    reranker_candidates: list[CandidateTrace] | None = None,
+) -> QueryTrace:
+    deterministic_candidates = deterministic_candidates or final_candidates
+    return QueryTrace(
+        query_id="q1",
+        question="question",
+        stages={
+            "dense_raw": StageTrace(name="dense_raw", candidates=[]),
+            "lexical_raw": StageTrace(name="lexical_raw", candidates=[]),
+            "rrf_fusion": StageTrace(name="rrf_fusion", candidates=[]),
+            "raw_seed_filter": StageTrace(name="raw_seed_filter", candidates=[]),
+            "neighbor_expansion": StageTrace(name="neighbor_expansion", candidates=[]),
+            "analysis_filter": StageTrace(name="analysis_filter", candidates=None),
+            "semantic_boundary_filter": StageTrace(name="semantic_boundary_filter", candidates=None),
+            "deterministic_ranking": StageTrace(
+                name="deterministic_ranking",
+                candidates=deterministic_candidates,
+            ),
+            "final_top_k": StageTrace(name="final_top_k", candidates=final_candidates),
+            "reranker": StageTrace(
+                name="reranker",
+                candidates=reranker_candidates,
+                unavailable_reason=None
+                if reranker_candidates is not None
+                else "reranker stage unavailable; #23 has not landed",
+            ),
+        },
+        final_citation_labels=citations or [],
+        answer_text=answer_text,
+    )
+
+
+def question(**overrides: Any) -> GoldenQuestion:
+    values = {
+        "id": "q1",
+        "question": "question",
+        "gold_sources": [source(scene_start=1, scene_end=2)],
+    }
+    values.update(overrides)
+    return GoldenQuestion(**values)
+
+
+def test_checked_in_golden_set_validates_scene_span_regression() -> None:
+    golden = load_golden_set("eval/golden_questions.json")
+
+    regression = next(item for item in golden.questions if item.id == "q001_izumi_acting_past")
+
+    assert len(golden.questions) == 30
+    assert regression.gold_sources == [source(scene_start=0, scene_end=0)]
+    assert "Izumi's acting background" in regression.question
+
+
+def test_metrics_count_partial_span_overlap_and_recall() -> None:
+    metric = evaluate_query(
+        trace(final_candidates=[candidate(1, source(scene_start=0, scene_end=3))]),
+        question(),
+    )
+
+    assert metric.gold_source_ranks == {
+        "105|Main|第5話『眠れる海のお姫様！』|ABYSS|story/105/第5話『眠れる海のお姫様！』/ABYSS.md|1|2": 1
+    }
+    assert metric.recall_at_k["recall@1"] is True
+
+
+def test_metrics_report_miss_citation_temporal_and_glossary_results() -> None:
+    metric = evaluate_query(
+        trace(
+            final_candidates=[candidate(4, source(scene_start=8, scene_end=8), story_order=20)],
+            citations=["wrong citation"],
+            answer_text="Uses Izumi but not the required translated unit name.",
+        ),
+        question(
+            required_citation_labels=["105 · Episode 5 · Part ABYSS · Scene 2"],
+            temporal_constraint=TemporalConstraint(max_story_order=15),
+            glossary_expectations={"required_terms": ["Hasunosora"], "forbidden_terms": ["bad"]},
+        ),
+    )
+
+    assert metric.gold_source_ranks[
+        "105|Main|第5話『眠れる海のお姫様！』|ABYSS|story/105/第5話『眠れる海のお姫様！』/ABYSS.md|1|2"
+    ] is None
+    assert metric.citation_correct is False
+    assert metric.temporal_leakage is True
+    assert metric.glossary_consistent is False
+    assert metric.reranker_hit is None
+
+
+def test_aggregate_marks_unavailable_reranker_metrics() -> None:
+    traces = [trace(final_candidates=[candidate(1, source(scene_start=1, scene_end=1))])]
+    metrics = [evaluate_query(traces[0], question())]
+
+    aggregate = aggregate_metrics(metrics, traces)
+
+    assert aggregate.reranker_hit_rate is None
+    assert aggregate.unavailable_reasons == {
+        "reranker_hit_rate": "reranker stage unavailable; #23 has not landed"
+    }
+
+
+def test_stable_json_is_byte_identical_for_equivalent_trace_dict_order() -> None:
+    first = trace(final_candidates=[candidate(1, source(scene_start=1, scene_end=1))])
+    second_data = json.loads(stable_json(first))
+    second = QueryTrace.model_validate(second_data)
+
+    assert stable_json(first) == stable_json(second)
+
+
+def test_diff_reports_aggregate_and_rank_changes() -> None:
+    before_metric = QueryMetrics(
+        query_id="q1",
+        gold_source_ranks={"gold": 5},
+        recall_at_k={"recall@5": True},
+    )
+    after_metric = QueryMetrics(
+        query_id="q1",
+        gold_source_ranks={"gold": 2},
+        recall_at_k={"recall@5": True},
+    )
+    before = EvalRun(
+        config=RunConfig(golden_set="golden.json"),
+        aggregate_metrics=AggregateMetrics(
+            query_count=1,
+            recall_at_k={"recall@5": 1.0},
+            deterministic_ranking_hit_rate=0.0,
+        ),
+        query_metrics=[before_metric],
+        traces=[],
+    )
+    after = EvalRun(
+        config=RunConfig(golden_set="golden.json"),
+        aggregate_metrics=AggregateMetrics(
+            query_count=1,
+            recall_at_k={"recall@5": 1.0},
+            deterministic_ranking_hit_rate=1.0,
+        ),
+        query_metrics=[after_metric],
+        traces=[],
+    )
+
+    diff = diff_runs(before, after)
+
+    assert diff.aggregate_deltas["deterministic_ranking_hit_rate"] == 1.0
+    assert diff.rank_deltas[0].before_rank == 5
+    assert diff.rank_deltas[0].after_rank == 2
+    assert diff.rank_deltas[0].delta == -3
+
+
+def test_golden_set_rejects_duplicate_ids(tmp_path: Path) -> None:
+    path = tmp_path / "golden.json"
+    payload = {
+        "questions": [
+            {"id": "duplicate", "question": "one", "gold_sources": [source().model_dump()]},
+            {"id": "duplicate", "question": "two", "gold_sources": [source().model_dump()]},
+        ]
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    try:
+        load_golden_set(path)
+    except ValueError as exc:
+        assert "golden question ids must be unique" in str(exc)
+    else:
+        raise AssertionError("duplicate ids should be rejected")

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -831,6 +831,81 @@ def test_rank_raw_candidates_prefers_exact_and_speaker_matches():
     assert ranked[0] == exact_match
 
 
+def test_retrieve_with_trace_records_neighbor_provenance(monkeypatch):
+    engine = make_engine()
+    engine.retrieval_config = RetrievalConfig(neighbor_scene_window=1, final_top_k=5)
+    seed = raw_node("seed scene", scene_start=5)
+    before = raw_node("neighbor before", scene_start=4)
+    after = raw_node("neighbor after", scene_start=6)
+
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
+    monkeypatch.setattr(
+        engine,
+        "_hybrid_retrieve_trace",
+        lambda question, **kwargs: (
+            [seed],
+            {
+                "dense_raw": query_engine.StageTrace(name="dense_raw", candidates=[]),
+                "lexical_raw": query_engine.StageTrace(name="lexical_raw", candidates=[]),
+                "rrf_fusion": query_engine.StageTrace(name="rrf_fusion", candidates=[]),
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        engine,
+        "_raw_nodes_for_part",
+        lambda question, metadata, **kwargs: [before, seed, after],
+    )
+
+    trace = engine.retrieve_with_trace("What happens nearby?", query_id="q-neighbor")
+    neighbor_stage = trace.stages["neighbor_expansion"]
+
+    assert neighbor_stage.candidates is not None
+    provenance = {
+        (candidate.source_span.scene_start if candidate.source_span else -1): (
+            candidate.provenance,
+            candidate.provenance_node_id,
+        )
+        for candidate in neighbor_stage.candidates
+    }
+    assert provenance[5] == ("direct_hit", None)
+    assert provenance[4][0] == "neighbor_of"
+    assert provenance[6][0] == "neighbor_of"
+
+
+def test_retrieve_with_trace_exposes_deterministic_ranking_components(monkeypatch):
+    engine = make_engine()
+    engine.retrieval_config = RetrievalConfig(neighbor_scene_window=0, final_top_k=5)
+    weak_seed = raw_node("unrelated direct candidate", scene_start=0)
+    exact_match = raw_node("花帆 talks about practice", scene_start=1, detected_speakers="花帆")
+
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
+    monkeypatch.setattr(
+        engine,
+        "_hybrid_retrieve_trace",
+        lambda question, **kwargs: (
+            [weak_seed, exact_match],
+            {
+                "dense_raw": query_engine.StageTrace(name="dense_raw", candidates=[]),
+                "lexical_raw": query_engine.StageTrace(name="lexical_raw", candidates=[]),
+                "rrf_fusion": query_engine.StageTrace(name="rrf_fusion", candidates=[]),
+            },
+        ),
+    )
+
+    trace = engine.retrieve_with_trace(
+        "What does 花帆 say?",
+        query_id="q-ranking",
+    )
+    ranking_stage = trace.stages["deterministic_ranking"]
+
+    assert ranking_stage.candidates is not None
+    assert ranking_stage.candidates[0].text == "花帆 talks about practice"
+    assert ranking_stage.candidates[0].scores.deterministic_score is not None
+    assert ranking_stage.candidates[0].signal_breakdown["matched_terms"] >= 1
+    assert ranking_stage.candidates[0].signal_breakdown["speaker_matches"] == 1
+
+
 def test_analysis_where_can_filter_raw_chunks_by_source_store_speaker() -> None:
     engine = make_engine()
 


### PR DESCRIPTION
## Summary
- Add a typed retrieval eval package with golden-set parsing, deterministic trace JSON, metrics, and run diffing
- Add `indexer eval run` / `indexer eval diff` CLI commands plus a 30-question checked-in golden set
- Add trace-oriented raw retrieval execution with per-stage candidates, scores, neighbor provenance, and reranker-unavailable placeholder

## Verification
- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`