### PR TITLE
Add typed Pydantic-AI query tools

### DIFF
--- a/src/linkura_story_indexer/indexer/source_store.py
+++ b/src/linkura_story_indexer/indexer/source_store.py
@@ -31,6 +31,20 @@ def _metadata_order(metadata: dict[str, Any]) -> int:
     return int(order) if isinstance(order, int) else 0
 
 
+def _row_to_scene(row: sqlite3.Row) -> dict[str, Any]:
+    metadata = json.loads(str(row["metadata_json"]))
+    if not isinstance(metadata, dict):
+        raise ValueError("source scene metadata_json must decode to an object")
+    return {
+        "scene_id": row["scene_id"],
+        "file_path": row["file_path"],
+        "parent_part_id": row["parent_part_id"],
+        "scene_index": row["scene_index"],
+        "text": row["text"],
+        "metadata": metadata,
+    }
+
+
 def _turn_speaker_tokens(turn: DialogueTurn) -> tuple[list[str], str]:
     if turn.speaker_tokens:
         return turn.speaker_tokens, turn.speaker_kind or SPEAKER_KIND_NAMED
@@ -315,19 +329,7 @@ class SourceRecordStore:
                 """
             ).fetchall()
 
-        scenes = []
-        for row in rows:
-            metadata = json.loads(str(row["metadata_json"]))
-            scenes.append(
-                {
-                    "scene_id": row["scene_id"],
-                    "file_path": row["file_path"],
-                    "parent_part_id": row["parent_part_id"],
-                    "scene_index": row["scene_index"],
-                    "text": row["text"],
-                    "metadata": metadata,
-                }
-            )
+        scenes = [_row_to_scene(row) for row in rows]
         return sorted(
             scenes,
             key=lambda scene: (
@@ -356,15 +358,7 @@ class SourceRecordStore:
         if row is None:
             return None
 
-        metadata = json.loads(str(row["metadata_json"]))
-        return {
-            "scene_id": row["scene_id"],
-            "file_path": row["file_path"],
-            "parent_part_id": row["parent_part_id"],
-            "scene_index": row["scene_index"],
-            "text": row["text"],
-            "metadata": metadata if isinstance(metadata, dict) else {},
-        }
+        return _row_to_scene(row)
 
     def cached_state_facts(
         self,

--- a/src/linkura_story_indexer/indexer/source_store.py
+++ b/src/linkura_story_indexer/indexer/source_store.py
@@ -337,6 +337,35 @@ class SourceRecordStore:
             ),
         )
 
+    def get_scene(self, file_path: str, scene_index: int) -> dict[str, Any] | None:
+        """Returns one persisted raw scene by source file and zero-based scene index."""
+        if scene_index < 0:
+            return None
+
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT scene_id, file_path, parent_part_id, scene_index, text, metadata_json
+                FROM source_scenes
+                WHERE file_path = ?
+                  AND scene_index = ?
+                """,
+                (file_path, scene_index),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        metadata = json.loads(str(row["metadata_json"]))
+        return {
+            "scene_id": row["scene_id"],
+            "file_path": row["file_path"],
+            "parent_part_id": row["parent_part_id"],
+            "scene_index": row["scene_index"],
+            "text": row["text"],
+            "metadata": metadata if isinstance(metadata, dict) else {},
+        }
+
     def cached_state_facts(
         self,
         *,

--- a/src/linkura_story_indexer/lexical.py
+++ b/src/linkura_story_indexer/lexical.py
@@ -43,6 +43,13 @@ def _japanese_short_aliases(value: str) -> list[str]:
     return aliases
 
 
+def glossary_aliases_for(japanese: str, english: str) -> list[str]:
+    aliases = [japanese, english]
+    aliases.extend(_english_alias_parts(english))
+    aliases.extend(_japanese_short_aliases(japanese))
+    return _ordered_unique(aliases)
+
+
 def glossary_alias_groups(glossary: dict[str, dict[str, str]] | None) -> list[list[str]]:
     if not glossary:
         return []
@@ -52,10 +59,7 @@ def glossary_alias_groups(glossary: dict[str, dict[str, str]] | None) -> list[li
         if not isinstance(terms, dict):
             continue
         for japanese, english in terms.items():
-            aliases = [japanese, english]
-            aliases.extend(_english_alias_parts(english))
-            aliases.extend(_japanese_short_aliases(japanese))
-            groups.append(_ordered_unique(aliases))
+            groups.append(glossary_aliases_for(japanese, english))
     return groups
 
 

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -1468,6 +1468,11 @@ class StoryQueryEngine:
         analysis: QueryAnalysis | None = None,
     ) -> RetrievalTraceResult:
         """Executes the deterministic raw retrieval pipeline and returns final nodes plus stages."""
+        if top_k is not None and top_k < 1:
+            raise ValueError("top_k must be at least 1")
+        if n_results is not None and n_results < 1:
+            raise ValueError("n_results must be at least 1")
+
         expanded_question = self._expanded_question(question)
         query_embedding = None
         dense_unavailable_reason = None
@@ -1485,7 +1490,9 @@ class StoryQueryEngine:
             )
         retrieved_nodes, stages = self._hybrid_retrieve_trace(
             expanded_question,
-            n_results=n_results or self._config().raw_candidate_count,
+            n_results=(
+                n_results if n_results is not None else self._config().raw_candidate_count
+            ),
             where=raw_where,
             query_embedding=query_embedding,
             dense_unavailable_reason=dense_unavailable_reason,
@@ -1589,7 +1596,7 @@ class StoryQueryEngine:
             ],
         )
 
-        final_top_k = top_k or self._config().final_top_k
+        final_top_k = top_k if top_k is not None else self._config().final_top_k
         if analysis is not None:
             final_raw_nodes = self._filter_raw_nodes_by_analysis(deterministic_nodes, analysis)[
                 :final_top_k
@@ -1619,6 +1626,9 @@ class StoryQueryEngine:
         top_k: int,
     ) -> RetrievalTraceResult:
         """Executes hybrid retrieval for summary tiers and returns nodes plus trace stages."""
+        if top_k < 1:
+            raise ValueError("top_k must be at least 1")
+
         expanded_question = self._expanded_question(question)
         query_embedding = None
         dense_unavailable_reason = None

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -76,6 +76,12 @@ class RetrievalConfig:
 DEFAULT_RETRIEVAL_CONFIG = RetrievalConfig()
 
 
+@dataclass(frozen=True)
+class RetrievalTraceResult:
+    nodes: list[Node]
+    stages: dict[StageName, StageTrace]
+
+
 class StoryQueryEngine:
     def __init__(
         self,
@@ -1452,19 +1458,16 @@ class StoryQueryEngine:
             if (order := self._story_order(node[1])) is not None and order < boundary_order
         ]
 
