### PR TITLE
Add LLM router for typed query dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,22 @@ path retrieves raw source evidence with `summary_level: 4`, does not add
 analyzer-derived metadata filters, and does not perform summary-tier retrieval
 or summary fanout.
 
-Use `--analyze` when you want targeted scoped workflows that apply
-analyzer-derived filters or structured helpers:
+Use `--routing-mode heuristic` when you want targeted scoped workflows that
+apply analyzer-derived filters or structured helpers. Use
+`--routing-mode llm_router` to let the configured router model select one
+typed query tool before retrieval. The router model is controlled by
+`LINKURA_ROUTER_MODEL` and defaults to `gemini-3.1-flash-lite-preview`.
 
 ```powershell
-indexer query "What happened in the 105th term?" --analyze
-indexer chat --analyze
+indexer query "What happened in the 105th term?" --routing-mode heuristic
+indexer chat --routing-mode llm_router
 ```
 
-Use `--no-analyze` to make the default explicit:
+Use `--routing-mode off` to make the default explicit:
 
 ```powershell
-indexer query "What happened in the 105th term?" --no-analyze
-indexer chat --no-analyze
+indexer query "What happened in the 105th term?" --routing-mode off
+indexer chat --routing-mode off
 ```
 
 ## Retrieval Evaluation
@@ -50,12 +53,12 @@ indexer chat --no-analyze
 Run the checked-in retrieval golden set without answer generation:
 
 ```powershell
-uv run indexer eval run --golden-set eval/golden_questions.json --mode raw --output runs/baseline.json
+uv run indexer eval run --golden-set eval/golden_questions.json --routing-mode off --output runs/baseline.json
 ```
 
-Use `--mode raw-analyze` to compare analyzer-derived filters, or
-`--mode raw-rerank` to exercise the placeholder reranker metric surface. Until
-the reranker lands, reranker metrics are emitted as unavailable.
+Use `--routing-mode heuristic` to compare analyzer-derived filters, or
+`--routing-mode llm_router` to evaluate typed router dispatch. Until the
+reranker lands, reranker metrics are emitted as unavailable.
 
 ## Index Rebuilds
 

--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -22,7 +22,7 @@ from .database import (
 )
 from .eval.io import load_eval_run, stable_json
 from .eval.metrics import diff_runs
