### PR TITLE
Use configured provider for query generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ configured generation provider:
   Completions endpoints)
 
 If `LINKURA_INGEST_MODEL` is unset, generation falls back to
-`LINKURA_CHAT_MODEL`, then the repo default Gemini chat model. When
+`LINKURA_CHAT_MODEL`, then the repo default Gemini chat model. Query answer
+generation uses the same configured provider and model, and LLM routing uses
+the same provider. When
 `LINKURA_INGEST_PROVIDER=openai`, set `LINKURA_INGEST_MODEL` or set
 `LINKURA_CHAT_MODEL` to an OpenAI model name so the default Gemini model is not
 sent to OpenAI. Google generation requires `GOOGLE_API_KEY`. OpenAI generation
@@ -20,8 +22,8 @@ requires `OPENAI_API_KEY`.
 
 Embeddings are separate and still use the Google GenAI embedding path controlled
 by `LINKURA_EMBEDDING_MODEL` (default: `gemini-embedding-2`). Running `ingest`
-therefore always requires `GOOGLE_API_KEY`, even when
-`LINKURA_INGEST_PROVIDER=openai`.
+and retrieval through `query` or `chat` therefore always requires
+`GOOGLE_API_KEY`, even when `LINKURA_INGEST_PROVIDER=openai`.
 
 ## Querying
 
@@ -34,7 +36,9 @@ Use `--routing-mode heuristic` when you want targeted scoped workflows that
 apply analyzer-derived filters or structured helpers. Use
 `--routing-mode llm_router` to let the configured router model select one
 typed query tool before retrieval. The router model is controlled by
