### PR TITLE
Label routed summary evidence correctly

### DIFF
--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -313,6 +313,8 @@ class StoryQueryEngine:
         episode = self._summary_episode_label(metadata)
         if episode.startswith("Episode "):
             return episode.removeprefix("Episode ")
+        if episode.startswith("Side Story "):
+            return episode.removeprefix("Side Story ")
         return episode
 
     def _summary_part_label(self, metadata: dict[str, Any]) -> str:

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -227,11 +227,23 @@ class StoryQueryEngine:
         self,
         arc_ids: set[str],
         analysis: QueryAnalysis | None = None,
+        *,
+        context_kind: Literal["raw", "summary"] = "raw",
     ) -> str:
         """Builds the system prompt with invariants and state ledger."""
+        context_description = (
+            "provided raw source text"
+            if context_kind == "raw"
+            else "provided retrieved context, which may be generated summaries rather than raw source text"
+        )
+        citation_source = (
+            "retrieved raw evidence labels"
+            if context_kind == "raw"
+            else "retrieved context labels"
+        )
         prompt = (
             "You are an expert lore-keeper and archivist for a Japanese narrative story.\n"
-            "Answer based strictly on the provided raw source text in retrieved context.\n"
+            f"Answer based strictly on the {context_description}.\n"
             "Do NOT use outside knowledge. If the provided context does not contain the answer, "
             "say so.\n"
             "Cite sources using only the CITATION labels provided in retrieved context. "
@@ -251,7 +263,7 @@ class StoryQueryEngine:
             prompt += "\n--- STATE LEDGER (FACTS) ---\n"
             prompt += (
                 "Use these source-backed facts only for routing and consistency. "
-                "Final answer citations must still come from retrieved raw evidence labels.\n"
+                f"Final answer citations must still come from {citation_source}.\n"
             )
             for arc_id in sorted(arc_ids):
                 arc_facts = [fact for fact in ledger_facts if fact.get("arc") == arc_id]
@@ -263,6 +275,10 @@ class StoryQueryEngine:
         return prompt
 
     def _citation_label(self, metadata: dict[str, Any]) -> str:
+        summary_level = metadata.get("summary_level")
+        if summary_level in {1, 2, 3}:
+            return self._summary_citation_label(metadata)
+
         arc_id = metadata.get("arc_id", "unknown")
         episode = self._episode_label(metadata)
 
@@ -271,6 +287,41 @@ class StoryQueryEngine:
         if scene_label:
             return f"{arc_id} · {episode} · Part {part} · {scene_label}"
         return f"{arc_id} · {episode} · Part {part}"
+
+    def _summary_citation_label(self, metadata: dict[str, Any]) -> str:
+        summary_level = metadata.get("summary_level")
+        arc_id = metadata.get("arc_id", "unknown")
+        story_type = metadata.get("story_type", "unknown")
+        episode = self._summary_episode_label(metadata)
+        part = self._summary_part_label(metadata)
+        return (
+            f"{arc_id} · {story_type} · {episode} · Part {part} · "
+            f"summary_level {summary_level}"
+        )
+
+    def _summary_episode_label(self, metadata: dict[str, Any]) -> str:
+        if metadata.get("summary_level") == 1:
+            return "Episode ALL_EPISODES"
+
+        episode_number = metadata.get("episode_number")
+        if isinstance(episode_number, int) and episode_number > 0:
+            return f"Episode {episode_number}"
+
+        return self._episode_label(metadata)
+
+    def _summary_episode_value(self, metadata: dict[str, Any]) -> str:
+        episode = self._summary_episode_label(metadata)
+        if episode.startswith("Episode "):
+            return episode.removeprefix("Episode ")
+        return episode
+
+    def _summary_part_label(self, metadata: dict[str, Any]) -> str:
+        if metadata.get("summary_level") in {1, 2}:
+            return "ALL_PARTS"
+        part = metadata.get("part_name")
+        if isinstance(part, str) and part:
+            return part
+        return "unknown"
 
     def _scene_label(self, metadata: dict[str, Any]) -> str:
         scene_start = metadata.get("scene_start")
@@ -291,6 +342,18 @@ class StoryQueryEngine:
         return ""
 
     def _citation_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        if metadata.get("summary_level") in {1, 2, 3}:
+            return {
+                "arc_id": metadata.get("arc_id"),
+                "story_type": metadata.get("story_type"),
+                "episode": self._summary_episode_value(metadata),
+                "part": self._summary_part_label(metadata),
+                "summary_level": metadata.get("summary_level"),
+                "parent_year_id": metadata.get("parent_year_id"),
+                "parent_episode_id": metadata.get("parent_episode_id"),
+                "parent_part_id": metadata.get("parent_part_id"),
+                "canonical_story_order": metadata.get("canonical_story_order"),
+            }
         return {
             "file_path": metadata.get("file_path"),
             "scene_index": metadata.get("scene_index"),
@@ -1200,6 +1263,36 @@ class StoryQueryEngine:
 
         return context_chunks
 
+    def _build_summary_context_chunks(self, summary_nodes: list[Node]) -> list[str]:
+        context_chunks = []
+        for idx, (document, meta) in enumerate(summary_nodes):
+            citation = self._summary_citation_label(meta)
+            citation_metadata = self._citation_metadata(meta)
+            safe_print(
+                f"  Summary evidence {idx + 1}: Year {meta.get('arc_id')}, "
+                f"Story type: {meta.get('story_type')}, "
+                f"Episode: {self._summary_episode_value(meta)}, "
+                f"Part: {self._summary_part_label(meta)}, "
+                f"summary_level: {meta.get('summary_level')}"
+            )
+            context_chunk = (
+                f"--- SUMMARY EVIDENCE {idx + 1} "
+                f"(CITATION: {citation}; "
+                f"METADATA: {json.dumps(citation_metadata, ensure_ascii=False)}) ---\n"
+            )
+            context_chunk += (
+                "SUMMARY METADATA:\n"
+                f"Year: {meta.get('arc_id')}\n"
+                f"Story type: {meta.get('story_type')}\n"
+                f"Episode: {self._summary_episode_value(meta)}\n"
+                f"Part: {self._summary_part_label(meta)}\n"
+                f"Summary level: {meta.get('summary_level')}\n\n"
+                f"GENERATED SUMMARY TEXT:\n{document}\n"
+            )
+            context_chunks.append(context_chunk)
+
+        return context_chunks
+
     def _raw_arc_ids(self, raw_nodes: list[tuple[str, dict[str, Any]]]) -> set[str]:
         arc_ids = set()
         for _, metadata in raw_nodes:
@@ -1222,6 +1315,33 @@ class StoryQueryEngine:
             "Please answer the following question based ONLY on the raw source text provided below.\n\n"
             "Every factual claim should cite one or more provided CITATION labels exactly as written. "
             "Use episode numbers in citations, never Japanese episode titles.\n\n"
+            f"QUESTION: {question}\n\n"
+            f"CONTEXT:\n{combined_context}"
+        )
+
+        safe_print("Synthesizing final answer with Gemini...")
+        result = create_text_agent(system_prompt).run_sync(user_prompt)
+        return result.output.strip() or "No answer generated."
+
+    def _answer_from_summary_evidence(
+        self,
+        question: str,
+        summary_nodes: list[Node],
+    ) -> str:
+        state_ledger_arc_ids = self._state_ledger_arc_ids(question, self._raw_arc_ids(summary_nodes))
+        system_prompt = self._build_system_prompt(
+            state_ledger_arc_ids,
+            None,
+            context_kind="summary",
+        )
+        combined_context = "\n".join(self._build_summary_context_chunks(summary_nodes))
+
+        user_prompt = (
+            "Please answer the following question based ONLY on the retrieved context provided "
+            "below. The context may contain generated summaries rather than raw source text.\n\n"
+            "Every factual claim should cite one or more provided CITATION labels exactly as "
+            "written. Use the summary citation labels exactly as provided, including "
+            "summary_level. Do not invent scene labels for summary evidence.\n\n"
             f"QUESTION: {question}\n\n"
             f"CONTEXT:\n{combined_context}"
         )
@@ -1736,6 +1856,19 @@ class StoryQueryEngine:
             return f"{INSUFFICIENT_SOURCE_CONTEXT} Tool warning: {tool_warnings[0]}"
         return INSUFFICIENT_SOURCE_CONTEXT
 
+    def _routed_chosen_tool(self, stages: dict[StageName, StageTrace]) -> str | None:
+        router_stage = stages.get("router")
+        if router_stage is None:
+            return None
+        chosen_tool = router_stage.metadata.get("chosen_tool")
+        return chosen_tool if isinstance(chosen_tool, str) else None
+
+    def _answer_from_routed_evidence(self, question: str, routed: RoutedTraceResult) -> str:
+        chosen_tool = self._routed_chosen_tool(routed.stages)
+        if chosen_tool == "search_summaries":
+            return self._answer_from_summary_evidence(question, routed.nodes)
+        return self._answer_from_raw_evidence(question, routed.nodes, None)
+
     def retrieve_with_trace(
         self,
         question: str,
@@ -1753,7 +1886,7 @@ class StoryQueryEngine:
                 if routed.direct_answer is not None:
                     answer_text = routed.direct_answer
                 elif routed.nodes:
-                    answer_text = self._answer_from_raw_evidence(question, routed.nodes, None)
+                    answer_text = self._answer_from_routed_evidence(question, routed)
                 else:
                     answer_text = self._router_unavailable_message(routed.stages)
             return QueryTrace(
@@ -1799,8 +1932,11 @@ class StoryQueryEngine:
                 return routed.direct_answer
             if not routed.nodes:
                 return self._router_unavailable_message(routed.stages)
-            safe_print("Building answer context from routed source evidence...")
-            return self._answer_from_raw_evidence(question, routed.nodes, None)
+            if self._routed_chosen_tool(routed.stages) == "search_summaries":
+                safe_print("Building answer context from routed summary evidence...")
+            else:
+                safe_print("Building answer context from routed source evidence...")
+            return self._answer_from_routed_evidence(question, routed)
 
         safe_print("Searching raw source evidence...")
         analysis = None

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -1143,3 +1143,48 @@ def test_citation_label_and_metadata_handle_scene_spans():
         "source_scene_count": 7,
         "canonical_story_order": 30,
     }
+
+
+def test_summary_citation_labels_include_summary_scope_without_scene():
+    engine = make_engine()
+
+    year_label = engine._citation_label(
+        {
+            "arc_id": "103",
+            "story_type": "Main",
+            "episode_name": "第1話『テスト』",
+            "episode_number": 1,
+            "part_name": "1",
+            "summary_level": 1,
+            "scene_index": 0,
+        }
+    )
+    episode_label = engine._citation_label(
+        {
+            "arc_id": "103",
+            "story_type": "Main",
+            "episode_name": "第3話『テスト』",
+            "episode_number": 3,
+            "part_name": "2",
+            "summary_level": 2,
+            "scene_index": 0,
+        }
+    )
+    part_label = engine._citation_label(
+        {
+            "arc_id": "103",
+            "story_type": "Main",
+            "episode_name": "第3話『テスト』",
+            "episode_number": 3,
+            "part_name": "2",
+            "summary_level": 3,
+            "scene_index": 0,
+        }
+    )
+
+    assert year_label == "103 · Main · Episode ALL_EPISODES · Part ALL_PARTS · summary_level 1"
+    assert episode_label == "103 · Main · Episode 3 · Part ALL_PARTS · summary_level 2"
+    assert part_label == "103 · Main · Episode 3 · Part 2 · summary_level 3"
+    assert "Scene" not in year_label
+    assert "Scene" not in episode_label
+    assert "Scene" not in part_label

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -1181,10 +1181,18 @@ def test_summary_citation_labels_include_summary_scope_without_scene():
             "scene_index": 0,
         }
     )