-from .eval.models import EvalMode
+from .eval.models import ROUTING_MODES, EvalMode
 from .eval.runner import run_eval_from_file
 from .glossary_candidates import (
     DEFAULT_GLOSSARY_CANDIDATE_FILE,
@@ -465,8 +465,8 @@ def extract_glossary_candidates_command(
 
 
 def _routing_mode(value: str) -> EvalMode:
-    if value not in {"off", "heuristic", "llm_router"}:
-        raise typer.BadParameter("routing mode must be one of: off, heuristic, llm_router")
+    if value not in ROUTING_MODES:
+        raise typer.BadParameter(f"routing mode must be one of: {', '.join(ROUTING_MODES)}")
     return cast(EvalMode, value)
 
 

--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -55,7 +55,7 @@ from .indexer.source_store import SourceRecordStore
 from .indexer.summarizer import SUMMARIZATION_PROMPT_VERSION, HierarchicalSummarizer
 from .lexical import LexicalIndex, get_lexical_db_path, glossary_alias_groups
 from .models.story import StoryNode
-from .query.engine import RetrievalConfig, StoryQueryEngine
+from .query.engine import INSUFFICIENT_SOURCE_CONTEXT, RetrievalConfig, StoryQueryEngine
 from .story_order import StoryOrder, default_story_order, load_story_order
 from .summary_export import (
     DEFAULT_PRODUCTION_READER_SOURCE,
@@ -68,6 +68,42 @@ app = typer.Typer()
 eval_app = typer.Typer(help="Run and compare retrieval evaluation harness outputs.")
 app.add_typer(eval_app, name="eval")
 console = Console()
+
+
+def _router_debug_lines(metadata: dict[str, Any]) -> list[str]:
+    fields = [
+        ("model", metadata.get("router_model")),
+        ("chosen_tool", metadata.get("chosen_tool")),
+        (
+            "args",
+            json.dumps(metadata.get("validated_args", {}), ensure_ascii=False, sort_keys=True),
+        ),
+        ("fallback_used", metadata.get("fallback_used")),
+        ("fallback_reason", metadata.get("fallback_reason")),
+    ]
+    lines = ["[bold cyan]Router:[/bold cyan]"]
+    lines.extend(f"  {name}: {value}" for name, value in fields)
+    validation_errors = metadata.get("validation_errors")
+    if validation_errors:
+        lines.append(
+            "  validation_errors: "
+            + json.dumps(validation_errors, ensure_ascii=False, sort_keys=True)
+        )
+    raw_output = metadata.get("raw_structured_model_output")
+    if raw_output is not None:
+        lines.append(
+            "  raw_output: " + json.dumps(raw_output, ensure_ascii=False, sort_keys=True)
+        )
+    return lines
+
+
+def _print_router_debug(engine: StoryQueryEngine, question: str) -> str:
+    trace = engine.retrieve_with_trace(question, answer_mode=True)
+    router_stage = trace.stages.get("router")
+    if router_stage is not None:
+        for line in _router_debug_lines(router_stage.metadata):
+            console.print(line)
+    return trace.answer_text or INSUFFICIENT_SOURCE_CONTEXT
 
 
 def _node_id(node: StoryNode) -> str:
@@ -305,30 +341,47 @@ def hello():
 @app.command()
 def query(
     question: str,
-    analyze: bool = typer.Option(
+    routing_mode: str = typer.Option(
+        "off",
+        "--routing-mode",
+        help="Routing mode: off, heuristic, or llm_router.",
+    ),
+    show_router: bool = typer.Option(
         False,
-        "--analyze/--no-analyze",
-        help="Enable analyzer-derived filters and structured query helpers.",
+        "--show-router/--hide-router",
+        help="Print the llm_router structured decision and validation metadata.",
     ),
 ):
     """Answers a question based on the RAG index and State Ledger."""
+    mode = _routing_mode(routing_mode)
     initialize_settings()
-    engine = StoryQueryEngine(retrieval_config=RetrievalConfig(enable_query_analysis=analyze))
+    engine = StoryQueryEngine(retrieval_config=RetrievalConfig(routing_mode=mode))
     console.print(f"\n[bold blue]Question:[/bold blue] {question}")
-    answer = engine.query(question)
+    if show_router and mode == "llm_router":
+        answer = _print_router_debug(engine, question)
+    else:
+        if show_router:
+            console.print("[yellow]--show-router only applies with --routing-mode llm_router.[/yellow]")
+        answer = engine.query(question)
     console.print(f"\n[bold green]Answer:[/bold green]\n{answer}\n")
 
 @app.command()
 def chat(
-    analyze: bool = typer.Option(
+    routing_mode: str = typer.Option(
+        "off",
+        "--routing-mode",
+        help="Routing mode: off, heuristic, or llm_router.",
+    ),
+    show_router: bool = typer.Option(
         False,
-        "--analyze/--no-analyze",
-        help="Enable analyzer-derived filters and structured query helpers.",
+        "--show-router/--hide-router",
+        help="Print the llm_router structured decision and validation metadata for each turn.",
     ),
 ):
     """Starts an interactive chat session with the RAG index."""
+    mode = _routing_mode(routing_mode)
     initialize_settings()
-    engine = StoryQueryEngine(retrieval_config=RetrievalConfig(enable_query_analysis=analyze))
+    engine = StoryQueryEngine(retrieval_config=RetrievalConfig(routing_mode=mode))
     console.print("[bold green]Interactive Chat Started! Type 'exit' or 'quit' to end.[/bold green]")
     
     while True:
@@ -340,7 +393,12 @@ def chat(
                 continue
                 
             console.print("\n[dim]Thinking...[/dim]")
-            answer = engine.query(question)
+            if show_router and mode == "llm_router":
+                answer = _print_router_debug(engine, question)
+            else:
+                if show_router:
+                    console.print("[yellow]--show-router only applies with --routing-mode llm_router.[/yellow]")
+                answer = engine.query(question)
             console.print(f"\n[bold green]Answer:[/bold green]\n{answer}\n")
         except (KeyboardInterrupt, EOFError):
             break
@@ -406,9 +464,9 @@ def extract_glossary_candidates_command(
         console.print(f"By category: {count_summary}")
 
 
-def _eval_mode(value: str) -> EvalMode:
-    if value not in {"raw", "raw-analyze", "raw-rerank"}:
-        raise typer.BadParameter("mode must be one of: raw, raw-analyze, raw-rerank")
+def _routing_mode(value: str) -> EvalMode:
+    if value not in {"off", "heuristic", "llm_router"}:
+        raise typer.BadParameter("routing mode must be one of: off, heuristic, llm_router")
     return cast(EvalMode, value)
 
 
@@ -419,10 +477,10 @@ def eval_run_command(
         "--golden-set",
         help="Path to the golden question set JSON.",
     ),
-    mode: str = typer.Option(
-        "raw",
-        "--mode",
-        help="Evaluation mode: raw, raw-analyze, or raw-rerank.",
+    routing_mode: str = typer.Option(
+        "off",
+        "--routing-mode",
+        help="Routing mode: off, heuristic, or llm_router.",
     ),
     output: str | None = typer.Option(
         None,
@@ -449,7 +507,7 @@ def eval_run_command(
     try:
         run = run_eval_from_file(
             golden_set,
-            mode=_eval_mode(mode),
+            mode=_routing_mode(routing_mode),
             output_path=output,
             inspect_query_id=inspect_query_id,
             dump_traces_dir=dump_traces_dir,

--- a/src/linkura_story_indexer/database.py
+++ b/src/linkura_story_indexer/database.py
@@ -14,6 +14,7 @@ from pydantic_ai.providers.google import GoogleProvider
 load_dotenv()
 
 DEFAULT_CHAT_MODEL = "gemini-3-flash-preview"
+DEFAULT_ROUTER_MODEL = "gemini-3.1-flash-lite-preview"
 DEFAULT_GENERATION_PROVIDER = "google"
 DEFAULT_EMBEDDING_MODEL = "gemini-embedding-2"
 DEFAULT_CHROMA_DB_PATH = "./chroma_db"
@@ -61,6 +62,10 @@ def get_generation_provider_name() -> str:
 
 def get_generation_model_name() -> str:
     return os.getenv("LINKURA_INGEST_MODEL") or get_chat_model_name()
+
+
+def get_router_model_name() -> str:
+    return os.getenv("LINKURA_ROUTER_MODEL", DEFAULT_ROUTER_MODEL)
 
 
 def get_embedding_model_name() -> str:

--- a/src/linkura_story_indexer/eval/models.py
+++ b/src/linkura_story_indexer/eval/models.py
@@ -2,7 +2,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-EvalMode = Literal["raw", "raw-analyze", "raw-rerank"]
+RoutingMode = Literal["off", "heuristic", "llm_router"]
+EvalMode = RoutingMode
 CandidateKind = Literal["raw_span", "summary", "summary_section", "reranker"]
 StageName = Literal[
     "dense_raw",
@@ -15,6 +16,7 @@ StageName = Literal[
     "deterministic_ranking",
     "final_top_k",
     "reranker",
+    "router",
 ]
 NeighborProvenance = Literal["direct_hit", "neighbor_of"]
 
@@ -75,7 +77,7 @@ class GoldenSet(BaseModel):
 
 
 class RunConfig(BaseModel):
-    mode: EvalMode = "raw"
+    mode: EvalMode = "off"
     golden_set: str
     top_k: int = 8
     answer_mode: bool = False
@@ -108,12 +110,13 @@ class StageTrace(BaseModel):
     name: StageName
     candidates: list[CandidateTrace] | None = None
     unavailable_reason: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 class QueryTrace(BaseModel):
     query_id: str
     question: str
-    mode: EvalMode = "raw"
+    mode: EvalMode = "off"
     config: dict[str, Any] = Field(default_factory=dict)
     stages: dict[StageName, StageTrace]
     final_citation_labels: list[str] = Field(default_factory=list)

--- a/src/linkura_story_indexer/eval/models.py
+++ b/src/linkura_story_indexer/eval/models.py
@@ -1,10 +1,10 @@
-from typing import Any, Literal
+from typing import Any, Literal, cast, get_args
 
 from pydantic import BaseModel, Field, model_validator
 
 RoutingMode = Literal["off", "heuristic", "llm_router"]
 EvalMode = RoutingMode
-ROUTING_MODES = ("off", "heuristic", "llm_router")
+ROUTING_MODES = cast(tuple[RoutingMode, ...], get_args(RoutingMode))
 CandidateKind = Literal["raw_span", "summary", "summary_section", "reranker"]
 StageName = Literal[
     "dense_raw",

--- a/src/linkura_story_indexer/eval/models.py
+++ b/src/linkura_story_indexer/eval/models.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field, model_validator
 
 RoutingMode = Literal["off", "heuristic", "llm_router"]
 EvalMode = RoutingMode
+ROUTING_MODES = ("off", "heuristic", "llm_router")
 CandidateKind = Literal["raw_span", "summary", "summary_section", "reranker"]
 StageName = Literal[
     "dense_raw",

--- a/src/linkura_story_indexer/eval/runner.py
+++ b/src/linkura_story_indexer/eval/runner.py
@@ -22,14 +22,12 @@ def run_eval(
     golden_set: GoldenSet,
     *,
     golden_set_path: str,
-    mode: EvalMode = "raw",
+    mode: EvalMode = "off",
     engine: TraceEngine | None = None,
     answer_mode: bool = False,
 ) -> EvalRun:
     if engine is None:
-        engine = StoryQueryEngine(
-            retrieval_config=RetrievalConfig(enable_query_analysis=mode == "raw-analyze")
-        )
+        engine = StoryQueryEngine(retrieval_config=RetrievalConfig(routing_mode=mode))
 
     traces = [
         engine.retrieve_with_trace(
@@ -49,7 +47,7 @@ def run_eval(
             mode=mode,
             golden_set=golden_set_path,
             answer_mode=answer_mode,
-            reranker_enabled=mode == "raw-rerank",
+            reranker_enabled=False,
         ),
         aggregate_metrics=aggregate_metrics(query_metrics, traces),
         query_metrics=query_metrics,
@@ -60,7 +58,7 @@ def run_eval(
 def run_eval_from_file(
     golden_set_path: str | Path,
     *,
-    mode: EvalMode = "raw",
+    mode: EvalMode = "off",
     output_path: str | Path | None = None,
     inspect_query_id: str | None = None,
     dump_traces_dir: str | Path | None = None,

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -3,7 +3,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from ..console import safe_print
 from ..database import RETRIEVAL_QUERY, create_text_agent, embed_texts, get_chroma_collection
@@ -54,7 +54,7 @@ class RetrievalConfig:
     max_ranked_candidates: int = MAX_RANKED_CANDIDATES
     final_top_k: int = FINAL_TOP_K
     rrf_k: int = RRF_K
-    enable_query_analysis: bool = False
+    routing_mode: Literal["off", "heuristic", "llm_router"] = "off"
 
     def __post_init__(self) -> None:
         if self.routing_candidate_count < 1:
@@ -71,6 +71,8 @@ class RetrievalConfig:
             raise ValueError(f"final_top_k must be between {MIN_FINAL_TOP_K} and {MAX_FINAL_TOP_K}")
         if self.rrf_k < 1:
             raise ValueError("rrf_k must be at least 1")
+        if self.routing_mode not in {"off", "heuristic", "llm_router"}:
+            raise ValueError("routing_mode must be one of: off, heuristic, llm_router")
 
 
 DEFAULT_RETRIEVAL_CONFIG = RetrievalConfig()
@@ -88,11 +90,13 @@ class StoryQueryEngine:
         state_file: str = "world_state.json",
         glossary_file: str = "glossary.json",
         retrieval_config: RetrievalConfig | None = None,
+        query_router: Any | None = None,
     ):
         self.collection = get_chroma_collection()
         self.lexical_index = LexicalIndex()
         self.source_store: Any = SourceRecordStore()
         self.retrieval_config = retrieval_config or DEFAULT_RETRIEVAL_CONFIG
+        self.query_router = query_router
 
         self.state_ledger: dict[str, Any] = {}
         if os.path.exists(state_file):
@@ -1269,11 +1273,13 @@ class StoryQueryEngine:
         name: StageName,
         candidates: list[CandidateTrace] | None,
         unavailable_reason: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> StageTrace:
         return StageTrace(
             name=name,
             candidates=candidates,
             unavailable_reason=unavailable_reason,
+            metadata=metadata or {},
         )
 
     def _neighbor_trace_provenance(
@@ -1646,17 +1652,94 @@ class StoryQueryEngine:
         )
         return RetrievalTraceResult(nodes=summary_nodes, stages=stages)
 
+    def _get_query_router(self) -> Any:
+        router = getattr(self, "query_router", None)
+        if router is None:
+            from .router import QueryRouter
+
+            router = QueryRouter()
+            self.query_router = router
+        return router
+
+    def _trace_candidate_from_tool_candidate(
+        self,
+        candidate: Any,
+    ) -> CandidateTrace:
+        metadata = dict(candidate.metadata)
+        text = str(candidate.text)
+        return CandidateTrace(
+            node_id=self._trace_node_id(text, metadata) if metadata else f"tool:{candidate.rank}",
+            rank=int(candidate.rank),
+            candidate_kind="raw_span" if metadata.get("summary_level") == 4 else "summary",
+            text=text,
+            metadata=metadata,
+            source_span=candidate.source_identity,
+        )
+
+    def _router_dispatch_with_trace(self, question: str) -> tuple[list[Node], dict[StageName, StageTrace]]:
+        dispatch = self._get_query_router().route_and_dispatch(
+            self,
+            question,
+            final_top_k=self._config().final_top_k,
+        )
+        tool_result = dispatch.tool_result
+        stages: dict[StageName, StageTrace] = {
+            "router": self._trace_stage(
+                "router",
+                None,
+                metadata={
+                    **dispatch.decision.metadata(),
+                    "tool_warnings": tool_result.warnings,
+                    "tool_errors": tool_result.errors,
+                    "tool_metadata": tool_result.metadata,
+                },
+            )
+        }
+        stages.update(tool_result.trace_stages)  # type: ignore[arg-type]
+
+        final_candidates = [
+            self._trace_candidate_from_tool_candidate(candidate)
+            for candidate in tool_result.candidates
+        ]
+        if "final_top_k" not in stages:
+            stages["final_top_k"] = self._trace_stage("final_top_k", final_candidates)
+
+        nodes = [
+            (candidate.text, dict(candidate.metadata))
+            for candidate in tool_result.candidates
+            if candidate.metadata
+        ]
+        return nodes, stages
+
     def retrieve_with_trace(
         self,
         question: str,
         *,
         query_id: str = "ad-hoc",
-        mode: EvalMode = "raw",
+        mode: EvalMode = "off",
         answer_mode: bool = False,
     ) -> QueryTrace:
         """Executes the raw-first retrieval flow and returns deterministic stage traces."""
+        effective_mode: EvalMode = mode if mode != "off" else self._config().routing_mode
+        if effective_mode == "llm_router":
+            final_nodes, stages = self._router_dispatch_with_trace(question)
+            answer_text = None
+            if answer_mode and final_nodes:
+                answer_text = self._answer_from_raw_evidence(question, final_nodes, None)
+            return QueryTrace(
+                query_id=query_id,
+                question=question,
+                mode=effective_mode,
+                config=self._config().__dict__,
+                stages=stages,
+                final_citation_labels=[
+                    self._citation_label(metadata) for _, metadata in final_nodes
+                ],
+                answer_text=answer_text,
+            )
+
         analysis = None
-        if mode == "raw-analyze" or self._config().enable_query_analysis:
+        if effective_mode == "heuristic":
             analysis = analyze_query(question, self.glossary)
         retrieval = self.retrieve_raw_nodes_with_trace(question, analysis=analysis)
         final_raw_nodes = retrieval.nodes
@@ -1668,7 +1751,7 @@ class StoryQueryEngine:
         return QueryTrace(
             query_id=query_id,
             question=question,
-            mode=mode,
+            mode=effective_mode,
             config=self._config().__dict__,
             stages=retrieval.stages,
             final_citation_labels=[
@@ -1679,9 +1762,17 @@ class StoryQueryEngine:
 
     def query(self, question: str) -> str:
         """Executes the raw-first RAG query flow."""
+        if self._config().routing_mode == "llm_router":
+            safe_print("Routing query to a typed retrieval tool...")
+            final_nodes, _ = self._router_dispatch_with_trace(question)
+            if not final_nodes:
+                return INSUFFICIENT_SOURCE_CONTEXT
+            safe_print("Building answer context from routed source evidence...")
+            return self._answer_from_raw_evidence(question, final_nodes, None)
+
         safe_print("Searching raw source evidence...")
         analysis = None
-        if self._config().enable_query_analysis:
+        if self._config().routing_mode == "heuristic":
             analysis = analyze_query(question, self.glossary)
             structured_answer = self._structured_answer(question, analysis)
             if structured_answer is not None:

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -3,11 +3,12 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from ..console import safe_print
 from ..database import RETRIEVAL_QUERY, create_text_agent, embed_texts, get_chroma_collection
 from ..eval.models import (
+    ROUTING_MODES,
     CandidateScores,
     CandidateTrace,
     EvalMode,
@@ -27,6 +28,9 @@ from .analysis import (
     QueryAnalysis,
     analyze_query,
 )
+
+if TYPE_CHECKING:
+    from .router import QueryRouter
 
 ROUTING_CANDIDATE_COUNT = 20
 RAW_CANDIDATE_COUNT = 40
@@ -71,8 +75,8 @@ class RetrievalConfig:
             raise ValueError(f"final_top_k must be between {MIN_FINAL_TOP_K} and {MAX_FINAL_TOP_K}")
         if self.rrf_k < 1:
             raise ValueError("rrf_k must be at least 1")
-        if self.routing_mode not in {"off", "heuristic", "llm_router"}:
-            raise ValueError("routing_mode must be one of: off, heuristic, llm_router")
+        if self.routing_mode not in ROUTING_MODES:
+            raise ValueError(f"routing_mode must be one of: {', '.join(ROUTING_MODES)}")
 
 
 DEFAULT_RETRIEVAL_CONFIG = RetrievalConfig()
@@ -84,13 +88,20 @@ class RetrievalTraceResult:
     stages: dict[StageName, StageTrace]
 
 
+@dataclass(frozen=True)
+class RoutedTraceResult:
+    nodes: list[Node]
+    stages: dict[StageName, StageTrace]
+    direct_answer: str | None = None
+
+
 class StoryQueryEngine:
     def __init__(
         self,
         state_file: str = "world_state.json",
         glossary_file: str = "glossary.json",
         retrieval_config: RetrievalConfig | None = None,
-        query_router: Any | None = None,
+        query_router: "QueryRouter | None" = None,
     ):
         self.collection = get_chroma_collection()
         self.lexical_index = LexicalIndex()
@@ -1652,14 +1663,12 @@ class StoryQueryEngine:
         )
         return RetrievalTraceResult(nodes=summary_nodes, stages=stages)
 
-    def _get_query_router(self) -> Any:
-        router = getattr(self, "query_router", None)
-        if router is None:
+    def _get_query_router(self) -> "QueryRouter":
+        if self.query_router is None:
             from .router import QueryRouter
 
-            router = QueryRouter()
-            self.query_router = router
-        return router
+            self.query_router = QueryRouter()
+        return self.query_router
 
     def _trace_candidate_from_tool_candidate(
         self,
@@ -1676,7 +1685,7 @@ class StoryQueryEngine:
             source_span=candidate.source_identity,
         )
 
-    def _router_dispatch_with_trace(self, question: str) -> tuple[list[Node], dict[StageName, StageTrace]]:
+    def _router_dispatch_with_trace(self, question: str) -> RoutedTraceResult:
         dispatch = self._get_query_router().route_and_dispatch(
             self,
             question,
@@ -1695,7 +1704,7 @@ class StoryQueryEngine:
                 },
             )
         }
-        stages.update(tool_result.trace_stages)  # type: ignore[arg-type]
+        stages.update(tool_result.trace_stages)
 
         final_candidates = [
             self._trace_candidate_from_tool_candidate(candidate)
@@ -1709,31 +1718,52 @@ class StoryQueryEngine:
             for candidate in tool_result.candidates
             if candidate.metadata
         ]
-        return nodes, stages
+        direct_answer = tool_result.metadata.get("direct_answer")
+        return RoutedTraceResult(
+            nodes=nodes,
+            stages=stages,
+            direct_answer=direct_answer if isinstance(direct_answer, str) else None,
+        )
+
+    def _router_unavailable_message(self, stages: dict[StageName, StageTrace]) -> str:
+        router_stage = stages.get("router")
+        metadata = router_stage.metadata if router_stage is not None else {}
+        tool_errors = metadata.get("tool_errors")
+        if isinstance(tool_errors, list) and tool_errors:
+            return f"{INSUFFICIENT_SOURCE_CONTEXT} Tool error: {tool_errors[0]}"
+        tool_warnings = metadata.get("tool_warnings")
+        if isinstance(tool_warnings, list) and tool_warnings:
+            return f"{INSUFFICIENT_SOURCE_CONTEXT} Tool warning: {tool_warnings[0]}"
+        return INSUFFICIENT_SOURCE_CONTEXT
 
     def retrieve_with_trace(
         self,
         question: str,
         *,
         query_id: str = "ad-hoc",
-        mode: EvalMode = "off",
+        mode: EvalMode | None = None,
         answer_mode: bool = False,
     ) -> QueryTrace:
         """Executes the raw-first retrieval flow and returns deterministic stage traces."""
-        effective_mode: EvalMode = mode if mode != "off" else self._config().routing_mode
+        effective_mode: EvalMode = mode if mode is not None else self._config().routing_mode
         if effective_mode == "llm_router":
-            final_nodes, stages = self._router_dispatch_with_trace(question)
+            routed = self._router_dispatch_with_trace(question)
             answer_text = None
-            if answer_mode and final_nodes:
-                answer_text = self._answer_from_raw_evidence(question, final_nodes, None)
+            if answer_mode:
+                if routed.direct_answer is not None:
+                    answer_text = routed.direct_answer
+                elif routed.nodes:
+                    answer_text = self._answer_from_raw_evidence(question, routed.nodes, None)
+                else:
+                    answer_text = self._router_unavailable_message(routed.stages)
             return QueryTrace(
                 query_id=query_id,
                 question=question,
                 mode=effective_mode,
                 config=self._config().__dict__,
-                stages=stages,
+                stages=routed.stages,
                 final_citation_labels=[
-                    self._citation_label(metadata) for _, metadata in final_nodes
+                    self._citation_label(metadata) for _, metadata in routed.nodes
                 ],
                 answer_text=answer_text,
             )
@@ -1764,11 +1794,13 @@ class StoryQueryEngine:
         """Executes the raw-first RAG query flow."""
         if self._config().routing_mode == "llm_router":
             safe_print("Routing query to a typed retrieval tool...")
-            final_nodes, _ = self._router_dispatch_with_trace(question)
-            if not final_nodes:
-                return INSUFFICIENT_SOURCE_CONTEXT
+            routed = self._router_dispatch_with_trace(question)
+            if routed.direct_answer is not None:
+                return routed.direct_answer
+            if not routed.nodes:
+                return self._router_unavailable_message(routed.stages)
             safe_print("Building answer context from routed source evidence...")
-            return self._answer_from_raw_evidence(question, final_nodes, None)
+            return self._answer_from_raw_evidence(question, routed.nodes, None)
 
         safe_print("Searching raw source evidence...")
         analysis = None

--- a/src/linkura_story_indexer/query/router.py
+++ b/src/linkura_story_indexer/query/router.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError
+from pydantic_ai import Agent
+
+from linkura_story_indexer.database import create_google_model, get_router_model_name
+from linkura_story_indexer.query.tools import (
+    QUERY_TOOL_REGISTRY,
+    SearchRawInput,
+    ToolResult,
+)
+
+
+class RouterOutput(BaseModel):
+    tool_name: str = Field(..., min_length=1)
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RouterDecision:
+    tool_name: str
+    validated_args: BaseModel
+    raw_output: dict[str, Any] | None
+    fallback_used: bool
+    fallback_reason: str | None
+    router_model: str
+    validation_errors: list[str]
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "chosen_tool": self.tool_name,
+            "validated_args": self.validated_args.model_dump(mode="json"),
+            "raw_structured_model_output": self.raw_output,
+            "fallback_used": self.fallback_used,
+            "fallback_reason": self.fallback_reason,
+            "router_model": self.router_model,
+            "validation_errors": self.validation_errors,
+        }
+
+
+@dataclass(frozen=True)
+class RouterDispatchResult:
+    decision: RouterDecision
+    tool_result: ToolResult
+
+
+def _fallback_decision(
+    question: str,
+    *,
+    final_top_k: int,
+    router_model: str,
+    raw_output: dict[str, Any] | None,
+    reason: str,
+    validation_errors: list[str],
+) -> RouterDecision:
+    return RouterDecision(
+        tool_name="search_raw",
+        validated_args=SearchRawInput(query=question, top_k=final_top_k),
+        raw_output=raw_output,
+        fallback_used=True,
+        fallback_reason=reason,
+        router_model=router_model,
+        validation_errors=validation_errors,
+    )
+
+
+def _raw_output(output: RouterOutput | None) -> dict[str, Any] | None:
+    if output is None:
+        return None
+    return output.model_dump(mode="json")
+
+
+def validate_router_output(
+    output: RouterOutput,
+    *,
+    question: str,
+    final_top_k: int,
+    router_model: str | None = None,
+) -> RouterDecision:
+    model_name = router_model or get_router_model_name()
+    raw_output = _raw_output(output)
+    spec = QUERY_TOOL_REGISTRY.get(output.tool_name)
+    if spec is None:
+        return _fallback_decision(
+            question,
+            final_top_k=final_top_k,
+            router_model=model_name,
+            raw_output=raw_output,
+            reason="unknown tool name",
+            validation_errors=[f"unknown tool name: {output.tool_name}"],
+        )
+
+    try:
+        validated_args = spec.input_model.model_validate(output.args)
+    except ValidationError as exc:
+        return _fallback_decision(
+            question,
+            final_top_k=final_top_k,
+            router_model=model_name,
+            raw_output=raw_output,
+            reason="invalid tool arguments",
+            validation_errors=[str(exc)],
+        )
+
+    return RouterDecision(
+        tool_name=spec.name,
+        validated_args=validated_args,
+        raw_output=raw_output,
+        fallback_used=False,
+        fallback_reason=None,
+        router_model=model_name,
+        validation_errors=[],
+    )
+
+
+def _tool_catalog() -> str:
+    entries = []
+    for spec in QUERY_TOOL_REGISTRY.values():
+        entries.append(
+            {
+                "name": spec.name,
+                "description": spec.description,
+                "args_schema": spec.input_model.model_json_schema(),
+            }
+        )
+    return json.dumps(entries, ensure_ascii=False, indent=2)
+
+
+def _episode_number(episode_name: Any) -> int | None:
+    match = re.search(r"第(\d+)話", str(episode_name))
+    return int(match.group(1)) if match else None
+
+
+def _compressed_numbers(values: set[int]) -> str:
+    numbers = sorted(values)
+    if not numbers:
+        return "none"
+
+    ranges = []
+    start = numbers[0]
+    previous = numbers[0]
+    for number in numbers[1:]:
+        if number == previous + 1:
+            previous = number
+            continue
+        ranges.append(f"{start}" if start == previous else f"{start}-{previous}")
+        start = number
+        previous = number
+    ranges.append(f"{start}" if start == previous else f"{start}-{previous}")
+    return ", ".join(ranges)
+
+
+def _story_location_catalog(engine: Any | None) -> str:
+    source_store = getattr(engine, "source_store", None)
+    iter_scenes = getattr(source_store, "iter_scenes", None)
+    if not callable(iter_scenes):
+        return "Available numbered episodes by arc are unavailable."
+
+    episodes_by_arc: dict[tuple[str, str], set[int]] = {}
+    try:
+        scenes = iter_scenes()
+    except Exception as exc:
+        return f"Available numbered episodes by arc are unavailable: {exc}"
+    if not isinstance(scenes, list):
+        return "Available numbered episodes by arc are unavailable."
+
+    for scene in scenes:
+        metadata = scene.get("metadata") if isinstance(scene, dict) else None
+        if not isinstance(metadata, dict):
+            continue
+        arc_id = metadata.get("arc_id")
+        story_type = metadata.get("story_type")
+        episode = _episode_number(metadata.get("episode_name"))
+        if not isinstance(arc_id, str) or not isinstance(story_type, str) or episode is None:
+            continue
+        episodes_by_arc.setdefault((arc_id, story_type), set()).add(episode)
+
+    if not episodes_by_arc:
+        return "Available numbered episodes by arc are unavailable."
+
+    lines = [
+        "Available numbered episodes by arc/story type. Treat chapter and episode as synonyms "
+        "for numbered main story entries:"
+    ]
+    for (arc_id, story_type), episodes in sorted(episodes_by_arc.items()):
+        lines.append(f"- arc_id={arc_id}, story_type={story_type}: episodes {_compressed_numbers(episodes)}")
+    lines.append(
+        "When the arc is known, only pass an episode filter if the requested episode appears "
+        "in this catalog. If the user asks for an unavailable episode, keep the original "
+        "episode wording in query and use broader search_raw filters such as arc_id only."
+    )
+    return "\n".join(lines)
+
+
+def _router_instructions(engine: Any | None = None) -> str:
+    return (
+        "Select exactly one query tool for the user's question. "
+        "Return only the tool name and arguments matching that tool's schema. "
+        "Do not invent tools.\n\n"
+        "Default to search_raw for normal story questions, especially questions that ask "
+        "what happened, how something happened, who said, did, knew, or felt something, "
+        "where evidence comes from, or anything requiring citations. Use search_raw when "
+        "exact evidence, dialogue, speaker-specific facts, or scene-level details are "
+        "needed.\n\n"
+        "Story location hints: phrases like '104th term', '104 term', or 'Year 104' map "
+        "to arc_id='104'. Phrases like 'episode 1', 'ep 1', or '第1話' map to episode=1. "
+        "If the question gives an arc or term and episode but does not provide both "
+        "file_path and zero-based scene_index, use search_raw with arc_id and episode "
+        "filters.\n\n"
+        "Use search_summaries only for broad recap or overview questions where exact "
+        "source evidence is less important. Use get_scene only when both file_path and "
+        "zero-based scene_index are explicitly known from the user or a previous retrieved "
+        "result. Use lookup_glossary only for direct glossary, translation, or term "
+        "resolution questions, not when a glossary term appears inside a broader story "
+        "question.\n\n"
+        "Examples:\n"
+        "Question: how did Kosuzu join the school idol club at episode 1 of the 104th term\n"
+        "Output: tool_name='search_raw', args={'query':'how did Kosuzu join the school "
+        "idol club','arc_id':'104','episode':1,'top_k':8}\n"
+        "Question: summarize the 104th term\n"
+        "Output: tool_name='search_summaries', args={'query':'summarize the 104th "
+        "term','arc_id':'104','summary_level':1,'top_k':8}\n"
+        "Question: resolve the glossary term 日野下花帆\n"
+        "Output: tool_name='lookup_glossary', args={'term':'日野下花帆'}\n\n"
+        f"{_story_location_catalog(engine)}\n\n"
+        f"Registered tools:\n{_tool_catalog()}"
+    )
+
+
+class QueryRouter:
+    def __init__(self, model_name: str | None = None) -> None:
+        self.model_name = model_name or get_router_model_name()
+
+    def _run_model(
+        self,
+        question: str,
+        *,
+        final_top_k: int,
+        engine: Any | None = None,
+    ) -> RouterOutput:
+        agent: Agent[None, RouterOutput] = Agent(
+            create_google_model(self.model_name),
+            output_type=RouterOutput,
+            instructions=_router_instructions(engine),
+        )
+        result = agent.run_sync(
+            json.dumps(
+                {"question": question, "default_top_k": final_top_k},
+                ensure_ascii=False,
+            )
+        )
+        return result.output
+
+    def route(
+        self,
+        question: str,
+        *,
+        final_top_k: int,
+        engine: Any | None = None,
+    ) -> RouterDecision:
+        try:
+            output = self._run_model(question, final_top_k=final_top_k, engine=engine)
+        except Exception as exc:
+            return _fallback_decision(
+                question,
+                final_top_k=final_top_k,
+                router_model=self.model_name,
+                raw_output=None,
+                reason="router model failure",
+                validation_errors=[str(exc)],
+            )
+        return validate_router_output(
+            output,
+            question=question,
+            final_top_k=final_top_k,
+            router_model=self.model_name,
+        )
+
+    def route_and_dispatch(
+        self,
+        engine: Any,
+        question: str,
+        *,
+        final_top_k: int,
+    ) -> RouterDispatchResult:
+        decision = self.route(question, final_top_k=final_top_k, engine=engine)
+        spec = QUERY_TOOL_REGISTRY[decision.tool_name]
+        try:
+            result = spec.dispatcher(engine, decision.validated_args)
+        except Exception as exc:
+            decision = _fallback_decision(
+                question,
+                final_top_k=final_top_k,
+                router_model=self.model_name,
+                raw_output=decision.raw_output,
+                reason="tool dispatch failure",
+                validation_errors=[*decision.validation_errors, str(exc)],
+            )
+            spec = QUERY_TOOL_REGISTRY[decision.tool_name]
+            result = spec.dispatcher(engine, decision.validated_args)
+
+        if isinstance(result, ToolResult):
+            return RouterDispatchResult(decision=decision, tool_result=result)
+        return RouterDispatchResult(
+            decision=decision,
+            tool_result=ToolResult(metadata={"tool_output": result.model_dump(mode="json")}),
+        )
+
+
+class FixtureQueryRouter(QueryRouter):
+    def __init__(
+        self,
+        tool_name: str = "search_raw",
+        args: dict[str, Any] | None = None,
+        *,
+        model_name: str = "fixture-router",
+        error: Exception | None = None,
+    ) -> None:
+        self.model_name = model_name
+        self._output = RouterOutput(tool_name=tool_name, args=args or {})
+        self._error = error
+
+    def _run_model(
+        self,
+        question: str,
+        *,
+        final_top_k: int,
+        engine: Any | None = None,
+    ) -> RouterOutput:
+        if self._error is not None:
+            raise self._error
+        return self._output

--- a/src/linkura_story_indexer/query/router.py
+++ b/src/linkura_story_indexer/query/router.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-import re
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any
 
 from pydantic import BaseModel, Field, ValidationError
@@ -75,6 +75,10 @@ def _raw_output(output: RouterOutput | None) -> dict[str, Any] | None:
     return output.model_dump(mode="json")
 
 
+def _validation_error_text(exc: ValidationError) -> str:
+    return str(exc)
+
+
 def validate_router_output(
     output: RouterOutput,
     *,
@@ -104,7 +108,7 @@ def validate_router_output(
             router_model=model_name,
             raw_output=raw_output,
             reason="invalid tool arguments",
-            validation_errors=[str(exc)],
+            validation_errors=[_validation_error_text(exc)],
         )
 
     return RouterDecision(
@@ -118,6 +122,7 @@ def validate_router_output(
     )
 
 
+@lru_cache(maxsize=1)
 def _tool_catalog() -> str:
     entries = []
     for spec in QUERY_TOOL_REGISTRY.values():
@@ -129,11 +134,6 @@ def _tool_catalog() -> str:
             }
         )
     return json.dumps(entries, ensure_ascii=False, indent=2)
-
-
-def _episode_number(episode_name: Any) -> int | None:
-    match = re.search(r"第(\d+)話", str(episode_name))
-    return int(match.group(1)) if match else None
 
 
 def _compressed_numbers(values: set[int]) -> str:
@@ -156,27 +156,25 @@ def _compressed_numbers(values: set[int]) -> str:
 
 
 def _story_location_catalog(engine: Any | None) -> str:
-    source_store = getattr(engine, "source_store", None)
-    iter_scenes = getattr(source_store, "iter_scenes", None)
-    if not callable(iter_scenes):
+    if engine is None:
         return "Available numbered episodes by arc are unavailable."
 
+    cached = getattr(engine, "_router_story_location_catalog", None)
+    if isinstance(cached, str):
+        return cached
+
+    source_store = engine.source_store
     episodes_by_arc: dict[tuple[str, str], set[int]] = {}
-    try:
-        scenes = iter_scenes()
-    except Exception as exc:
-        return f"Available numbered episodes by arc are unavailable: {exc}"
-    if not isinstance(scenes, list):
-        return "Available numbered episodes by arc are unavailable."
-
-    for scene in scenes:
+    for scene in source_store.iter_scenes():
         metadata = scene.get("metadata") if isinstance(scene, dict) else None
         if not isinstance(metadata, dict):
             continue
         arc_id = metadata.get("arc_id")
         story_type = metadata.get("story_type")
-        episode = _episode_number(metadata.get("episode_name"))
+        episode = metadata.get("episode_number")
         if not isinstance(arc_id, str) or not isinstance(story_type, str) or episode is None:
+            continue
+        if not isinstance(episode, int):
             continue
         episodes_by_arc.setdefault((arc_id, story_type), set()).add(episode)
 
@@ -194,7 +192,9 @@ def _story_location_catalog(engine: Any | None) -> str:
         "in this catalog. If the user asks for an unavailable episode, keep the original "
         "episode wording in query and use broader search_raw filters such as arc_id only."
     )
-    return "\n".join(lines)
+    catalog = "\n".join(lines)
+    setattr(engine, "_router_story_location_catalog", catalog)
+    return catalog
 
 
 def _router_instructions(engine: Any | None = None) -> str:
@@ -293,23 +293,31 @@ class QueryRouter:
         try:
             result = spec.dispatcher(engine, decision.validated_args)
         except Exception as exc:
+            first_error = str(exc)
             decision = _fallback_decision(
                 question,
                 final_top_k=final_top_k,
                 router_model=self.model_name,
                 raw_output=decision.raw_output,
                 reason="tool dispatch failure",
-                validation_errors=[*decision.validation_errors, str(exc)],
+                validation_errors=[*decision.validation_errors, first_error],
             )
             spec = QUERY_TOOL_REGISTRY[decision.tool_name]
-            result = spec.dispatcher(engine, decision.validated_args)
+            try:
+                result = spec.dispatcher(engine, decision.validated_args)
+            except Exception as fallback_exc:
+                return RouterDispatchResult(
+                    decision=decision,
+                    tool_result=ToolResult(
+                        errors=[
+                            f"fallback tool dispatch failed after {decision.fallback_reason}: "
+                            f"{fallback_exc}"
+                        ],
+                        metadata={"initial_dispatch_error": first_error},
+                    ),
+                )
 
-        if isinstance(result, ToolResult):
-            return RouterDispatchResult(decision=decision, tool_result=result)
-        return RouterDispatchResult(
-            decision=decision,
-            tool_result=ToolResult(metadata={"tool_output": result.model_dump(mode="json")}),
-        )
+        return RouterDispatchResult(decision=decision, tool_result=result)
 
 
 class FixtureQueryRouter(QueryRouter):

--- a/src/linkura_story_indexer/query/router.py
+++ b/src/linkura_story_indexer/query/router.py
@@ -49,6 +49,10 @@ class RouterDispatchResult:
     tool_result: ToolResult
 
 
+def _engine_cache_key(engine: Any | None) -> int | None:
+    return id(engine) if engine is not None else None
+
+
 def _fallback_decision(
     question: str,
     *,
@@ -73,10 +77,6 @@ def _raw_output(output: RouterOutput | None) -> dict[str, Any] | None:
     if output is None:
         return None
     return output.model_dump(mode="json")
-
-
-def _validation_error_text(exc: ValidationError) -> str:
-    return str(exc)
 
 
 def validate_router_output(
@@ -108,7 +108,7 @@ def validate_router_output(
             router_model=model_name,
             raw_output=raw_output,
             reason="invalid tool arguments",
-            validation_errors=[_validation_error_text(exc)],
+            validation_errors=[str(exc)],
         )
 
     return RouterDecision(
@@ -172,9 +172,7 @@ def _story_location_catalog(engine: Any | None) -> str:
         arc_id = metadata.get("arc_id")
         story_type = metadata.get("story_type")
         episode = metadata.get("episode_number")
-        if not isinstance(arc_id, str) or not isinstance(story_type, str) or episode is None:
-            continue
-        if not isinstance(episode, int):
+        if not isinstance(arc_id, str) or not isinstance(story_type, str) or not isinstance(episode, int):
             continue
         episodes_by_arc.setdefault((arc_id, story_type), set()).add(episode)
 
@@ -192,12 +190,10 @@ def _story_location_catalog(engine: Any | None) -> str:
         "in this catalog. If the user asks for an unavailable episode, keep the original "
         "episode wording in query and use broader search_raw filters such as arc_id only."
     )
-    catalog = "\n".join(lines)
-    setattr(engine, "_router_story_location_catalog", catalog)
-    return catalog
+    return "\n".join(lines)
 
 
-def _router_instructions(engine: Any | None = None) -> str:
+def _router_instructions_from_catalog(story_location_catalog: str) -> str:
     return (
         "Select exactly one query tool for the user's question. "
         "Return only the tool name and arguments matching that tool's schema. "
@@ -227,14 +223,28 @@ def _router_instructions(engine: Any | None = None) -> str:
         "term','arc_id':'104','summary_level':1,'top_k':8}\n"
         "Question: resolve the glossary term 日野下花帆\n"
         "Output: tool_name='lookup_glossary', args={'term':'日野下花帆'}\n\n"
-        f"{_story_location_catalog(engine)}\n\n"
+        f"{story_location_catalog}\n\n"
         f"Registered tools:\n{_tool_catalog()}"
     )
+
+
+def _router_instructions(engine: Any | None = None) -> str:
+    return _router_instructions_from_catalog(_story_location_catalog(engine))
 
 
 class QueryRouter:
     def __init__(self, model_name: str | None = None) -> None:
         self.model_name = model_name or get_router_model_name()
+        self._location_catalogs_by_engine_id: dict[int | None, str] = {}
+
+    def _story_location_catalog(self, engine: Any | None) -> str:
+        cache_key = _engine_cache_key(engine)
+        if cache_key not in self._location_catalogs_by_engine_id:
+            self._location_catalogs_by_engine_id[cache_key] = _story_location_catalog(engine)
+        return self._location_catalogs_by_engine_id[cache_key]
+
+    def _instructions(self, engine: Any | None) -> str:
+        return _router_instructions_from_catalog(self._story_location_catalog(engine))
 
     def _run_model(
         self,
@@ -246,7 +256,7 @@ class QueryRouter:
         agent: Agent[None, RouterOutput] = Agent(
             create_google_model(self.model_name),
             output_type=RouterOutput,
-            instructions=_router_instructions(engine),
+            instructions=self._instructions(engine),
         )
         result = agent.run_sync(
             json.dumps(

--- a/src/linkura_story_indexer/query/tools.py
+++ b/src/linkura_story_indexer/query/tools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 from pydantic import BaseModel, Field, model_validator
@@ -77,6 +78,17 @@ class GlossaryLookupResult(BaseModel):
     aliases: list[str] = Field(default_factory=list)
     match_type: Literal["canonical", "translation", "alias", "miss"] = "miss"
     errors: list[str] = Field(default_factory=list)
+
+
+QueryToolDispatcher = Callable[[StoryQueryEngine, BaseModel], BaseModel]
+
+
+@dataclass(frozen=True)
+class QueryToolSpec:
+    name: str
+    input_model: type[BaseModel]
+    dispatcher: QueryToolDispatcher
+    description: str
 
 
 def _candidate_from_node(
@@ -317,3 +329,56 @@ def build_query_toolset(engine: StoryQueryEngine) -> FunctionToolset:
     toolset.add_function(get_scene_tool, name="get_scene")
     toolset.add_function(lookup_glossary_tool, name="lookup_glossary")
     return toolset
+
+
+def _dispatch_search_raw(engine: StoryQueryEngine, args: BaseModel) -> ToolResult:
+    return search_raw(engine, cast(SearchRawInput, args))
+
+
+def _dispatch_search_summaries(engine: StoryQueryEngine, args: BaseModel) -> ToolResult:
+    return search_summaries(engine, cast(SearchSummariesInput, args))
+
+
+def _dispatch_get_scene(engine: StoryQueryEngine, args: BaseModel) -> ToolResult:
+    return get_scene(engine, cast(GetSceneInput, args))
+
+
+def _dispatch_lookup_glossary(engine: StoryQueryEngine, args: BaseModel) -> GlossaryLookupResult:
+    return lookup_glossary(engine, cast(LookupGlossaryInput, args))
+
+
+QUERY_TOOL_REGISTRY: dict[str, QueryToolSpec] = {
+    "search_raw": QueryToolSpec(
+        name="search_raw",
+        input_model=SearchRawInput,
+        dispatcher=_dispatch_search_raw,
+        description=(
+            "Search raw source scenes for exact evidence, dialogue, scene-level details, "
+            "and citation-backed answers."
+        ),
+    ),
+    "search_summaries": QueryToolSpec(
+        name="search_summaries",
+        input_model=SearchSummariesInput,
+        dispatcher=_dispatch_search_summaries,
+        description=(
+            "Search year, episode, or part summaries for broad narrative context rather "
+            "than exact source evidence."
+        ),
+    ),
+    "get_scene": QueryToolSpec(
+        name="get_scene",
+        input_model=GetSceneInput,
+        dispatcher=_dispatch_get_scene,
+        description="Fetch one exact raw source scene by file path and zero-based scene index.",
+    ),
+    "lookup_glossary": QueryToolSpec(
+        name="lookup_glossary",
+        input_model=LookupGlossaryInput,
+        dispatcher=_dispatch_lookup_glossary,
+        description=(
+            "Resolve a Japanese glossary term, English translation, or generated alias "
+            "without performing source retrieval."
+        ),
+    ),
+}

--- a/src/linkura_story_indexer/query/tools.py
+++ b/src/linkura_story_indexer/query/tools.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, cast
 from pydantic import BaseModel, Field, model_validator
 from pydantic_ai import FunctionToolset
 
-from linkura_story_indexer.eval.models import SourceIdentity, StageTrace
+from linkura_story_indexer.eval.models import SourceIdentity, StageName, StageTrace
 from linkura_story_indexer.lexical import glossary_aliases_for
 from linkura_story_indexer.query.engine import Node, StoryQueryEngine
 
@@ -65,7 +65,7 @@ class ToolCandidate(BaseModel):
 
 class ToolResult(BaseModel):
     candidates: list[ToolCandidate] = Field(default_factory=list)
-    trace_stages: dict[str, StageTrace] = Field(default_factory=dict)
+    trace_stages: dict[StageName, StageTrace] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
@@ -80,7 +80,7 @@ class GlossaryLookupResult(BaseModel):
     errors: list[str] = Field(default_factory=list)
 
 
-QueryToolDispatcher = Callable[[StoryQueryEngine, BaseModel], BaseModel]
+QueryToolDispatcher = Callable[[StoryQueryEngine, BaseModel], ToolResult]
 
 
 @dataclass(frozen=True)
@@ -173,8 +173,8 @@ def _summary_where(engine: StoryQueryEngine, args: SearchSummariesInput) -> dict
     return engine._and_where(filters)
 
 
-def _public_trace_stages(stages: dict[Any, StageTrace]) -> dict[str, StageTrace]:
-    return {str(name): stage for name, stage in stages.items()}
+def _public_trace_stages(stages: dict[StageName, StageTrace]) -> dict[StageName, StageTrace]:
+    return stages
 
 
 def search_raw(engine: StoryQueryEngine, args: SearchRawInput) -> ToolResult:
@@ -343,8 +343,26 @@ def _dispatch_get_scene(engine: StoryQueryEngine, args: BaseModel) -> ToolResult
     return get_scene(engine, cast(GetSceneInput, args))
 
 
-def _dispatch_lookup_glossary(engine: StoryQueryEngine, args: BaseModel) -> GlossaryLookupResult:
-    return lookup_glossary(engine, cast(LookupGlossaryInput, args))
+def _glossary_direct_answer(result: GlossaryLookupResult, term: str) -> str:
+    if result.errors:
+        return result.errors[0]
+    if result.canonical_term is None or result.translation is None:
+        return f"Glossary term not found: {term}"
+    aliases = ", ".join(result.aliases)
+    suffix = f" Aliases: {aliases}." if aliases else ""
+    return f"{result.canonical_term} translates to {result.translation}.{suffix}"
+
+
+def _dispatch_lookup_glossary(engine: StoryQueryEngine, args: BaseModel) -> ToolResult:
+    typed_args = cast(LookupGlossaryInput, args)
+    result = lookup_glossary(engine, typed_args)
+    return ToolResult(
+        errors=result.errors,
+        metadata={
+            "tool_output": result.model_dump(mode="json"),
+            "direct_answer": _glossary_direct_answer(result, typed_args.term),
+        },
+    )
 
 
 QUERY_TOOL_REGISTRY: dict[str, QueryToolSpec] = {

--- a/src/linkura_story_indexer/query/tools.py
+++ b/src/linkura_story_indexer/query/tools.py
@@ -173,10 +173,6 @@ def _summary_where(engine: StoryQueryEngine, args: SearchSummariesInput) -> dict
     return engine._and_where(filters)
 
 
-def _public_trace_stages(stages: dict[StageName, StageTrace]) -> dict[StageName, StageTrace]:
-    return stages
-
-
 def search_raw(engine: StoryQueryEngine, args: SearchRawInput) -> ToolResult:
     where, warnings, empty = _raw_where(engine, args)
     if empty:
@@ -194,7 +190,7 @@ def search_raw(engine: StoryQueryEngine, args: SearchRawInput) -> ToolResult:
             _candidate_from_node(engine, node, rank=rank, fetch_raw_text=True)
             for rank, node in enumerate(retrieval.nodes, start=1)
         ],
-        trace_stages=_public_trace_stages(retrieval.stages),
+        trace_stages=retrieval.stages,
         warnings=warnings,
         metadata={"where": where},
     )
@@ -215,7 +211,7 @@ def search_summaries(engine: StoryQueryEngine, args: SearchSummariesInput) -> To
             _candidate_from_node(engine, node, rank=rank)
             for rank, node in enumerate(summary_nodes, start=1)
         ],
-        trace_stages=_public_trace_stages(retrieval.stages),
+        trace_stages=retrieval.stages,
         metadata={"where": where},
     )
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -8,24 +8,28 @@ def test_model_and_chroma_env_defaults_and_overrides(monkeypatch):
     monkeypatch.delenv("LINKURA_CHAT_MODEL", raising=False)
     monkeypatch.delenv("LINKURA_INGEST_PROVIDER", raising=False)
     monkeypatch.delenv("LINKURA_INGEST_MODEL", raising=False)
+    monkeypatch.delenv("LINKURA_ROUTER_MODEL", raising=False)
     monkeypatch.delenv("LINKURA_EMBEDDING_MODEL", raising=False)
     monkeypatch.delenv("LINKURA_CHROMA_DB_PATH", raising=False)
 
     assert database.get_chat_model_name() == database.DEFAULT_CHAT_MODEL
     assert database.get_generation_provider_name() == database.DEFAULT_GENERATION_PROVIDER
     assert database.get_generation_model_name() == database.DEFAULT_CHAT_MODEL
+    assert database.get_router_model_name() == database.DEFAULT_ROUTER_MODEL
     assert database.get_embedding_model_name() == database.DEFAULT_EMBEDDING_MODEL
     assert database.get_chroma_db_path() == database.DEFAULT_CHROMA_DB_PATH
 
     monkeypatch.setenv("LINKURA_CHAT_MODEL", "custom-chat")
     monkeypatch.setenv("LINKURA_INGEST_PROVIDER", "openai")
     monkeypatch.setenv("LINKURA_INGEST_MODEL", "custom-ingest")
+    monkeypatch.setenv("LINKURA_ROUTER_MODEL", "custom-router")
     monkeypatch.setenv("LINKURA_EMBEDDING_MODEL", "custom-embedding")
     monkeypatch.setenv("LINKURA_CHROMA_DB_PATH", "./custom_chroma")
 
     assert database.get_chat_model_name() == "custom-chat"
     assert database.get_generation_provider_name() == "openai"
     assert database.get_generation_model_name() == "custom-ingest"
+    assert database.get_router_model_name() == "custom-router"
     assert database.get_embedding_model_name() == "custom-embedding"
     assert database.get_chroma_db_path() == "./custom_chroma"
 

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -444,7 +444,7 @@ def test_query_default_expands_ranks_and_synthesizes_raw_evidence(monkeypatch):
 
 def test_query_analysis_enabled_applies_analyzer_filters(monkeypatch):
     engine = make_engine()
-    engine.retrieval_config = RetrievalConfig(enable_query_analysis=True, neighbor_scene_window=0)
+    engine.retrieval_config = RetrievalConfig(routing_mode="heuristic", neighbor_scene_window=0)
     raw_hit = raw_node("花帆: scoped raw scene", scene_start=4)
     raw_hit[1]["arc_id"] = "105"
     calls: list[dict[str, Any]] = []

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -95,10 +95,10 @@ def test_router_prompt_includes_available_episode_catalog() -> None:
     class FakeSourceStore:
         def iter_scenes(self) -> list[dict[str, Any]]:
             return [
-                {"metadata": {"arc_id": "104", "story_type": "Main", "episode_name": "第1話"}},
-                {"metadata": {"arc_id": "104", "story_type": "Main", "episode_name": "第2話"}},
-                {"metadata": {"arc_id": "104", "story_type": "Main", "episode_name": "第4話"}},
-                {"metadata": {"arc_id": "105", "story_type": "Main", "episode_name": "第12話"}},
+                {"metadata": {"arc_id": "104", "story_type": "Main", "episode_number": 1}},
+                {"metadata": {"arc_id": "104", "story_type": "Main", "episode_number": 2}},
+                {"metadata": {"arc_id": "104", "story_type": "Main", "episode_number": 4}},
+                {"metadata": {"arc_id": "105", "story_type": "Main", "episode_number": 12}},
             ]
 
     engine.source_store = FakeSourceStore()
@@ -216,6 +216,68 @@ def test_llm_router_trace_records_router_metadata_and_final_candidates(
     assert trace.stages["router"].metadata["fallback_used"] is False
     assert trace.stages["final_top_k"].candidates is not None
     assert trace.stages["final_top_k"].candidates[0].text == "routed raw scene"
+
+
+def test_llm_router_returns_direct_glossary_answer() -> None:
+    engine = make_engine()
+    engine.retrieval_config = RetrievalConfig(routing_mode="llm_router", final_top_k=5)
+    engine.query_router = FixtureQueryRouter("lookup_glossary", {"term": "日野下花帆"})
+
+    answer = engine.query("translate 日野下花帆")
+
+    assert answer.startswith("日野下花帆 translates to Kaho Hinoshita.")
+    assert "花帆" in answer
+
+    trace = engine.retrieve_with_trace("translate 日野下花帆", answer_mode=True)
+
+    assert trace.answer_text == answer
+    assert trace.stages["router"].metadata["chosen_tool"] == "lookup_glossary"
+
+
+def test_llm_router_surfaces_tool_errors_in_query_path() -> None:
+    engine = make_engine()
+    engine.retrieval_config = RetrievalConfig(routing_mode="llm_router", final_top_k=5)
+    engine.query_router = FixtureQueryRouter(
+        "get_scene",
+        {"file_path": "missing.md", "scene_index": 0},
+    )
+
+    class FakeSourceStore:
+        def get_scene(self, file_path: str, scene_index: int) -> None:
+            return None
+
+    engine.source_store = FakeSourceStore()
+
+    answer = engine.query("show missing scene")
+
+    assert "Insufficient source context" in answer
+    assert "Tool error: scene not found" in answer
+
+
+def test_fallback_dispatch_failure_returns_tool_result_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = make_engine()
+    engine.query_router = FixtureQueryRouter(error=RuntimeError("model unavailable"))
+
+    def fail_retrieve_raw_nodes_with_trace(
+        question: str,
+        *,
+        where: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        n_results: int | None = None,
+        analysis: Any = None,
+    ) -> RetrievalTraceResult:
+        raise RuntimeError("retrieval unavailable")
+
+    monkeypatch.setattr(engine, "retrieve_raw_nodes_with_trace", fail_retrieve_raw_nodes_with_trace)
+
+    result = engine.query_router.route_and_dispatch(engine, "original", final_top_k=5)
+
+    assert result.decision.fallback_used is True
+    assert result.tool_result.candidates == []
+    assert "fallback tool dispatch failed" in result.tool_result.errors[0]
+    assert "retrieval unavailable" in result.tool_result.errors[0]
 
 
 def test_fixture_router_falls_back_on_invalid_args_and_model_failure(

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from linkura_story_indexer.cli import _router_debug_lines
+from linkura_story_indexer.query.engine import (
+    RetrievalConfig,
+    RetrievalTraceResult,
+    StoryQueryEngine,
+)
+from linkura_story_indexer.query.router import (
+    FixtureQueryRouter,
+    RouterOutput,
+    _compressed_numbers,
+    _router_instructions,
+    validate_router_output,
+)
+
+
+def make_engine() -> StoryQueryEngine:
+    engine = StoryQueryEngine.__new__(StoryQueryEngine)
+    engine.retrieval_config = RetrievalConfig(neighbor_scene_window=0, final_top_k=5)
+    engine.glossary = {"characters": {"日野下花帆": "Kaho Hinoshita"}}
+    engine.state_ledger = {}
+    return engine
+
+
+def raw_node(text: str = "raw scene") -> tuple[str, dict[str, Any]]:
+    return (
+        text,
+        {
+            "arc_id": "103",
+            "story_type": "Main",
+            "episode_name": "第1話『花咲きたい！』",
+            "episode_number": 1,
+            "part_name": "1",
+            "summary_level": 4,
+            "file_path": "story/103/第1話『花咲きたい！』/1.md",
+            "scene_index": 0,
+            "scene_start": 0,
+            "scene_end": 0,
+            "source_scene_count": 1,
+            "canonical_story_order": 1,
+            "chunk_id": "chunk:103:1:0",
+        },
+    )
+
+
+def test_router_output_accepts_structured_tool_selection() -> None:
+    output = RouterOutput.model_validate(
+        {"tool_name": "search_raw", "args": {"query": "Kaho", "top_k": 3}}
+    )
+
+    assert output.tool_name == "search_raw"
+    assert output.args == {"query": "Kaho", "top_k": 3}
+
+
+def test_router_prompt_guides_story_locations_to_filtered_raw_search() -> None:
+    instructions = _router_instructions()
+
+    assert "'104th term', '104 term', or 'Year 104' map to arc_id='104'" in instructions
+    assert "'episode 1', 'ep 1', or '第1話' map to episode=1" in instructions
+    assert "use search_raw with arc_id and episode filters" in instructions
+    assert "how did Kosuzu join the school idol club" in instructions
+
+
+def test_router_debug_lines_include_selection_and_fallback_metadata() -> None:
+    lines = _router_debug_lines(
+        {
+            "router_model": "fixture-router",
+            "chosen_tool": "search_raw",
+            "validated_args": {"query": "Kaho", "top_k": 5},
+            "fallback_used": True,
+            "fallback_reason": "invalid tool arguments",
+            "validation_errors": ["bad args"],
+            "raw_structured_model_output": {"tool_name": "search_summaries", "args": {}},
+        }
+    )
+
+    assert lines[0] == "[bold cyan]Router:[/bold cyan]"
+    assert "  model: fixture-router" in lines
+    assert "  chosen_tool: search_raw" in lines
+    assert '  args: {"query": "Kaho", "top_k": 5}' in lines
+    assert "  fallback_used: True" in lines
+    assert "  fallback_reason: invalid tool arguments" in lines
+    assert '  validation_errors: ["bad args"]' in lines
+    assert '  raw_output: {"args": {}, "tool_name": "search_summaries"}' in lines
+
+
+def test_router_prompt_includes_available_episode_catalog() -> None:
+    engine = make_engine()
+
+    class FakeSourceStore:
+        def iter_scenes(self) -> list[dict[str, Any]]:
+            return [
+                {"metadata": {"arc_id": "104", "story_type": "Main", "episode_name": "第1話"}},
+                {"metadata": {"arc_id": "104", "story_type": "Main", "episode_name": "第2話"}},
+                {"metadata": {"arc_id": "104", "story_type": "Main", "episode_name": "第4話"}},
+                {"metadata": {"arc_id": "105", "story_type": "Main", "episode_name": "第12話"}},
+            ]
+
+    engine.source_store = FakeSourceStore()
+
+    instructions = _router_instructions(engine)
+
+    assert "Available numbered episodes by arc/story type" in instructions
+    assert "arc_id=104, story_type=Main: episodes 1-2, 4" in instructions
+    assert "arc_id=105, story_type=Main: episodes 12" in instructions
+    assert "only pass an episode filter if the requested episode appears" in instructions
+
+
+def test_compressed_numbers_formats_ranges_and_gaps() -> None:
+    assert _compressed_numbers({1, 2, 3, 5, 8, 9}) == "1-3, 5, 8-9"
+
+
+def test_router_rejects_unknown_tool_with_raw_search_fallback() -> None:
+    decision = validate_router_output(
+        RouterOutput(tool_name="unknown", args={"query": "ignored"}),
+        question="original question",
+        final_top_k=5,
+        router_model="test-router",
+    )
+
+    assert decision.fallback_used is True
+    assert decision.tool_name == "search_raw"
+    assert decision.validated_args.model_dump(include={"query", "top_k"}) == {
+        "query": "original question",
+        "top_k": 5,
+    }
+    assert decision.validation_errors == ["unknown tool name: unknown"]
+
+
+def test_router_validates_selected_tool_arguments() -> None:
+    valid = validate_router_output(
+        RouterOutput(tool_name="search_summaries", args={"query": "Kaho", "summary_level": 2}),
+        question="original",
+        final_top_k=5,
+        router_model="test-router",
+    )
+    invalid = validate_router_output(
+        RouterOutput(tool_name="search_summaries", args={"query": "Kaho", "summary_level": 4}),
+        question="original",
+        final_top_k=5,
+        router_model="test-router",
+    )
+
+    assert valid.fallback_used is False
+    assert valid.validated_args.model_dump()["summary_level"] == 2
+    assert invalid.fallback_used is True
+    assert invalid.tool_name == "search_raw"
+    assert "summary_level" in invalid.validation_errors[0]
+
+
+def test_fixture_router_dispatches_selected_tool_without_model_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = make_engine()
+    node = raw_node("花帆: routed raw scene")
+    captured: list[dict[str, Any]] = []
+
+    def fake_retrieve_raw_nodes_with_trace(
+        question: str,
+        *,
+        where: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        n_results: int | None = None,
+        analysis: Any = None,
+    ) -> RetrievalTraceResult:
+        captured.append(
+            {"question": question, "where": where, "top_k": top_k, "n_results": n_results}
+        )
+        return RetrievalTraceResult(
+            nodes=[node],
+            stages={"final_top_k": engine._trace_stage("final_top_k", [])},
+        )
+
+    monkeypatch.setattr(engine, "retrieve_raw_nodes_with_trace", fake_retrieve_raw_nodes_with_trace)
+    monkeypatch.setattr(engine, "_fetch_raw_text", lambda metadata: "")
+
+    router = FixtureQueryRouter("search_raw", {"query": "routed query", "top_k": 1})
+    result = router.route_and_dispatch(engine, "original question", final_top_k=5)
+
+    assert result.decision.fallback_used is False
+    assert result.decision.tool_name == "search_raw"
+    assert result.tool_result.candidates[0].text == "花帆: routed raw scene"
+    assert captured[0]["question"] == "routed query"
+    assert captured[0]["top_k"] == 1
+
+
+def test_llm_router_trace_records_router_metadata_and_final_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = make_engine()
+    engine.retrieval_config = RetrievalConfig(routing_mode="llm_router", final_top_k=5)
+    engine.query_router = FixtureQueryRouter("search_raw", {"query": "routed query", "top_k": 1})
+
+    def fake_retrieve_raw_nodes_with_trace(
+        question: str,
+        *,
+        where: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        n_results: int | None = None,
+        analysis: Any = None,
+    ) -> RetrievalTraceResult:
+        return RetrievalTraceResult(nodes=[raw_node("routed raw scene")], stages={})
+
+    monkeypatch.setattr(engine, "retrieve_raw_nodes_with_trace", fake_retrieve_raw_nodes_with_trace)
+    monkeypatch.setattr(engine, "_fetch_raw_text", lambda metadata: "")
+
+    trace = engine.retrieve_with_trace("original", query_id="q-router")
+
+    assert trace.mode == "llm_router"
+    assert trace.stages["router"].metadata["chosen_tool"] == "search_raw"
+    assert trace.stages["router"].metadata["fallback_used"] is False
+    assert trace.stages["final_top_k"].candidates is not None
+    assert trace.stages["final_top_k"].candidates[0].text == "routed raw scene"
+
+
+def test_fixture_router_falls_back_on_invalid_args_and_model_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = make_engine()
+    captured: list[str] = []
+
+    def fake_retrieve_raw_nodes_with_trace(
+        question: str,
+        *,
+        where: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        n_results: int | None = None,
+        analysis: Any = None,
+    ) -> RetrievalTraceResult:
+        captured.append(f"{question}:{top_k}")
+        return RetrievalTraceResult(nodes=[raw_node()], stages={})
+
+    monkeypatch.setattr(engine, "retrieve_raw_nodes_with_trace", fake_retrieve_raw_nodes_with_trace)
+    monkeypatch.setattr(engine, "_fetch_raw_text", lambda metadata: "")
+
+    invalid_args = FixtureQueryRouter("search_raw", {"query": "", "top_k": 1})
+    failed_model = FixtureQueryRouter(error=RuntimeError("model unavailable"))
+
+    invalid_result = invalid_args.route_and_dispatch(engine, "original", final_top_k=5)
+    failure_result = failed_model.route_and_dispatch(engine, "original", final_top_k=5)
+
+    assert invalid_result.decision.fallback_used is True
+    assert invalid_result.decision.fallback_reason == "invalid tool arguments"
+    assert failure_result.decision.fallback_used is True
+    assert failure_result.decision.fallback_reason == "router model failure"
+    assert captured == ["original:5", "original:5"]

--- a/tests/test_query_tools.py
+++ b/tests/test_query_tools.py
@@ -12,6 +12,7 @@ from linkura_story_indexer.indexer.source_store import SourceRecordStore
 from linkura_story_indexer.query import engine as query_engine
 from linkura_story_indexer.query.engine import RetrievalConfig, StoryQueryEngine
 from linkura_story_indexer.query.tools import (
+    QUERY_TOOL_REGISTRY,
     GetSceneInput,
     LookupGlossaryInput,
     SearchRawInput,
@@ -268,3 +269,5 @@ def test_build_query_toolset_registers_pydantic_schema_tools() -> None:
     )
     assert search_raw_schema["properties"]["top_k"]["minimum"] == 1
     assert "OR semantics" in search_raw_schema["properties"]["speakers"]["description"]
+    assert set(QUERY_TOOL_REGISTRY) == set(by_name)
+    assert QUERY_TOOL_REGISTRY["search_raw"].input_model is SearchRawInput


### PR DESCRIPTION
## Summary

- Add `RetrievalConfig.routing_mode` with `off`, `heuristic`, and `llm_router` modes.
- Add a Pydantic AI structured-output query router that selects exactly one registered typed query tool, validates arguments, and falls back safely to `search_raw`.
- Add shared query tool registry metadata used by router/tool dispatch.
- Add router trace metadata, `LINKURA_ROUTER_MODEL`, CLI `--routing-mode`, and opt-in `--show-router` debug output.
- Add router prompt context for story term/episode routing and available episode catalogs derived from source metadata.

## Follow-up

- Created #58 for the discovered summary-result rendering issue: routed `search_summaries` output should expand to raw evidence or render as summaries instead of fake scene evidence.

## Verification

- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`