-`LINKURA_ROUTER_MODEL` and defaults to `gemini-3.1-flash-lite-preview`.
+`LINKURA_ROUTER_MODEL`. With the Google provider it defaults to
+`gemini-3.1-flash-lite-preview`; with the OpenAI provider it defaults to the
+configured generation model.
 
 ```powershell
 indexer query "What happened in the 105th term?" --routing-mode heuristic

--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -18,7 +18,7 @@ from .database import (
     get_generation_provider_name,
     initialize_generation_settings,
     initialize_ingest_settings,
-    initialize_settings,
+    initialize_query_settings,
 )
 from .eval.io import load_eval_run, stable_json
 from .eval.metrics import diff_runs
@@ -354,7 +354,7 @@ def query(
 ):
     """Answers a question based on the RAG index and State Ledger."""
     mode = _routing_mode(routing_mode)
-    initialize_settings()
+    initialize_query_settings()
     engine = StoryQueryEngine(retrieval_config=RetrievalConfig(routing_mode=mode))
     console.print(f"\n[bold blue]Question:[/bold blue] {question}")
     if show_router and mode == "llm_router":
@@ -380,7 +380,7 @@ def chat(
 ):
     """Starts an interactive chat session with the RAG index."""
     mode = _routing_mode(routing_mode)
-    initialize_settings()
+    initialize_query_settings()
     engine = StoryQueryEngine(retrieval_config=RetrievalConfig(routing_mode=mode))
     console.print("[bold green]Interactive Chat Started! Type 'exit' or 'quit' to end.[/bold green]")
     

--- a/src/linkura_story_indexer/database.py
+++ b/src/linkura_story_indexer/database.py
@@ -65,7 +65,11 @@ def get_generation_model_name() -> str:
 
 
 def get_router_model_name() -> str:
-    return os.getenv("LINKURA_ROUTER_MODEL", DEFAULT_ROUTER_MODEL)
+    if router_model := os.getenv("LINKURA_ROUTER_MODEL"):
+        return router_model
+    if get_generation_provider_name() == "openai":
+        return get_generation_model_name()
+    return DEFAULT_ROUTER_MODEL
 
 
 def get_embedding_model_name() -> str:
@@ -106,9 +110,15 @@ def initialize_ingest_settings() -> None:
     initialize_generation_settings()
 
 
+def initialize_query_settings() -> None:
+    """Validates environment configuration for retrieval and answer generation."""
+    get_google_api_key()
+    initialize_generation_settings()
+
+
 def create_text_agent(instructions: str) -> Agent[None, str]:
-    """Creates a PydanticAI agent backed by Gemini."""
-    return Agent(create_google_model(), instructions=instructions)
+    """Creates a PydanticAI agent backed by the configured generation provider."""
+    return Agent(create_generation_model(), instructions=instructions)
 
 
 def create_generation_text_agent(instructions: str) -> Agent[None, str]:
@@ -116,9 +126,9 @@ def create_generation_text_agent(instructions: str) -> Agent[None, str]:
     return Agent(create_generation_model(), instructions=instructions)
 
 
-def create_generation_model() -> Any:
+def create_generation_model(model_name: str | None = None) -> Any:
     provider = get_generation_provider_name()
-    model_name = get_generation_model_name()
+    model_name = model_name or get_generation_model_name()
     if provider == "google":
         return create_google_model(model_name)
     if provider == "openai":

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -6,7 +6,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from ..console import safe_print
-from ..database import RETRIEVAL_QUERY, create_text_agent, embed_texts, get_chroma_collection
+from ..database import (
+    RETRIEVAL_QUERY,
+    create_text_agent,
+    embed_texts,
+    get_chroma_collection,
+    get_generation_model_name,
+)
 from ..eval.models import (
     ROUTING_MODES,
     CandidateScores,
@@ -1321,7 +1327,7 @@ class StoryQueryEngine:
             f"CONTEXT:\n{combined_context}"
         )
 
-        safe_print("Synthesizing final answer with Gemini...")
+        safe_print(f"Synthesizing final answer with {get_generation_model_name()}...")
         result = create_text_agent(system_prompt).run_sync(user_prompt)
         return result.output.strip() or "No answer generated."
 
@@ -1348,7 +1354,7 @@ class StoryQueryEngine:
             f"CONTEXT:\n{combined_context}"
         )
 
-        safe_print("Synthesizing final answer with Gemini...")
+        safe_print(f"Synthesizing final answer with {get_generation_model_name()}...")
         result = create_text_agent(system_prompt).run_sync(user_prompt)
         return result.output.strip() or "No answer generated."
 

--- a/src/linkura_story_indexer/query/router.py
+++ b/src/linkura_story_indexer/query/router.py
@@ -8,7 +8,7 @@ from typing import Any
 from pydantic import BaseModel, Field, ValidationError
 from pydantic_ai import Agent
 
-from linkura_story_indexer.database import create_google_model, get_router_model_name
+from linkura_story_indexer.database import create_generation_model, get_router_model_name
 from linkura_story_indexer.query.tools import (
     QUERY_TOOL_REGISTRY,
     SearchRawInput,
@@ -259,7 +259,7 @@ class QueryRouter:
         engine: Any | None = None,
     ) -> RouterOutput:
         agent: Agent[None, RouterOutput] = Agent(
-            create_google_model(self.model_name),
+            create_generation_model(self.model_name),
             output_type=RouterOutput,
             instructions=self._instructions(engine),
         )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -41,6 +41,14 @@ def test_generation_model_falls_back_to_chat_model(monkeypatch):
     assert database.get_generation_model_name() == "fallback-chat"
 
 
+def test_router_model_falls_back_to_openai_generation_model(monkeypatch):
+    monkeypatch.delenv("LINKURA_ROUTER_MODEL", raising=False)
+    monkeypatch.setenv("LINKURA_INGEST_PROVIDER", "openai")
+    monkeypatch.setenv("LINKURA_INGEST_MODEL", "gpt-5-mini")
+
+    assert database.get_router_model_name() == "gpt-5-mini"
+
+
 def test_generation_model_uses_google_by_default(monkeypatch):
     database.reset_client_caches()
     monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
@@ -83,6 +91,20 @@ def test_generation_model_uses_openai_when_selected(monkeypatch):
     assert calls == ["gpt-5-mini"]
 
 
+def test_generation_model_honors_model_override(monkeypatch):
+    monkeypatch.setenv("LINKURA_INGEST_PROVIDER", "openai")
+    calls: list[str | None] = []
+
+    def fake_create_openai_model(model_name: str | None = None) -> str:
+        calls.append(model_name)
+        return "openai-model"
+
+    monkeypatch.setattr(database, "create_openai_model", fake_create_openai_model)
+
+    assert database.create_generation_model("gpt-router") == "openai-model"
+    assert calls == ["gpt-router"]
+
+
 def test_generation_settings_validate_only_selected_provider(monkeypatch):
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
@@ -118,6 +140,20 @@ def test_ingest_settings_still_require_google_for_embeddings(monkeypatch):
         assert "GOOGLE_API_KEY" in str(exc)
     else:
         raise AssertionError("initialize_ingest_settings should require GOOGLE_API_KEY")
+
+
+def test_query_settings_still_require_google_for_embeddings(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setenv("LINKURA_INGEST_PROVIDER", "openai")
+    monkeypatch.setenv("LINKURA_INGEST_MODEL", "gpt-5-mini")
+
+    try:
+        database.initialize_query_settings()
+    except ValueError as exc:
+        assert "GOOGLE_API_KEY" in str(exc)
+    else:
+        raise AssertionError("initialize_query_settings should require GOOGLE_API_KEY")
 
 
 def test_client_and_model_helpers_return_singletons(monkeypatch):


### PR DESCRIPTION
## Summary

- validate Google retrieval credentials and the selected generation provider for `query` and `chat`
- use the configured generation provider for final answers and LLM routing, with a provider-appropriate router model fallback
- report the configured generation model during synthesis and document the provider/model behavior
- add regression coverage for OpenAI router fallback, model overrides, and query credential validation

## Testing

- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest` (185 passed)