-    def retrieve_with_trace(
+    def retrieve_raw_nodes_with_trace(
         self,
         question: str,
         *,
-        query_id: str = "ad-hoc",
-        mode: EvalMode = "raw",
-        answer_mode: bool = False,
-    ) -> QueryTrace:
-        """Executes the raw-first retrieval flow and returns deterministic stage traces."""
-        analysis = None
-        if mode == "raw-analyze" or self._config().enable_query_analysis:
-            analysis = analyze_query(question, self.glossary)
-
+        where: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        n_results: int | None = None,
+        analysis: QueryAnalysis | None = None,
+    ) -> RetrievalTraceResult:
+        """Executes the deterministic raw retrieval pipeline and returns final nodes plus stages."""
         expanded_question = self._expanded_question(question)
         query_embedding = None
         dense_unavailable_reason = None
@@ -1473,14 +1476,16 @@ class StoryQueryEngine:
         except Exception as exc:
             dense_unavailable_reason = f"query embedding unavailable: {exc}"
 
-        raw_where = self._where_for_analysis(
-            analysis,
-            summary_level=4,
-            include_scene_constraint=True,
-        )
+        raw_where = where
+        if raw_where is None:
+            raw_where = self._where_for_analysis(
+                analysis,
+                summary_level=4,
+                include_scene_constraint=True,
+            )
         retrieved_nodes, stages = self._hybrid_retrieve_trace(
             expanded_question,
-            n_results=self._config().raw_candidate_count,
+            n_results=n_results or self._config().raw_candidate_count,
             where=raw_where,
             query_embedding=query_embedding,
             dense_unavailable_reason=dense_unavailable_reason,
@@ -1584,12 +1589,13 @@ class StoryQueryEngine:
             ],
         )
 
+        final_top_k = top_k or self._config().final_top_k
         if analysis is not None:
             final_raw_nodes = self._filter_raw_nodes_by_analysis(deterministic_nodes, analysis)[
-                : self._config().final_top_k
+                :final_top_k
             ]
         else:
-            final_raw_nodes = deterministic_nodes[: self._config().final_top_k]
+            final_raw_nodes = deterministic_nodes[:final_top_k]
         stages["final_top_k"] = self._trace_stage(
             "final_top_k",
             [
@@ -1603,6 +1609,48 @@ class StoryQueryEngine:
             "reranker stage unavailable; #23 has not landed",
         )
 
+        return RetrievalTraceResult(nodes=final_raw_nodes, stages=stages)
+
+    def retrieve_summary_nodes_with_trace(
+        self,
+        question: str,
+        *,
+        where: dict[str, Any] | None,
+        top_k: int,
+    ) -> RetrievalTraceResult:
+        """Executes hybrid retrieval for summary tiers and returns nodes plus trace stages."""
+        expanded_question = self._expanded_question(question)
+        query_embedding = None
+        dense_unavailable_reason = None
+        try:
+            query_embedding = self._query_embedding(expanded_question)
+        except Exception as exc:
+            dense_unavailable_reason = f"query embedding unavailable: {exc}"
+
+        summary_nodes, stages = self._hybrid_retrieve_trace(
+            expanded_question,
+            n_results=top_k,
+            where=where,
+            query_embedding=query_embedding,
+            dense_unavailable_reason=dense_unavailable_reason,
+        )
+        return RetrievalTraceResult(nodes=summary_nodes, stages=stages)
+
+    def retrieve_with_trace(
+        self,
+        question: str,
+        *,
+        query_id: str = "ad-hoc",
+        mode: EvalMode = "raw",
+        answer_mode: bool = False,
+    ) -> QueryTrace:
+        """Executes the raw-first retrieval flow and returns deterministic stage traces."""
+        analysis = None
+        if mode == "raw-analyze" or self._config().enable_query_analysis:
+            analysis = analyze_query(question, self.glossary)
+        retrieval = self.retrieve_raw_nodes_with_trace(question, analysis=analysis)
+        final_raw_nodes = retrieval.nodes
+
         answer_text = None
         if answer_mode and final_raw_nodes:
             answer_text = self._answer_from_raw_evidence(question, final_raw_nodes, analysis)
@@ -1612,7 +1660,7 @@ class StoryQueryEngine:
             question=question,
             mode=mode,
             config=self._config().__dict__,
-            stages=stages,
+            stages=retrieval.stages,
             final_citation_labels=[
                 self._citation_label(metadata) for _, metadata in final_raw_nodes
             ],

--- a/src/linkura_story_indexer/query/tools.py
+++ b/src/linkura_story_indexer/query/tools.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import Any, Literal, cast
 
 from pydantic import BaseModel, Field, model_validator
 from pydantic_ai import FunctionToolset
 
-from linkura_story_indexer.eval.models import CandidateScores, SourceIdentity, StageTrace
-from linkura_story_indexer.lexical import glossary_alias_groups
+from linkura_story_indexer.eval.models import SourceIdentity, StageTrace
 from linkura_story_indexer.query.engine import Node, StoryQueryEngine
+
+_CJK_RE = re.compile(r"[\u3040-\u30ff\u3400-\u9fff々〆〤ー]+")
+_WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9'_-]*")
 
 
 class SearchRawInput(BaseModel):
@@ -19,7 +22,13 @@ class SearchRawInput(BaseModel):
     part: str | None = None
     scene_start: int | None = Field(default=None, ge=0)
     scene_end: int | None = Field(default=None, ge=0)
-    speakers: list[str] = Field(default_factory=list)
+    speakers: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional speaker names to filter raw chunks. Multiple speakers use OR semantics: "
+            "a result may contain any listed speaker, not necessarily all of them."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_scene_range(self) -> SearchRawInput:
@@ -73,14 +82,6 @@ class GlossaryLookupResult(BaseModel):
     errors: list[str] = Field(default_factory=list)
 
 
-def _combine_filters(engine: StoryQueryEngine, filters: list[dict[str, Any]]) -> dict[str, Any] | None:
-    return engine._and_where(filters)
-
-
-def _source_identity(engine: StoryQueryEngine, metadata: dict[str, Any]) -> SourceIdentity | None:
-    return engine._source_identity(metadata)
-
-
 def _candidate_from_node(
     engine: StoryQueryEngine,
     node: Node,
@@ -94,7 +95,7 @@ def _candidate_from_node(
         text=text or document,
         citation_label=engine._citation_label(metadata),
         metadata=dict(metadata),
-        source_identity=_source_identity(engine, metadata),
+        source_identity=engine._source_identity(metadata),
         rank=rank,
     )
 
@@ -149,7 +150,7 @@ def _raw_where(
     if speaker_filter is not None:
         filters.append(speaker_filter)
 
-    return _combine_filters(engine, filters), warnings, empty
+    return engine._and_where(filters), warnings, empty
 
 
 def _summary_where(engine: StoryQueryEngine, args: SearchSummariesInput) -> dict[str, Any] | None:
@@ -160,7 +161,7 @@ def _summary_where(engine: StoryQueryEngine, args: SearchSummariesInput) -> dict
         filters.append({"summary_level": args.summary_level})
     if args.arc_id is not None:
         filters.append({"arc_id": args.arc_id})
-    return _combine_filters(engine, filters)
+    return engine._and_where(filters)
 
 
 def _public_trace_stages(stages: dict[Any, StageTrace]) -> dict[str, StageTrace]:
@@ -172,82 +173,19 @@ def search_raw(engine: StoryQueryEngine, args: SearchRawInput) -> ToolResult:
     if empty:
         return ToolResult(warnings=warnings, metadata={"where": where})
 
-    expanded_query = engine._expanded_question(args.query)
-    query_embedding = None
-    dense_unavailable_reason = None
-    try:
-        query_embedding = engine._query_embedding(expanded_query)
-    except Exception as exc:
-        dense_unavailable_reason = f"query embedding unavailable: {exc}"
-
-    retrieved_nodes, stages = engine._hybrid_retrieve_trace(
-        expanded_query,
-        n_results=max(args.top_k, engine._config().raw_candidate_count),
-        where=where,
-        query_embedding=query_embedding,
-        dense_unavailable_reason=dense_unavailable_reason,
-    )
-    seed_nodes = engine._raw_evidence_nodes(retrieved_nodes)
-    stages["raw_seed_filter"] = engine._trace_stage(
-        "raw_seed_filter",
-        [engine._trace_candidate(node, rank=rank) for rank, node in enumerate(seed_nodes, start=1)],
-    )
-
-    expanded_nodes = engine._expand_raw_neighbors(
-        expanded_query,
-        seed_nodes,
-        query_embedding=query_embedding,
-    )
-    stages["neighbor_expansion"] = engine._trace_stage(
-        "neighbor_expansion",
-        [
-            engine._trace_candidate(
-                node,
-                rank=rank,
-                provenance=provenance,
-                provenance_node_id=provenance_node_id,
-            )
-            for rank, node in enumerate(expanded_nodes, start=1)
-            for provenance, provenance_node_id in [
-                engine._neighbor_trace_provenance(node, seed_nodes)
-            ]
-        ],
-    )
-
-    ranked_with_scores = engine._score_raw_candidates(
+    retrieval = engine.retrieve_raw_nodes_with_trace(
         args.query,
-        expanded_query,
-        expanded_nodes,
-        seed_nodes,
-    )
-    stages["deterministic_ranking"] = engine._trace_stage(
-        "deterministic_ranking",
-        [
-            engine._trace_candidate(
-                node,
-                rank=rank,
-                scores=CandidateScores(deterministic_score=float(score)),
-                signal_breakdown=signal_breakdown,
-            )
-            for rank, (node, signal_breakdown, score) in enumerate(
-                ranked_with_scores,
-                start=1,
-            )
-        ],
-    )
-
-    final_nodes = [node for node, _, _ in ranked_with_scores[: args.top_k]]
-    stages["final_top_k"] = engine._trace_stage(
-        "final_top_k",
-        [engine._trace_candidate(node, rank=rank) for rank, node in enumerate(final_nodes, start=1)],
+        where=where,
+        top_k=args.top_k,
+        n_results=max(args.top_k, engine._config().raw_candidate_count),
     )
 
     return ToolResult(
         candidates=[
             _candidate_from_node(engine, node, rank=rank, fetch_raw_text=True)
-            for rank, node in enumerate(final_nodes, start=1)
+            for rank, node in enumerate(retrieval.nodes, start=1)
         ],
-        trace_stages=_public_trace_stages(stages),
+        trace_stages=_public_trace_stages(retrieval.stages),
         warnings=warnings,
         metadata={"where": where},
     )
@@ -255,31 +193,20 @@ def search_raw(engine: StoryQueryEngine, args: SearchRawInput) -> ToolResult:
 
 def search_summaries(engine: StoryQueryEngine, args: SearchSummariesInput) -> ToolResult:
     where = _summary_where(engine, args)
-    expanded_query = engine._expanded_question(args.query)
-    query_embedding = None
-    dense_unavailable_reason = None
-    try:
-        query_embedding = engine._query_embedding(expanded_query)
-    except Exception as exc:
-        dense_unavailable_reason = f"query embedding unavailable: {exc}"
-
-    summary_nodes, stages = engine._hybrid_retrieve_trace(
-        expanded_query,
-        n_results=args.top_k,
+    retrieval = engine.retrieve_summary_nodes_with_trace(
+        args.query,
         where=where,
-        query_embedding=query_embedding,
-        dense_unavailable_reason=dense_unavailable_reason,
+        top_k=args.top_k,
     )
-    summary_nodes = [
-        node for node in summary_nodes if node[1].get("summary_level") in {1, 2, 3}
-    ][: args.top_k]
+    # Summary tier bounds are enforced by the dense and lexical retrieval where clause.
+    summary_nodes = retrieval.nodes
 
     return ToolResult(
         candidates=[
             _candidate_from_node(engine, node, rank=rank)
             for rank, node in enumerate(summary_nodes, start=1)
         ],
-        trace_stages=_public_trace_stages(stages),
+        trace_stages=_public_trace_stages(retrieval.stages),
         metadata={"where": where},
     )
 
@@ -307,10 +234,33 @@ def get_scene(engine: StoryQueryEngine, args: GetSceneInput) -> ToolResult:
         text=str(scene.get("text", "")),
         citation_label=engine._citation_label(metadata),
         metadata=metadata,
-        source_identity=_source_identity(engine, metadata),
+        source_identity=engine._source_identity(metadata),
         rank=1,
     )
     return ToolResult(candidates=[candidate])
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    unique = []
+    seen = set()
+    for value in values:
+        cleaned = value.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        unique.append(cleaned)
+        seen.add(cleaned)
+    return unique
+
+
+def _glossary_aliases(canonical_term: str, translation: str) -> list[str]:
+    aliases = [canonical_term, translation]
+    aliases.extend(part for part in _WORD_RE.findall(translation) if len(part) >= 2)
+    if _CJK_RE.fullmatch(canonical_term):
+        if len(canonical_term) >= 4:
+            aliases.append(canonical_term[-2:])
+        if len(canonical_term) >= 5:
+            aliases.append(canonical_term[-3:])
+    return _ordered_unique(aliases)
 
 
 def lookup_glossary(engine: StoryQueryEngine, args: LookupGlossaryInput) -> GlossaryLookupResult:
@@ -322,15 +272,13 @@ def lookup_glossary(engine: StoryQueryEngine, args: LookupGlossaryInput) -> Glos
     for category, terms in glossary.items():
         if not isinstance(terms, dict):
             continue
-        category_groups = glossary_alias_groups({category: terms})
-        for (canonical_term, translation), aliases in zip(
-            terms.items(),
-            category_groups,
-            strict=False,
-        ):
-            if args.term == canonical_term:
+        for canonical_term, translation in terms.items():
+            canonical = str(canonical_term)
+            translated = str(translation)
+            aliases = _glossary_aliases(canonical, translated)
+            if args.term == canonical:
                 match_type: Literal["canonical", "translation", "alias"] = "canonical"
-            elif normalized_term == str(translation).casefold():
+            elif normalized_term == translated.casefold():
                 match_type = "translation"
             elif any(normalized_term == alias.casefold() for alias in aliases):
                 match_type = "alias"
@@ -339,8 +287,8 @@ def lookup_glossary(engine: StoryQueryEngine, args: LookupGlossaryInput) -> Glos
 
             return GlossaryLookupResult(
                 matched_category=str(category),
-                canonical_term=str(canonical_term),
-                translation=str(translation),
+                canonical_term=canonical,
+                translation=translated,
                 aliases=aliases,
                 match_type=match_type,
             )
@@ -355,19 +303,39 @@ def build_query_toolset(engine: StoryQueryEngine) -> FunctionToolset:
     toolset = FunctionToolset()
 
     def search_raw_tool(args: SearchRawInput) -> ToolResult:
-        """Search raw source scenes and nearby context."""
+        """Search raw source scenes for exact evidence, dialogue, and scene-level details.
+
+        Prefer this over summaries when the user asks about specific lines, who said something,
+        what happened in a scene, or needs citations to raw story text. Use speaker filters as
+        an OR-union when narrowing to scenes involving any listed speaker.
+        """
         return search_raw(engine, args)
 
     def search_summaries_tool(args: SearchSummariesInput) -> ToolResult:
-        """Search indexed year, episode, or part summaries."""
+        """Search indexed year, episode, or part summaries for broad narrative context.
+
+        Prefer this when the user asks for arc-level, episode-level, or part-level overview
+        information rather than exact quoted evidence. The summary-level and arc filters are
+        enforced by the retrieval query.
+        """
         return search_summaries(engine, args)
 
     def get_scene_tool(args: GetSceneInput) -> ToolResult:
-        """Fetch one exact raw source scene by file path and scene index."""
+        """Fetch one exact raw source scene by file path and scene index.
+
+        Use this after a search result has already identified a file_path and scene_index, or
+        when the caller already knows that exact source location. Do not use it for discovery
+        because it does not search.
+        """
         return get_scene(engine, args)
 
     def lookup_glossary_tool(args: LookupGlossaryInput) -> GlossaryLookupResult:
-        """Resolve a glossary term, translation, or generated alias."""
+        """Resolve a Japanese glossary term, English translation, or generated alias.
+
+        Use this first when a query contains character, unit, location, or story-specific terms
+        that may need Japanese-English alias expansion before searching. The result gives the
+        canonical Japanese term, official translation, aliases, and match type.
+        """
         return lookup_glossary(engine, args)
 
     toolset.add_function(search_raw_tool, name="search_raw")

--- a/src/linkura_story_indexer/query/tools.py
+++ b/src/linkura_story_indexer/query/tools.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel, Field, model_validator
+from pydantic_ai import FunctionToolset
+
+from linkura_story_indexer.eval.models import CandidateScores, SourceIdentity, StageTrace
+from linkura_story_indexer.lexical import glossary_alias_groups
+from linkura_story_indexer.query.engine import Node, StoryQueryEngine
+
+
+class SearchRawInput(BaseModel):
+    query: str = Field(..., min_length=1)
+    top_k: int = Field(8, ge=1)
+    arc_id: str | None = None
+    episode: int | None = None
+    part: str | None = None
+    scene_start: int | None = Field(default=None, ge=0)
+    scene_end: int | None = Field(default=None, ge=0)
+    speakers: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_scene_range(self) -> SearchRawInput:
+        if (
+            self.scene_start is not None
+            and self.scene_end is not None
+            and self.scene_end < self.scene_start
+        ):
+            raise ValueError("scene_end must be greater than or equal to scene_start")
+        return self
+
+
+class SearchSummariesInput(BaseModel):
+    query: str = Field(..., min_length=1)
+    top_k: int = Field(8, ge=1)
+    summary_level: Literal[1, 2, 3] | None = None
+    arc_id: str | None = None
+
+
+class GetSceneInput(BaseModel):
+    file_path: str = Field(..., min_length=1)
+    scene_index: int = Field(..., ge=0)
+
+
+class LookupGlossaryInput(BaseModel):
+    term: str = Field(..., min_length=1)
+
+
+class ToolCandidate(BaseModel):
+    text: str
+    citation_label: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    source_identity: SourceIdentity | None = None
+    rank: int = Field(..., ge=1)
+
+
+class ToolResult(BaseModel):
+    candidates: list[ToolCandidate] = Field(default_factory=list)
+    trace_stages: dict[str, StageTrace] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class GlossaryLookupResult(BaseModel):
+    matched_category: str | None = None
+    canonical_term: str | None = None
+    translation: str | None = None
+    aliases: list[str] = Field(default_factory=list)
+    match_type: Literal["canonical", "translation", "alias", "miss"] = "miss"
+    errors: list[str] = Field(default_factory=list)
+
+
+def _combine_filters(engine: StoryQueryEngine, filters: list[dict[str, Any]]) -> dict[str, Any] | None:
+    return engine._and_where(filters)
+
+
+def _source_identity(engine: StoryQueryEngine, metadata: dict[str, Any]) -> SourceIdentity | None:
+    return engine._source_identity(metadata)
+
+
+def _candidate_from_node(
+    engine: StoryQueryEngine,
+    node: Node,
+    *,
+    rank: int,
+    fetch_raw_text: bool = False,
+) -> ToolCandidate:
+    document, metadata = node
+    text = engine._fetch_raw_text(metadata) if fetch_raw_text else ""
+    return ToolCandidate(
+        text=text or document,
+        citation_label=engine._citation_label(metadata),
+        metadata=dict(metadata),
+        source_identity=_source_identity(engine, metadata),
+        rank=rank,
+    )
+
+
+def _speaker_chunk_filter(
+    engine: StoryQueryEngine,
+    speakers: list[str],
+) -> tuple[dict[str, Any] | None, list[str], bool]:
+    if not speakers:
+        return None, [], False
+
+    source_store = getattr(engine, "source_store", None)
+    chunk_ids_for_speaker = getattr(source_store, "chunk_ids_for_speaker", None)
+    if not callable(chunk_ids_for_speaker):
+        return None, ["speaker filtering unavailable: source store has no speaker index"], False
+    typed_chunk_ids_for_speaker = cast(Callable[[str], list[str]], chunk_ids_for_speaker)
+
+    chunk_ids = []
+    seen = set()
+    for speaker in speakers:
+        for chunk_id in typed_chunk_ids_for_speaker(speaker):
+            if chunk_id in seen:
+                continue
+            seen.add(chunk_id)
+            chunk_ids.append(chunk_id)
+
+    if not chunk_ids:
+        return None, [f"no source chunks matched speakers: {', '.join(speakers)}"], True
+    return {"chunk_id": {"$in": chunk_ids}}, [], False
+
+
+def _raw_where(
+    engine: StoryQueryEngine,
+    args: SearchRawInput,
+) -> tuple[dict[str, Any] | None, list[str], bool]:
+    filters: list[dict[str, Any]] = [{"summary_level": 4}]
+    if args.arc_id is not None:
+        filters.append({"arc_id": args.arc_id})
+    if args.episode is not None:
+        filters.append({"episode_number": args.episode})
+    if args.part is not None:
+        filters.append({"part_name": args.part})
+
+    scene_start = args.scene_start
+    scene_end = args.scene_end if args.scene_end is not None else args.scene_start
+    if scene_start is not None:
+        filters.append({"scene_end": {"$gte": scene_start}})
+    if scene_end is not None:
+        filters.append({"scene_start": {"$lte": scene_end}})
+
+    speaker_filter, warnings, empty = _speaker_chunk_filter(engine, args.speakers)
+    if speaker_filter is not None:
+        filters.append(speaker_filter)
+
+    return _combine_filters(engine, filters), warnings, empty
+
+
+def _summary_where(engine: StoryQueryEngine, args: SearchSummariesInput) -> dict[str, Any] | None:
+    filters: list[dict[str, Any]] = []
+    if args.summary_level is None:
+        filters.append({"summary_level": {"$in": [1, 2, 3]}})
+    else:
+        filters.append({"summary_level": args.summary_level})
+    if args.arc_id is not None:
+        filters.append({"arc_id": args.arc_id})
+    return _combine_filters(engine, filters)
+
+
+def _public_trace_stages(stages: dict[Any, StageTrace]) -> dict[str, StageTrace]:
+    return {str(name): stage for name, stage in stages.items()}
+
+
+def search_raw(engine: StoryQueryEngine, args: SearchRawInput) -> ToolResult:
+    where, warnings, empty = _raw_where(engine, args)
+    if empty:
+        return ToolResult(warnings=warnings, metadata={"where": where})
+
+    expanded_query = engine._expanded_question(args.query)
+    query_embedding = None
+    dense_unavailable_reason = None
+    try:
+        query_embedding = engine._query_embedding(expanded_query)
+    except Exception as exc:
+        dense_unavailable_reason = f"query embedding unavailable: {exc}"
+
+    retrieved_nodes, stages = engine._hybrid_retrieve_trace(
+        expanded_query,
+        n_results=max(args.top_k, engine._config().raw_candidate_count),
+        where=where,
+        query_embedding=query_embedding,
+        dense_unavailable_reason=dense_unavailable_reason,
+    )
+    seed_nodes = engine._raw_evidence_nodes(retrieved_nodes)
+    stages["raw_seed_filter"] = engine._trace_stage(
+        "raw_seed_filter",
+        [engine._trace_candidate(node, rank=rank) for rank, node in enumerate(seed_nodes, start=1)],
+    )
+
+    expanded_nodes = engine._expand_raw_neighbors(
+        expanded_query,
+        seed_nodes,
+        query_embedding=query_embedding,
+    )
+    stages["neighbor_expansion"] = engine._trace_stage(
+        "neighbor_expansion",
+        [
+            engine._trace_candidate(
+                node,
+                rank=rank,
+                provenance=provenance,
+                provenance_node_id=provenance_node_id,
+            )
+            for rank, node in enumerate(expanded_nodes, start=1)
+            for provenance, provenance_node_id in [
+                engine._neighbor_trace_provenance(node, seed_nodes)
+            ]
+        ],
+    )
+
+    ranked_with_scores = engine._score_raw_candidates(
+        args.query,
+        expanded_query,
+        expanded_nodes,
+        seed_nodes,
+    )
+    stages["deterministic_ranking"] = engine._trace_stage(
+        "deterministic_ranking",
+        [
+            engine._trace_candidate(
+                node,
+                rank=rank,
+                scores=CandidateScores(deterministic_score=float(score)),
+                signal_breakdown=signal_breakdown,
+            )
+            for rank, (node, signal_breakdown, score) in enumerate(
+                ranked_with_scores,
+                start=1,
+            )
+        ],
+    )
+
+    final_nodes = [node for node, _, _ in ranked_with_scores[: args.top_k]]
+    stages["final_top_k"] = engine._trace_stage(
+        "final_top_k",
+        [engine._trace_candidate(node, rank=rank) for rank, node in enumerate(final_nodes, start=1)],
+    )
+
+    return ToolResult(
+        candidates=[
+            _candidate_from_node(engine, node, rank=rank, fetch_raw_text=True)
+            for rank, node in enumerate(final_nodes, start=1)
+        ],
+        trace_stages=_public_trace_stages(stages),
+        warnings=warnings,
+        metadata={"where": where},
+    )
+
+
+def search_summaries(engine: StoryQueryEngine, args: SearchSummariesInput) -> ToolResult:
+    where = _summary_where(engine, args)
+    expanded_query = engine._expanded_question(args.query)
+    query_embedding = None
+    dense_unavailable_reason = None
+    try:
+        query_embedding = engine._query_embedding(expanded_query)
+    except Exception as exc:
+        dense_unavailable_reason = f"query embedding unavailable: {exc}"
+
+    summary_nodes, stages = engine._hybrid_retrieve_trace(
+        expanded_query,
+        n_results=args.top_k,
+        where=where,
+        query_embedding=query_embedding,
+        dense_unavailable_reason=dense_unavailable_reason,
+    )
+    summary_nodes = [
+        node for node in summary_nodes if node[1].get("summary_level") in {1, 2, 3}
+    ][: args.top_k]
+
+    return ToolResult(
+        candidates=[
+            _candidate_from_node(engine, node, rank=rank)
+            for rank, node in enumerate(summary_nodes, start=1)
+        ],
+        trace_stages=_public_trace_stages(stages),
+        metadata={"where": where},
+    )
+
+
+def get_scene(engine: StoryQueryEngine, args: GetSceneInput) -> ToolResult:
+    source_store = getattr(engine, "source_store", None)
+    get_scene_func = getattr(source_store, "get_scene", None)
+    if not callable(get_scene_func):
+        return ToolResult(errors=["scene lookup unavailable: source store has no get_scene method"])
+    typed_get_scene = cast(Callable[[str, int], dict[str, Any] | None], get_scene_func)
+
+    scene = typed_get_scene(args.file_path, args.scene_index)
+    if scene is None:
+        return ToolResult(
+            errors=["scene not found"],
+            metadata={"file_path": args.file_path, "scene_index": args.scene_index},
+        )
+
+    metadata = dict(scene.get("metadata") or {})
+    metadata.setdefault("file_path", scene.get("file_path"))
+    metadata.setdefault("scene_index", scene.get("scene_index"))
+    metadata.setdefault("scene_start", scene.get("scene_index"))
+    metadata.setdefault("scene_end", scene.get("scene_index"))
+    candidate = ToolCandidate(
+        text=str(scene.get("text", "")),
+        citation_label=engine._citation_label(metadata),
+        metadata=metadata,
+        source_identity=_source_identity(engine, metadata),
+        rank=1,
+    )
+    return ToolResult(candidates=[candidate])
+
+
+def lookup_glossary(engine: StoryQueryEngine, args: LookupGlossaryInput) -> GlossaryLookupResult:
+    glossary = getattr(engine, "glossary", None)
+    if not glossary:
+        return GlossaryLookupResult(errors=["glossary unavailable"])
+
+    normalized_term = args.term.casefold()
+    for category, terms in glossary.items():
+        if not isinstance(terms, dict):
+            continue
+        category_groups = glossary_alias_groups({category: terms})
+        for (canonical_term, translation), aliases in zip(
+            terms.items(),
+            category_groups,
+            strict=False,
+        ):
+            if args.term == canonical_term:
+                match_type: Literal["canonical", "translation", "alias"] = "canonical"
+            elif normalized_term == str(translation).casefold():
+                match_type = "translation"
+            elif any(normalized_term == alias.casefold() for alias in aliases):
+                match_type = "alias"
+            else:
+                continue
+
+            return GlossaryLookupResult(
+                matched_category=str(category),
+                canonical_term=str(canonical_term),
+                translation=str(translation),
+                aliases=aliases,
+                match_type=match_type,
+            )
+
+    return GlossaryLookupResult(
+        match_type="miss",
+        errors=[f"glossary term not found: {args.term}"],
+    )
+
+
+def build_query_toolset(engine: StoryQueryEngine) -> FunctionToolset:
+    toolset = FunctionToolset()
+
+    def search_raw_tool(args: SearchRawInput) -> ToolResult:
+        """Search raw source scenes and nearby context."""
+        return search_raw(engine, args)
+
+    def search_summaries_tool(args: SearchSummariesInput) -> ToolResult:
+        """Search indexed year, episode, or part summaries."""
+        return search_summaries(engine, args)
+
+    def get_scene_tool(args: GetSceneInput) -> ToolResult:
+        """Fetch one exact raw source scene by file path and scene index."""
+        return get_scene(engine, args)
+
+    def lookup_glossary_tool(args: LookupGlossaryInput) -> GlossaryLookupResult:
+        """Resolve a glossary term, translation, or generated alias."""
+        return lookup_glossary(engine, args)
+
+    toolset.add_function(search_raw_tool, name="search_raw")
+    toolset.add_function(search_summaries_tool, name="search_summaries")
+    toolset.add_function(get_scene_tool, name="get_scene")
+    toolset.add_function(lookup_glossary_tool, name="lookup_glossary")
+    return toolset

--- a/src/linkura_story_indexer/query/tools.py
+++ b/src/linkura_story_indexer/query/tools.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from collections.abc import Callable
 from typing import Any, Literal, cast
 
@@ -8,10 +7,8 @@ from pydantic import BaseModel, Field, model_validator
 from pydantic_ai import FunctionToolset
 
 from linkura_story_indexer.eval.models import SourceIdentity, StageTrace
+from linkura_story_indexer.lexical import glossary_aliases_for
 from linkura_story_indexer.query.engine import Node, StoryQueryEngine
-
-_CJK_RE = re.compile(r"[\u3040-\u30ff\u3400-\u9fff々〆〤ー]+")
-_WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9'_-]*")
 
 
 class SearchRawInput(BaseModel):
@@ -240,29 +237,6 @@ def get_scene(engine: StoryQueryEngine, args: GetSceneInput) -> ToolResult:
     return ToolResult(candidates=[candidate])
 
 
-def _ordered_unique(values: list[str]) -> list[str]:
-    unique = []
-    seen = set()
-    for value in values:
-        cleaned = value.strip()
-        if not cleaned or cleaned in seen:
-            continue
-        unique.append(cleaned)
-        seen.add(cleaned)
-    return unique
-
-
-def _glossary_aliases(canonical_term: str, translation: str) -> list[str]:
-    aliases = [canonical_term, translation]
-    aliases.extend(part for part in _WORD_RE.findall(translation) if len(part) >= 2)
-    if _CJK_RE.fullmatch(canonical_term):
-        if len(canonical_term) >= 4:
-            aliases.append(canonical_term[-2:])
-        if len(canonical_term) >= 5:
-            aliases.append(canonical_term[-3:])
-    return _ordered_unique(aliases)
-
-
 def lookup_glossary(engine: StoryQueryEngine, args: LookupGlossaryInput) -> GlossaryLookupResult:
     glossary = getattr(engine, "glossary", None)
     if not glossary:
@@ -275,7 +249,7 @@ def lookup_glossary(engine: StoryQueryEngine, args: LookupGlossaryInput) -> Glos
         for canonical_term, translation in terms.items():
             canonical = str(canonical_term)
             translated = str(translation)
-            aliases = _glossary_aliases(canonical, translated)
+            aliases = glossary_aliases_for(canonical, translated)
             if args.term == canonical:
                 match_type: Literal["canonical", "translation", "alias"] = "canonical"
             elif normalized_term == translated.casefold():

--- a/tests/test_lexical.py
+++ b/tests/test_lexical.py
@@ -2,7 +2,12 @@ from pathlib import Path
 from typing import Any
 
 from linkura_story_indexer import cli
-from linkura_story_indexer.lexical import LexicalIndex, expand_query_with_glossary
+from linkura_story_indexer.lexical import (
+    LexicalIndex,
+    expand_query_with_glossary,
+    glossary_alias_groups,
+    glossary_aliases_for,
+)
 from linkura_story_indexer.models.story import StoryMetadata, StoryNode
 
 
@@ -36,6 +41,15 @@ def test_glossary_expansion_adds_full_and_short_aliases() -> None:
     assert "Kaho Hinoshita" in expanded
     assert "日野下花帆" in expanded
     assert "花帆" in expanded
+
+
+def test_glossary_alias_groups_uses_single_entry_alias_helper() -> None:
+    aliases = glossary_aliases_for("日野下花帆", "Kaho Hinoshita")
+
+    assert aliases == ["日野下花帆", "Kaho Hinoshita", "Kaho", "Hinoshita", "花帆", "下花帆"]
+    assert glossary_alias_groups({"characters": {"日野下花帆": "Kaho Hinoshita"}}) == [
+        aliases
+    ]
 
 
 def test_lexical_index_finds_short_japanese_name_and_preserves_span(tmp_path: Path) -> None:

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -171,6 +171,35 @@ def test_retrieval_config_rejects_invalid_rrf_k():
         raise AssertionError("RetrievalConfig accepted an invalid RRF k")
 
 
+def test_retrieve_raw_nodes_with_trace_rejects_invalid_limits():
+    engine = make_engine()
+
+    try:
+        engine.retrieve_raw_nodes_with_trace("question", top_k=0)
+    except ValueError as exc:
+        assert "top_k must be at least 1" in str(exc)
+    else:
+        raise AssertionError("accepted invalid raw retrieval top_k")
+
+    try:
+        engine.retrieve_raw_nodes_with_trace("question", n_results=0)
+    except ValueError as exc:
+        assert "n_results must be at least 1" in str(exc)
+    else:
+        raise AssertionError("accepted invalid raw retrieval n_results")
+
+
+def test_retrieve_summary_nodes_with_trace_rejects_invalid_top_k():
+    engine = make_engine()
+
+    try:
+        engine.retrieve_summary_nodes_with_trace("question", where={"summary_level": 1}, top_k=0)
+    except ValueError as exc:
+        assert "top_k must be at least 1" in str(exc)
+    else:
+        raise AssertionError("accepted invalid summary retrieval top_k")
+
+
 def test_rrf_fusion_combines_fixed_ranked_lists():
     engine = make_engine()
     a = raw_node("a", scene_start=0)

--- a/tests/test_query_tools.py
+++ b/tests/test_query_tools.py
@@ -1,0 +1,267 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from linkura_story_indexer.indexer.chunker import build_retrieval_chunks
+from linkura_story_indexer.indexer.processor import StoryProcessor
+from linkura_story_indexer.indexer.source_store import SourceRecordStore
+from linkura_story_indexer.query import engine as query_engine
+from linkura_story_indexer.query.engine import RetrievalConfig, StoryQueryEngine
+from linkura_story_indexer.query.tools import (
+    GetSceneInput,
+    LookupGlossaryInput,
+    SearchRawInput,
+    SearchSummariesInput,
+    build_query_toolset,
+    get_scene,
+    lookup_glossary,
+    search_raw,
+    search_summaries,
+)
+
+
+def make_engine() -> StoryQueryEngine:
+    engine = StoryQueryEngine.__new__(StoryQueryEngine)
+    engine.retrieval_config = RetrievalConfig(neighbor_scene_window=0)
+    engine.glossary = {"characters": {"日野下花帆": "Kaho Hinoshita"}}
+    engine.state_ledger = {}
+    return engine
+
+
+def raw_node(
+    text: str = "花帆: raw scene",
+    *,
+    scene_start: int = 0,
+    arc_id: str = "103",
+) -> tuple[str, dict[str, Any]]:
+    return (
+        text,
+        {
+            "arc_id": arc_id,
+            "story_type": "Main",
+            "episode_name": "第1話『花咲きたい！』",
+            "episode_number": 1,
+            "part_name": "1",
+            "summary_level": 4,
+            "file_path": "story/103/第1話『花咲きたい！』/1.md",
+            "scene_index": scene_start,
+            "scene_start": scene_start,
+            "scene_end": scene_start,
+            "source_scene_count": 1,
+            "canonical_story_order": scene_start,
+            "parent_part_id": "103|Main|第1話『花咲きたい！』|1",
+            "chunk_id": f"chunk:103:1:{scene_start}",
+            "detected_speakers": "花帆",
+        },
+    )
+
+
+def summary_node(
+    text: str = "episode summary",
+    *,
+    summary_level: int = 2,
+    arc_id: str = "103",
+) -> tuple[str, dict[str, Any]]:
+    return (
+        text,
+        {
+            "arc_id": arc_id,
+            "story_type": "Main",
+            "episode_name": "第1話『花咲きたい！』",
+            "episode_number": 1,
+            "part_name": "1",
+            "summary_level": summary_level,
+            "parent_episode_id": "103|Main|第1話『花咲きたい！』",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "model,args",
+    [
+        (SearchRawInput, {"query": "x", "top_k": 0}),
+        (SearchRawInput, {"query": "x", "top_k": 1, "scene_start": -1}),
+        (SearchRawInput, {"query": "x", "top_k": 1, "scene_start": 3, "scene_end": 2}),
+        (SearchSummariesInput, {"query": "x", "top_k": 0}),
+        (SearchSummariesInput, {"query": "x", "top_k": 1, "summary_level": 4}),
+        (GetSceneInput, {"file_path": "story.md", "scene_index": -1}),
+    ],
+)
+def test_query_tool_inputs_reject_invalid_arguments(
+    model: type[Any],
+    args: dict[str, Any],
+) -> None:
+    with pytest.raises(ValidationError):
+        model.model_validate(args)
+
+
+def test_search_raw_returns_ranked_candidates_and_trace(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = make_engine()
+    seed = raw_node("weak seed", scene_start=0)
+    exact = raw_node("花帆 talks about practice", scene_start=1)
+    captured: list[dict[str, Any]] = []
+
+    class FakeSourceStore:
+        def chunk_ids_for_speaker(self, speaker: str) -> list[str]:
+            assert speaker == "花帆"
+            return ["chunk:103:1:0", "chunk:103:1:1"]
+
+    engine.source_store = FakeSourceStore()
+
+    def fake_hybrid_retrieve_trace(
+        question: str,
+        *,
+        n_results: int,
+        where: dict[str, Any] | None,
+        query_embedding: list[float] | None,
+        dense_unavailable_reason: str | None = None,
+    ) -> tuple[list[tuple[str, dict[str, Any]]], dict[str, query_engine.StageTrace]]:
+        captured.append({"question": question, "n_results": n_results, "where": where})
+        assert query_embedding == [0.1]
+        assert dense_unavailable_reason is None
+        return (
+            [seed, exact],
+            {
+                "dense_raw": engine._trace_stage("dense_raw", []),
+                "lexical_raw": engine._trace_stage("lexical_raw", []),
+                "rrf_fusion": engine._trace_stage("rrf_fusion", []),
+            },
+        )
+
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
+    monkeypatch.setattr(engine, "_hybrid_retrieve_trace", fake_hybrid_retrieve_trace)
+    monkeypatch.setattr(engine, "_fetch_raw_text", lambda metadata: "")
+
+    result = search_raw(
+        engine,
+            SearchRawInput(
+                query="What practice does 花帆 mention?",
+            top_k=1,
+            arc_id="103",
+            episode=1,
+            part="1",
+            scene_start=1,
+            speakers=["花帆"],
+        ),
+    )
+
+    assert result.candidates[0].text == "花帆 talks about practice"
+    assert result.candidates[0].citation_label == "103 · Episode 1 · Part 1 · Scene 2"
+    assert result.trace_stages["final_top_k"].candidates is not None
+    assert result.trace_stages["final_top_k"].candidates[0].rank == 1
+    assert captured[0]["where"] == {
+        "$and": [
+            {"summary_level": 4},
+            {"arc_id": "103"},
+            {"episode_number": 1},
+            {"part_name": "1"},
+            {"scene_end": {"$gte": 1}},
+            {"scene_start": {"$lte": 1}},
+            {"chunk_id": {"$in": ["chunk:103:1:0", "chunk:103:1:1"]}},
+        ]
+    }
+
+
+def test_search_summaries_filters_level_and_arc(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = make_engine()
+    summary = summary_node("Kaho starts school.", summary_level=2, arc_id="103")
+    raw = raw_node("raw should not leak", arc_id="103")
+    captured: list[dict[str, Any]] = []
+
+    def fake_hybrid_retrieve_trace(
+        question: str,
+        *,
+        n_results: int,
+        where: dict[str, Any] | None,
+        query_embedding: list[float] | None,
+        dense_unavailable_reason: str | None = None,
+    ) -> tuple[list[tuple[str, dict[str, Any]]], dict[str, query_engine.StageTrace]]:
+        captured.append({"n_results": n_results, "where": where})
+        return (
+            [summary, raw],
+            {
+                "dense_raw": engine._trace_stage("dense_raw", []),
+                "lexical_raw": engine._trace_stage("lexical_raw", []),
+                "rrf_fusion": engine._trace_stage("rrf_fusion", []),
+            },
+        )
+
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
+    monkeypatch.setattr(engine, "_hybrid_retrieve_trace", fake_hybrid_retrieve_trace)
+
+    result = search_summaries(
+        engine,
+        SearchSummariesInput(query="Kaho", top_k=3, summary_level=2, arc_id="103"),
+    )
+
+    assert [candidate.text for candidate in result.candidates] == ["Kaho starts school."]
+    assert captured == [
+        {
+            "n_results": 3,
+            "where": {"$and": [{"summary_level": 2}, {"arc_id": "103"}]},
+        }
+    ]
+
+
+def test_get_scene_returns_exact_source_text_and_structured_errors(tmp_path: Path) -> None:
+    story_file = tmp_path / "story" / "103" / "第1話『花咲きたい！』" / "1.md"
+    story_file.parent.mkdir(parents=True, exist_ok=True)
+    story_file.write_text("花帆: scene zero\n---\nさやか: scene one", encoding="utf-8")
+    raw_nodes = StoryProcessor.process_file(story_file)
+    chunks = build_retrieval_chunks(raw_nodes, min_chars=1, target_chars=500, max_chars=500)
+    store = SourceRecordStore(tmp_path / "source.db")
+    store.replace_all(raw_nodes, chunks)
+
+    engine = make_engine()
+    engine.source_store = store
+
+    found = get_scene(engine, GetSceneInput(file_path=str(story_file), scene_index=1))
+    missing = get_scene(engine, GetSceneInput(file_path=str(story_file), scene_index=5))
+
+    assert found.candidates[0].text == "さやか: scene one"
+    assert found.candidates[0].metadata["scene_index"] == 1
+    assert found.candidates[0].source_identity is not None
+    assert missing.candidates == []
+    assert missing.errors == ["scene not found"]
+
+
+def test_lookup_glossary_resolves_terms_translations_and_aliases() -> None:
+    engine = make_engine()
+
+    canonical = lookup_glossary(engine, LookupGlossaryInput(term="日野下花帆"))
+    translation = lookup_glossary(engine, LookupGlossaryInput(term="Kaho Hinoshita"))
+    alias = lookup_glossary(engine, LookupGlossaryInput(term="花帆"))
+    miss = lookup_glossary(engine, LookupGlossaryInput(term="unknown"))
+
+    assert canonical.match_type == "canonical"
+    assert translation.match_type == "translation"
+    assert alias.match_type == "alias"
+    assert alias.canonical_term == "日野下花帆"
+    assert alias.translation == "Kaho Hinoshita"
+    assert "花帆" in alias.aliases
+    assert miss.match_type == "miss"
+    assert miss.errors == ["glossary term not found: unknown"]
+
+
+def test_build_query_toolset_registers_pydantic_schema_tools() -> None:
+    engine = make_engine()
+    toolset = build_query_toolset(engine)
+    test_model = TestModel()
+    agent = Agent(test_model)
+
+    agent.run_sync("What tools are available?", toolsets=[toolset])
+
+    request_parameters = test_model.last_model_request_parameters
+    assert request_parameters is not None
+    tools = request_parameters.function_tools
+    by_name = {tool.name: tool for tool in tools}
+    assert set(by_name) == {"search_raw", "search_summaries", "get_scene", "lookup_glossary"}
+    search_raw_schema = by_name["search_raw"].parameters_json_schema
+    assert {"query", "top_k", "scene_start", "scene_end"}.issubset(
+        search_raw_schema["properties"]
+    )
+    assert search_raw_schema["properties"]["top_k"]["minimum"] == 1

--- a/tests/test_query_tools.py
+++ b/tests/test_query_tools.py
@@ -25,6 +25,9 @@ from linkura_story_indexer.query.tools import (
 
 
 def make_engine() -> StoryQueryEngine:
+    # Bypass __init__ so these unit tests can exercise tool formatting without opening Chroma,
+    # SQLite, or model-provider resources. Tests only rely on retrieval_config, glossary,
+    # state_ledger, source_store, and monkeypatched retrieval methods.
     engine = StoryQueryEngine.__new__(StoryQueryEngine)
     engine.retrieval_config = RetrievalConfig(neighbor_scene_window=0)
     engine.glossary = {"characters": {"日野下花帆": "Kaho Hinoshita"}}
@@ -169,7 +172,6 @@ def test_search_raw_returns_ranked_candidates_and_trace(monkeypatch: pytest.Monk
 def test_search_summaries_filters_level_and_arc(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = make_engine()
     summary = summary_node("Kaho starts school.", summary_level=2, arc_id="103")
-    raw = raw_node("raw should not leak", arc_id="103")
     captured: list[dict[str, Any]] = []
 
     def fake_hybrid_retrieve_trace(
@@ -182,7 +184,7 @@ def test_search_summaries_filters_level_and_arc(monkeypatch: pytest.MonkeyPatch)
     ) -> tuple[list[tuple[str, dict[str, Any]]], dict[str, query_engine.StageTrace]]:
         captured.append({"n_results": n_results, "where": where})
         return (
-            [summary, raw],
+            [summary],
             {
                 "dense_raw": engine._trace_stage("dense_raw", []),
                 "lexical_raw": engine._trace_stage("lexical_raw", []),
@@ -265,3 +267,4 @@ def test_build_query_toolset_registers_pydantic_schema_tools() -> None:
         search_raw_schema["properties"]
     )
     assert search_raw_schema["properties"]["top_k"]["minimum"] == 1
+    assert "OR semantics" in search_raw_schema["properties"]["speakers"]["description"]


### PR DESCRIPTION
## Summary
- add typed query tool request/response models and direct helpers for raw search, summary search, scene lookup, and glossary lookup
- expose the helpers as a Pydantic-AI `FunctionToolset`
- add exact `SourceRecordStore.get_scene()` lookup for source scenes
- cover validation, retrieval shaping, glossary aliases, source lookup errors, and toolset schema registration

## Validation
- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`