+    side_story_episode = engine._summary_episode_value(
+        {
+            "story_type": "Side",
+            "episode_name": "～Shades of Stars～",
+            "summary_level": 2,
+        }
+    )
 
     assert year_label == "103 · Main · Episode ALL_EPISODES · Part ALL_PARTS · summary_level 1"
     assert episode_label == "103 · Main · Episode 3 · Part ALL_PARTS · summary_level 2"
     assert part_label == "103 · Main · Episode 3 · Part 2 · summary_level 3"
+    assert side_story_episode == "～Shades of Stars～"
     assert "Scene" not in year_label
     assert "Scene" not in episode_label
     assert "Scene" not in part_label

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from linkura_story_indexer.cli import _router_debug_lines
+from linkura_story_indexer.query import engine as query_engine
 from linkura_story_indexer.query.engine import (
     RetrievalConfig,
     RetrievalTraceResult,
@@ -44,6 +45,23 @@ def raw_node(text: str = "raw scene") -> tuple[str, dict[str, Any]]:
             "source_scene_count": 1,
             "canonical_story_order": 1,
             "chunk_id": "chunk:103:1:0",
+        },
+    )
+
+
+def summary_node(text: str = "summary") -> tuple[str, dict[str, Any]]:
+    return (
+        text,
+        {
+            "arc_id": "103",
+            "story_type": "Main",
+            "episode_name": "第1話『花咲きたい！』",
+            "episode_number": 1,
+            "part_name": "1",
+            "summary_level": 1,
+            "scene_index": 0,
+            "parent_year_id": "103",
+            "canonical_story_order": 1,
         },
     )
 
@@ -216,6 +234,75 @@ def test_llm_router_trace_records_router_metadata_and_final_candidates(
     assert trace.stages["router"].metadata["fallback_used"] is False
     assert trace.stages["final_top_k"].candidates is not None
     assert trace.stages["final_top_k"].candidates[0].text == "routed raw scene"
+
+
+def test_llm_router_summary_route_uses_summary_evidence_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = make_engine()
+    engine.retrieval_config = RetrievalConfig(routing_mode="llm_router", final_top_k=5)
+    engine.query_router = FixtureQueryRouter(
+        "search_summaries",
+        {"query": "routed summary query", "top_k": 1, "summary_level": 1},
+    )
+    prompts: list[str] = []
+    console_lines: list[str] = []
+
+    class FakeAgent:
+        def run_sync(self, prompt: str) -> Any:
+            prompts.append(prompt)
+
+            class Result:
+                output = "answered from summary"
+
+            return Result()
+
+    def fake_retrieve_summary_nodes_with_trace(
+        question: str,
+        *,
+        where: dict[str, Any] | None,
+        top_k: int,
+    ) -> RetrievalTraceResult:
+        assert question == "routed summary query"
+        assert where == {"summary_level": 1}
+        assert top_k == 1
+        return RetrievalTraceResult(
+            nodes=[summary_node("Kaho starts the school year in summary form.")],
+            stages={},
+        )
+
+    monkeypatch.setattr(
+        engine,
+        "retrieve_summary_nodes_with_trace",
+        fake_retrieve_summary_nodes_with_trace,
+    )
+    monkeypatch.setattr(
+        engine,
+        "_fetch_raw_text",
+        lambda metadata: pytest.fail("_fetch_raw_text should not be called for summaries"),
+    )
+    monkeypatch.setattr(query_engine, "create_text_agent", lambda system_prompt: FakeAgent())
+    monkeypatch.setattr(query_engine, "safe_print", lambda message: console_lines.append(message))
+
+    trace = engine.retrieve_with_trace("original", query_id="q-summary", answer_mode=True)
+
+    assert trace.mode == "llm_router"
+    assert trace.answer_text == "answered from summary"
+    assert trace.stages["router"].metadata["chosen_tool"] == "search_summaries"
+    assert trace.stages["final_top_k"].candidates is not None
+    assert trace.stages["final_top_k"].candidates[0].candidate_kind == "summary"
+    assert trace.final_citation_labels == [
+        "103 · Main · Episode ALL_EPISODES · Part ALL_PARTS · summary_level 1"
+    ]
+    assert prompts
+    assert "SUMMARY EVIDENCE 1" in prompts[0]
+    assert "summary_level 1" in prompts[0]
+    assert "Episode: ALL_EPISODES" in prompts[0]
+    assert "Part: ALL_PARTS" in prompts[0]
+    assert "GENERATED SUMMARY TEXT" in prompts[0]
+    assert "Scene 1" not in prompts[0]
+    assert any("Summary evidence 1" in line for line in console_lines)
+    assert all("Scene 1" not in line for line in console_lines)
 
 
 def test_llm_router_returns_direct_glossary_answer() -> None:

--- a/tests/test_query_tools.py
+++ b/tests/test_query_tools.py
@@ -202,6 +202,10 @@ def test_search_summaries_filters_level_and_arc(monkeypatch: pytest.MonkeyPatch)
     )
 
     assert [candidate.text for candidate in result.candidates] == ["Kaho starts school."]
+    assert (
+        result.candidates[0].citation_label
+        == "103 · Main · Episode 1 · Part ALL_PARTS · summary_level 2"
+    )
     assert captured == [
         {
             "n_results": 3,


### PR DESCRIPTION
## Summary
- Add summary-specific citation/context formatting for routed `search_summaries` evidence.
- Keep raw routed evidence on the existing raw-source formatter while preventing summary nodes from being labeled as scenes.
- Include `summary_level`, `ALL_EPISODES`, and `ALL_PARTS` in summary evidence labels and prompts.

Closes #58.

## Verification
- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest`