### PR TITLE
Stream answers in interactive chat

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -205,7 +205,7 @@ retrieval — don't start until Phases 1-5 are solid.
 
 ## Misc low-priority polish
 
-- [ ] Streaming for `cli.chat` instead of blocking `run_sync`.
+- [x] Streaming for `cli.chat` instead of blocking `run_sync`.
 - [ ] Migrate `summaries_cache.json` to SQLite or JSONL — **only
       after** content-hash invalidation and stale-vector pruning
       land. Format migration alone fixes nothing.
@@ -215,3 +215,4 @@ retrieval — don't start until Phases 1-5 are solid.
 Task 1 is the natural starting point: entirely local edits, no new
 concepts, gets the system prompt to stop lying while Tier 4 indexing
 is being built.
+

--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -101,9 +101,13 @@ def _print_router_debug(engine: StoryQueryEngine, question: str) -> str:
     trace = engine.retrieve_with_trace(question, answer_mode=True)
     router_stage = trace.stages.get("router")
     if router_stage is not None:
-        for line in _router_debug_lines(router_stage.metadata):
-            console.print(line)
+        _print_router_metadata(router_stage.metadata)
     return trace.answer_text or INSUFFICIENT_SOURCE_CONTEXT
+
+
+def _print_router_metadata(metadata: dict[str, Any]) -> None:
+    for line in _router_debug_lines(metadata):
+        console.print(line)
 
 
 def _node_id(node: StoryNode) -> str:
@@ -383,26 +387,39 @@ def chat(
     initialize_query_settings()
     engine = StoryQueryEngine(retrieval_config=RetrievalConfig(routing_mode=mode))
     console.print("[bold green]Interactive Chat Started! Type 'exit' or 'quit' to end.[/bold green]")
-    
+
     while True:
         try:
             question = typer.prompt("Question")
-            if question.strip().lower() in ["exit", "quit"]:
-                break
-            if not question.strip():
-                continue
-                
-            console.print("\n[dim]Thinking...[/dim]")
-            if show_router and mode == "llm_router":
-                answer = _print_router_debug(engine, question)
-            else:
-                if show_router:
-                    console.print("[yellow]--show-router only applies with --routing-mode llm_router.[/yellow]")
-                answer = engine.query(question)
-            console.print(f"\n[bold green]Answer:[/bold green]\n{answer}\n")
         except (KeyboardInterrupt, EOFError):
             break
-            
+
+        if question.strip().lower() in ["exit", "quit"]:
+            break
+        if not question.strip():
+            continue
+
+        answer_deltas = None
+        try:
+            console.print("\n[dim]Thinking...[/dim]")
+            result = engine.stream_query(question)
+            answer_deltas = result.answer_deltas
+            if show_router and mode == "llm_router" and result.router_metadata is not None:
+                _print_router_metadata(result.router_metadata)
+            elif show_router:
+                console.print(
+                    "[yellow]--show-router only applies with --routing-mode llm_router.[/yellow]"
+                )
+            console.print("\n[bold green]Answer:[/bold green]")
+            for delta in answer_deltas:
+                console.print(delta, end="", markup=False, highlight=True)
+            console.print()
+        except KeyboardInterrupt:
+            close = getattr(answer_deltas, "close", None)
+            if close is not None:
+                close()
+            console.print("\n[yellow]Answer interrupted. Ready for another question.[/yellow]\n")
+
     console.print("[bold blue]Chat session ended. Goodbye![/bold blue]")
 
 @app.command()
@@ -717,3 +734,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -99,6 +100,23 @@ class RoutedTraceResult:
     nodes: list[Node]
     stages: dict[StageName, StageTrace]
     direct_answer: str | None = None
+
+
+@dataclass(frozen=True)
+class StreamingQueryResult:
+    """A prepared query whose answer can be consumed exactly once as text deltas."""
+
+    answer_deltas: Iterator[str]
+    router_metadata: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class _PreparedQuery:
+    immediate_answer: str | None = None
+    system_prompt: str | None = None
+    user_prompt: str | None = None
+    router_metadata: dict[str, Any] | None = None
+    final_citation_labels: tuple[str, ...] = ()
 
 
 class StoryQueryEngine:
@@ -496,1098 +514,7 @@ class StoryQueryEngine:
         seen = set()
         for speaker in analysis.character_names:
             for chunk_id in source_store.chunk_ids_for_speaker(speaker):
-                if chunk_id in seen:
-                    continue
-                seen.add(chunk_id)
-                chunk_ids.append(chunk_id)
-
-        if not chunk_ids:
-            return None
-        return {"chunk_id": {"$in": chunk_ids}}
-
-    def _combine_where(self, *filters: dict[str, Any] | None) -> dict[str, Any] | None:
-        flattened: list[dict[str, Any]] = []
-        for item in filters:
-            if not item:
-                continue
-            if set(item.keys()) == {"$and"} and isinstance(item.get("$and"), list):
-                flattened.extend(
-                    sub_item for sub_item in item["$and"] if isinstance(sub_item, dict)
-                )
-            else:
-                flattened.append(item)
-        return self._and_where(flattened)
-
-    def _metadata_value(self, metadata: dict[str, Any], key: str) -> Any:
-        if key == "story_order":
-            return metadata.get("story_order", metadata.get("canonical_story_order"))
-        return metadata.get(key)
-
-    def _metadata_matches_filter(self, metadata: dict[str, Any], where: dict[str, Any]) -> bool:
-        and_filters = where.get("$and")
-        if isinstance(and_filters, list):
-            return all(
-                isinstance(item, dict) and self._metadata_matches_filter(metadata, item)
-                for item in and_filters
-            )
-
-        for key, expected in where.items():
-            if key == "$and":
-                continue
-            actual = self._metadata_value(metadata, key)
-            if isinstance(expected, dict):
-                if not self._metadata_matches_operator(actual, expected):
-                    return False
-                continue
-            if actual != expected:
-                return False
-        return True
-
-    def _metadata_matches_operator(self, actual: Any, expected: dict[str, Any]) -> bool:
-        for operator, value in expected.items():
-            if operator == "$eq":
-                if actual != value:
-                    return False
-                continue
-            if operator == "$in":
-                if not isinstance(value, list) or actual not in value:
-                    return False
-                continue
-            if not isinstance(actual, (int, float)) or not isinstance(value, (int, float)):
-                return False
-            if operator == "$lt" and not actual < value:
-                return False
-            if operator == "$lte" and not actual <= value:
-                return False
-            if operator == "$gt" and not actual > value:
-                return False
-            if operator == "$gte" and not actual >= value:
-                return False
-            if operator not in {"$lt", "$lte", "$gt", "$gte"}:
-                return False
-        return True
-
-    def _temporal_story_order_filter(
-        self,
-        analysis: QueryAnalysis,
-    ) -> dict[str, Any] | None:
-        constraint = analysis.temporal_constraint
-        if constraint is None:
-            return None
-
-        story_order = self._resolve_temporal_story_order(analysis)
-        if story_order is None:
-            return None
-
-        if constraint.operator == "before":
-            return {"story_order": {"$lt": story_order}}
-        if constraint.operator == "after":
-            return {"story_order": {"$gt": story_order}}
-        return {"story_order": {"$lte": story_order}}
-
-    def _resolve_temporal_story_order(self, analysis: QueryAnalysis) -> int | None:
-        constraint = analysis.temporal_constraint
-        if constraint is None:
-            return None
-
-        filters: list[dict[str, Any]] = [{"summary_level": 4}]
-        if constraint.episode_number is not None:
-            filters.append({"episode_number": constraint.episode_number})
-        if constraint.arc_id is not None:
-            filters.append({"arc_id": constraint.arc_id})
-        if len(analysis.arc_ids) == 1 and constraint.arc_id is None:
-            filters.append({"arc_id": analysis.arc_ids[0]})
-        if analysis.story_type:
-            filters.append({"story_type": analysis.story_type})
-
-        where = self._and_where(filters)
-        if where is None or where == {"summary_level": 4}:
-            return None
-
-        collection_get = getattr(getattr(self, "collection", None), "get", None)
-        if not callable(collection_get):
-            return None
-
-        try:
-            results = collection_get(where=where, include=["metadatas"])
-        except (TypeError, ValueError):
-            return None
-
-        if not isinstance(results, dict):
-            return None
-        orders = [
-            int(order)
-            for metadata in results.get("metadatas", [])
-            if isinstance(metadata, dict)
-            for order in [metadata.get("story_order", metadata.get("canonical_story_order"))]
-            if isinstance(order, int)
-        ]
-        if not orders:
-            return None
-        if constraint.operator == "before":
-            return min(orders)
-        return max(orders)
-
-    def _results_to_nodes(self, results: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
-        documents = results.get("documents") or [[]]
-        metadatas = results.get("metadatas") or [[]]
-        return [
-            (document, dict(metadata or {}))
-            for document, metadata in zip(documents[0], metadatas[0], strict=False)
-        ]
-
-    def _results_to_ranked_nodes(
-        self,
-        results: dict[str, Any],
-    ) -> list[tuple[Node, float | None]]:
-        documents = results.get("documents") or [[]]
-        metadatas = results.get("metadatas") or [[]]
-        distances = results.get("distances") or [[]]
-        output = []
-        for index, (document, metadata) in enumerate(
-            zip(documents[0], metadatas[0], strict=False)
-        ):
-            distance = distances[0][index] if distances and distances[0] and index < len(distances[0]) else None
-            output.append(((document, dict(metadata or {})), distance))
-        return output
-
-    def _flat_results_to_nodes(self, results: dict[str, Any]) -> list[Node]:
-        documents = results.get("documents") or []
-        metadatas = results.get("metadatas") or []
-        return [
-            (document, dict(metadata or {}))
-            for document, metadata in zip(documents, metadatas, strict=False)
-        ]
-
-    def _lexical_retrieve(
-        self,
-        question: str,
-        *,
-        n_results: int = ROUTING_CANDIDATE_COUNT,
-        where: dict[str, Any] | None = None,
-    ) -> list[Node]:
-        lexical_index = getattr(self, "lexical_index", None)
-        if lexical_index is None:
-            return []
-        return lexical_index.search(question, n_results=n_results, where=where)
-
-    def _retrieve_with_dense_scores(
-        self,
-        question: str,
-        *,
-        n_results: int,
-        where: dict[str, Any] | None,
-        query_embedding: list[float],
-    ) -> list[tuple[Node, float | None]]:
-        query_kwargs: dict[str, Any] = {
-            "query_embeddings": [query_embedding],
-            "n_results": n_results,
-            "include": ["documents", "metadatas", "distances"],
-        }
-        if where:
-            query_kwargs["where"] = where
-
-        try:
-            results = self.collection.query(**query_kwargs)
-        except ValueError:
-            query_kwargs["include"] = ["documents", "metadatas"]
-            results = self.collection.query(**query_kwargs)
-        return self._results_to_ranked_nodes(results)
-
-    def _node_key(self, document: str, metadata: dict[str, Any]) -> tuple[Any, ...]:
-        scene_start = metadata.get("scene_start")
-        if not isinstance(scene_start, int):
-            scene_start = metadata.get("scene_index")
-        scene_end = metadata.get("scene_end")
-        if not isinstance(scene_end, int):
-            scene_end = scene_start
-        key = (
-            metadata.get("summary_level"),
-            metadata.get("parent_year_id"),
-            metadata.get("parent_episode_id"),
-            metadata.get("parent_part_id"),
-            metadata.get("file_path"),
-            scene_start,
-            scene_end,
-        )
-        if any(part not in (None, "") for part in key):
-            return key
-        return (document,)
-
-    def _dedupe_nodes(
-        self,
-        nodes: list[Node],
-    ) -> list[Node]:
-        deduped = []
-        seen = set()
-        for document, metadata in nodes:
-            key = self._node_key(document, metadata)
-            if key in seen:
-                continue
-            seen.add(key)
-            deduped.append((document, metadata))
-        return deduped
-
-    def _rrf_fuse(
-        self,
-        ranked_lists: list[list[Node]],
-        *,
-        k: int | None = None,
-    ) -> list[Node]:
-        rrf_k = self._config().rrf_k if k is None else k
-        if rrf_k < 1:
-            raise ValueError("rrf k must be at least 1")
-
-        scores: dict[tuple[Any, ...], float] = {}
-        nodes_by_key: dict[tuple[Any, ...], Node] = {}
-        first_seen: dict[tuple[Any, ...], int] = {}
-        seen_order = 0
-
-        for ranked_list in ranked_lists:
-            seen_in_list: set[tuple[Any, ...]] = set()
-            for rank, (document, metadata) in enumerate(ranked_list, start=1):
-                key = self._node_key(document, metadata)
-                if key in seen_in_list:
-                    continue
-                seen_in_list.add(key)
-
-                if key not in nodes_by_key:
-                    nodes_by_key[key] = (document, metadata)
-                    first_seen[key] = seen_order
-                    seen_order += 1
-
-                scores[key] = scores.get(key, 0.0) + (1.0 / (rrf_k + rank))
-
-        ranked_keys = sorted(
-            scores,
-            key=lambda key: (-scores[key], first_seen[key]),
-        )
-        return [nodes_by_key[key] for key in ranked_keys]
-
-    def _rrf_fuse_with_scores(
-        self,
-        ranked_lists: list[list[Node]],
-        *,
-        k: int | None = None,
-    ) -> list[tuple[Node, float]]:
-        rrf_k = self._config().rrf_k if k is None else k
-        if rrf_k < 1:
-            raise ValueError("rrf k must be at least 1")
-
-        scores: dict[tuple[Any, ...], float] = {}
-        nodes_by_key: dict[tuple[Any, ...], Node] = {}
-        first_seen: dict[tuple[Any, ...], int] = {}
-        seen_order = 0
-
-        for ranked_list in ranked_lists:
-            seen_in_list: set[tuple[Any, ...]] = set()
-            for rank, (document, metadata) in enumerate(ranked_list, start=1):
-                key = self._node_key(document, metadata)
-                if key in seen_in_list:
-                    continue
-                seen_in_list.add(key)
-
-                if key not in nodes_by_key:
-                    nodes_by_key[key] = (document, metadata)
-                    first_seen[key] = seen_order
-                    seen_order += 1
-
-                scores[key] = scores.get(key, 0.0) + (1.0 / (rrf_k + rank))
-
-        ranked_keys = sorted(scores, key=lambda key: (-scores[key], first_seen[key]))
-        return [(nodes_by_key[key], scores[key]) for key in ranked_keys]
-
-    def _hybrid_retrieve(
-        self,
-        question: str,
-        *,
-        n_results: int = ROUTING_CANDIDATE_COUNT,
-        where: dict[str, Any] | None = None,
-        query_embedding: list[float] | None = None,
-    ) -> list[Node]:
-        dense_nodes = self._retrieve(
-            question,
-            n_results=n_results,
-            where=where,
-            query_embedding=query_embedding,
-        )
-        lexical_nodes = self._lexical_retrieve(question, n_results=n_results, where=where)
-        return self._rrf_fuse([dense_nodes, lexical_nodes])[:n_results]
-
-    def _tiered_retrieve(
-        self,
-        question: str,
-        *,
-        query_embedding: list[float] | None = None,
-        analysis: QueryAnalysis | None = None,
-    ) -> list[Node]:
-        if query_embedding is None:
-            query_embedding = self._query_embedding(question)
-        config = self._config()
-        summary_levels = self._summary_levels_for_analysis(analysis)
-        ranked_lists = []
-        for summary_level in summary_levels:
-            ranked_lists.append(
-                self._hybrid_retrieve(
-                    question,
-                    n_results=config.routing_candidate_count,
-                    where=self._where_for_analysis(analysis, summary_level=summary_level),
-                    query_embedding=query_embedding,
-                )
-            )
-        ranked_lists.append(
-            self._hybrid_retrieve(
-                question,
-                n_results=config.raw_candidate_count,
-                where=self._where_for_analysis(
-                    analysis,
-                    summary_level=4,
-                    include_scene_constraint=True,
-                ),
-                query_embedding=query_embedding,
-            )
-        )
-        return self._rrf_fuse(ranked_lists)
-
-    def _summary_levels_for_analysis(self, analysis: QueryAnalysis | None) -> tuple[int, ...]:
-        if analysis is None:
-            return (1, 2, 3)
-        if analysis.scene_constraint is not None or analysis.intent_bucket in {
-            EXACT_EVIDENCE_INTENT,
-            QUANTITATIVE_INTENT,
-        }:
-            return (3,)
-        if analysis.intent_bucket == SUMMARY_INTENT:
-            return (1, 2, 3)
-        if analysis.intent_bucket == CHRONOLOGY_INTENT:
-            return (2, 3)
-        return (1, 2, 3)
-
-    def _raw_scene_filter_for_summary(
-        self,
-        metadata: dict[str, Any],
-        analysis: QueryAnalysis | None = None,
-    ) -> dict[str, Any] | None:
-        level = metadata.get("summary_level")
-        analysis_filter = self._where_for_analysis(
-            analysis,
-            summary_level=4,
-            include_scene_constraint=True,
-        )
-        if level == 1:
-            parent_year_id = metadata.get("parent_year_id") or metadata.get("arc_id")
-            if isinstance(parent_year_id, str) and parent_year_id:
-                return self._combine_where(analysis_filter, {"parent_year_id": parent_year_id})
-        if level == 2:
-            parent_episode_id = metadata.get("parent_episode_id")
-            if isinstance(parent_episode_id, str) and parent_episode_id:
-                return self._combine_where(analysis_filter, {"parent_episode_id": parent_episode_id})
-        if level == 3:
-            parent_part_id = metadata.get("parent_part_id")
-            if isinstance(parent_part_id, str) and parent_part_id:
-                return self._combine_where(analysis_filter, {"parent_part_id": parent_part_id})
-        return None
-
-    def _expand_summaries_to_raw_scenes(
-        self,
-        question: str,
-        summaries: list[Node],
-        *,
-        query_embedding: list[float] | None = None,
-        analysis: QueryAnalysis | None = None,
-    ) -> list[Node]:
-        if query_embedding is None:
-            query_embedding = self._query_embedding(question)
-        child_ranked_lists: list[list[Node]] = []
-
-        for _, metadata in summaries:
-            raw_filter = self._raw_scene_filter_for_summary(metadata, analysis)
-            if raw_filter is None:
-                continue
-
-            child_nodes = self._raw_evidence_nodes(
-                self._hybrid_retrieve(
-                    question,
-                    n_results=self._config().summary_child_candidate_count,
-                    where=raw_filter,
-                    query_embedding=query_embedding,
-                )
-            )
-            if child_nodes:
-                child_ranked_lists.append(child_nodes)
-
-        return self._rrf_fuse(child_ranked_lists)
-
-    def _raw_evidence_nodes(
-        self,
-        nodes: list[Node],
-    ) -> list[Node]:
-        return [(document, metadata) for document, metadata in nodes if metadata.get("summary_level") == 4]
-
-    def _scene_span(self, metadata: dict[str, Any]) -> tuple[int, int] | None:
-        scene_start = metadata.get("scene_start")
-        scene_end = metadata.get("scene_end")
-        if not isinstance(scene_start, int) or not isinstance(scene_end, int):
-            scene_index = metadata.get("scene_index")
-            scene_start = scene_index
-            scene_end = scene_index
-
-        if (
-            not isinstance(scene_start, int)
-            or not isinstance(scene_end, int)
-            or scene_start < 0
-            or scene_end < scene_start
-        ):
-            return None
-        return scene_start, scene_end
-
-    def _raw_part_filter(self, metadata: dict[str, Any]) -> dict[str, Any] | None:
-        parent_part_id = metadata.get("parent_part_id")
-        if isinstance(parent_part_id, str) and parent_part_id:
-            return {
-                "$and": [
-                    {"summary_level": 4},
-                    {"parent_part_id": parent_part_id},
-                ]
-            }
-
-        file_path = metadata.get("file_path")
-        if isinstance(file_path, str) and file_path:
-            return {
-                "$and": [
-                    {"summary_level": 4},
-                    {"file_path": file_path},
-                ]
-            }
-        return None
-
-    def _raw_nodes_for_part(
-        self,
-        question: str,
-        metadata: dict[str, Any],
-        *,
-        query_embedding: list[float] | None = None,
-    ) -> list[Node]:
-        raw_filter = self._raw_part_filter(metadata)
-        if raw_filter is None:
-            return []
-
-        collection_get = getattr(getattr(self, "collection", None), "get", None)
-        if callable(collection_get):
-            try:
-                results = collection_get(
-                    where=raw_filter,
-                    include=["documents", "metadatas"],
-                )
-                if isinstance(results, dict):
-                    return self._flat_results_to_nodes(results)
-            except (TypeError, ValueError):
-                pass
-
-        return self._hybrid_retrieve(
-            question,
-            n_results=max(self._config().raw_candidate_count, self._config().max_ranked_candidates),
-            where=raw_filter,
-            query_embedding=query_embedding,
-        )
-
-    def _sort_raw_nodes(self, nodes: list[Node]) -> list[Node]:
-        def sort_key(node: Node) -> tuple[Any, ...]:
-            _, metadata = node
-            span = self._scene_span(metadata) or (-1, -1)
-            return (
-                metadata.get("canonical_story_order", 0),
-                metadata.get("parent_part_id", ""),
-                metadata.get("file_path", ""),
-                span[0],
-                span[1],
-            )
-
-        return sorted(nodes, key=sort_key)
-
-    def _expand_raw_neighbors(
-        self,
-        question: str,
-        raw_nodes: list[Node],
-        *,
-        query_embedding: list[float] | None = None,
-    ) -> list[Node]:
-        window = self._config().neighbor_scene_window
-        if window < 1:
-            return self._dedupe_nodes(raw_nodes)
-
-        expanded_nodes: list[Node] = list(raw_nodes)
-        part_cache: dict[tuple[Any, ...], list[Node]] = {}
-
-        for _, metadata in raw_nodes:
-            span = self._scene_span(metadata)
-            if span is None:
-                continue
-            part_filter = self._raw_part_filter(metadata)
-            if part_filter is None:
-                continue
-
-            part_cache_key = tuple(
-                sorted(
-                    (str(key), json.dumps(value, sort_keys=True))
-                    for key, value in part_filter.items()
-                )
-            )
-            if part_cache_key not in part_cache:
-                if query_embedding is not None:
-                    part_nodes = self._raw_nodes_for_part(
-                        question,
-                        metadata,
-                        query_embedding=query_embedding,
-                    )
-                else:
-                    part_nodes = self._raw_nodes_for_part(question, metadata)
-                part_cache[part_cache_key] = self._sort_raw_nodes(
-                    part_nodes
-                )
-
-            window_start = span[0] - window
-            window_end = span[1] + window
-            for candidate in part_cache[part_cache_key]:
-                _, candidate_metadata = candidate
-                candidate_span = self._scene_span(candidate_metadata)
-                if candidate_span is None:
-                    continue
-                if candidate_span[0] <= window_end and candidate_span[1] >= window_start:
-                    expanded_nodes.append(candidate)
-
-        return self._dedupe_nodes(expanded_nodes)
-
-    def _normalized_speakers(self, metadata: dict[str, Any]) -> list[str]:
-        speakers = metadata.get("detected_speakers")
-        if isinstance(speakers, list):
-            return [str(speaker) for speaker in speakers if str(speaker)]
-        if isinstance(speakers, str):
-            return [speaker for speaker in speakers.split("|") if speaker]
-        return []
-
-    def _question_quote(self, question: str) -> str | None:
-        match = re.search(r"[\"“「『](.+?)[\"”」』]", question)
-        if match:
-            return match.group(1)
-
-        match = re.search(r"\bwho said\s+(.+?)[?.!]*$", question, re.IGNORECASE)
-        if match:
-            return match.group(1).strip(" '\"“”「」『』")
-        return None
-
-    def _structured_answer(self, question: str, analysis: QueryAnalysis) -> str | None:
-        source_store = getattr(self, "source_store", None)
-        if source_store is None:
-            return None
-
-        question_lower = question.casefold()
-        if "who said" in question_lower:
-            quote = self._question_quote(question)
-            if not quote:
-                return None
-            matches = source_store.turns_matching_text(quote)
-            if not matches:
-                return None
-            speakers = []
-            seen = set()
-            for match in matches:
-                speaker = str(match.get("speaker", ""))
-                if speaker and speaker not in seen:
-                    speakers.append(speaker)
-                    seen.add(speaker)
-            if not speakers:
-                return None
-            return f"{', '.join(speakers)} said it."
-
-        if analysis.intent_bucket == QUANTITATIVE_INTENT and analysis.character_names:
-            speaker = analysis.character_names[0]
-            count = source_store.count_turns(speaker)
-            return f"{speaker} has {count} dialogue turns in the indexed source records."
-        return None
-
-    def _query_terms(self, question: str) -> list[str]:
-        terms = []
-        terms.extend(term for term in re.findall(r"[\u3040-\u30ff\u3400-\u9fff々〆〤ー]+", question) if len(term) >= 2)
-        terms.extend(term for term in re.findall(r"[A-Za-z0-9][A-Za-z0-9'_-]*", question) if len(term) >= 2)
-
-        unique_terms = []
-        seen = set()
-        for term in terms:
-            normalized = term.casefold()
-            if normalized in seen:
-                continue
-            seen.add(normalized)
-            unique_terms.append(term)
-        return unique_terms
-
-    def _metadata_match_score(self, question: str, metadata: dict[str, Any]) -> int:
-        score = 0
-        question_lower = question.casefold()
-
-        arc_id = metadata.get("arc_id")
-        if isinstance(arc_id, str) and arc_id and arc_id in question:
-            score += 1
-
-        part_name = metadata.get("part_name")
-        if isinstance(part_name, str) and part_name and part_name.casefold() in question_lower:
-            score += 1
-
-        episode_name = str(metadata.get("episode_name", ""))
-        episode_match = re.search(r"第(\d+)話", episode_name)
-        if episode_match:
-            episode_number = episode_match.group(1)
-            if (
-                f"episode {episode_number}" in question_lower
-                or f"ep {episode_number}" in question_lower
-                or f"第{episode_number}話" in question
-            ):
-                score += 1
-
-        return score
-
-    def _near_seed_score(
-        self,
-        metadata: dict[str, Any],
-        seed_nodes: list[Node],
-    ) -> int:
-        candidate_span = self._scene_span(metadata)
-        if candidate_span is None:
-            return 0
-
-        score = 0
-        window = self._config().neighbor_scene_window
-        for _, seed_metadata in seed_nodes:
-            if self._raw_part_filter(metadata) != self._raw_part_filter(seed_metadata):
-                continue
-            seed_span = self._scene_span(seed_metadata)
-            if seed_span is None:
-                continue
-            if candidate_span[0] <= seed_span[1] + window and candidate_span[1] >= seed_span[0] - window:
-                score += 1
-        return score
-
-    def _score_raw_candidates(
-        self,
-        question: str,
-        expanded_question: str,
-        raw_nodes: list[Node],
-        seed_nodes: list[Node],
-    ) -> list[ScoredRankedNode]:
-        terms = self._query_terms(expanded_question)
-        seed_rank = {
-            self._node_key(document, metadata): index
-            for index, (document, metadata) in enumerate(seed_nodes)
-        }
-
-        scored_nodes: list[tuple[int, int, int, Node, dict[str, Any]]] = []
-        for index, (document, metadata) in enumerate(raw_nodes):
-            searchable = " ".join(
-                [
-                    document,
-                    str(metadata.get("arc_id", "")),
-                    str(metadata.get("episode_name", "")),
-                    str(metadata.get("part_name", "")),
-                    " ".join(self._normalized_speakers(metadata)),
-                ]
-            )
-            searchable_lower = searchable.casefold()
-            matched_terms = sum(1 for term in terms if term.casefold() in searchable_lower)
-            speaker_matches = sum(
-                1
-                for speaker in self._normalized_speakers(metadata)
-                if speaker and speaker in expanded_question
-            )
-            key = self._node_key(document, metadata)
-            is_seed = key in seed_rank
-            metadata_match_score = self._metadata_match_score(question, metadata)
-            near_seed_score = self._near_seed_score(metadata, seed_nodes)
-            score = (
-                matched_terms * 25
-                + speaker_matches * 30
-                + metadata_match_score * 40
-                + near_seed_score * 10
-                + (20 if is_seed else 0)
-            )
-            signal_breakdown = {
-                "matched_terms": matched_terms,
-                "speaker_matches": speaker_matches,
-                "metadata_match_score": metadata_match_score,
-                "near_seed_score": near_seed_score,
-                "is_seed": is_seed,
-            }
-            scored_nodes.append(
-                (
-                    -score,
-                    seed_rank.get(key, len(seed_rank) + index),
-                    index,
-                    (document, metadata),
-                    signal_breakdown,
-                )
-            )
-
-        scored_nodes.sort()
-        return [
-            (node, signal_breakdown, -negative_score)
-            for negative_score, _, _, node, signal_breakdown in scored_nodes
-        ][: self._config().max_ranked_candidates]
-
-    def _rank_raw_candidates(
-        self,
-        question: str,
-        expanded_question: str,
-        raw_nodes: list[Node],
-        seed_nodes: list[Node],
-    ) -> list[Node]:
-        return [
-            node
-            for node, _, _ in self._score_raw_candidates(
-                question,
-                expanded_question,
-                raw_nodes,
-                seed_nodes,
-            )
-        ]
-
-    def _build_context_chunks(self, raw_nodes: list[Node]) -> list[str]:
-        context_chunks = []
-        for idx, (document, meta) in enumerate(raw_nodes):
-            arc_id = meta.get("arc_id")
-            safe_print(
-                f"  Evidence {idx + 1}: Year {arc_id}, Ep: {meta.get('episode_name')}, "
-                f"Part: {meta.get('part_name')}, {self._scene_label(meta) or 'Scene unknown'}"
-            )
-
-            raw_text = self._fetch_raw_text(meta) or document
-            citation = self._citation_label(meta)
-            citation_metadata = self._citation_metadata(meta)
-            context_chunk = (
-                f"--- RAW EVIDENCE {idx + 1} "
-                f"(CITATION: {citation}; "
-                f"METADATA: {json.dumps(citation_metadata, ensure_ascii=False)}) ---\n"
-            )
-            context_chunk += f"RAW SOURCE TEXT:\n{raw_text}\n"
-            context_chunks.append(context_chunk)
-
-        return context_chunks
-
-    def _build_summary_context_chunks(self, summary_nodes: list[Node]) -> list[str]:
-        context_chunks = []
-        for idx, (document, meta) in enumerate(summary_nodes):
-            citation = self._summary_citation_label(meta)
-            citation_metadata = self._citation_metadata(meta)
-            safe_print(
-                f"  Summary evidence {idx + 1}: Year {meta.get('arc_id')}, "
-                f"Story type: {meta.get('story_type')}, "
-                f"Episode: {self._summary_episode_value(meta)}, "
-                f"Part: {self._summary_part_label(meta)}, "
-                f"summary_level: {meta.get('summary_level')}"
-            )
-            context_chunk = (
-                f"--- SUMMARY EVIDENCE {idx + 1} "
-                f"(CITATION: {citation}; "
-                f"METADATA: {json.dumps(citation_metadata, ensure_ascii=False)}) ---\n"
-            )
-            context_chunk += (
-                "SUMMARY METADATA:\n"
-                f"Year: {meta.get('arc_id')}\n"
-                f"Story type: {meta.get('story_type')}\n"
-                f"Episode: {self._summary_episode_value(meta)}\n"
-                f"Part: {self._summary_part_label(meta)}\n"
-                f"Summary level: {meta.get('summary_level')}\n\n"
-                f"GENERATED SUMMARY TEXT:\n{document}\n"
-            )
-            context_chunks.append(context_chunk)
-
-        return context_chunks
-
-    def _raw_arc_ids(self, raw_nodes: list[tuple[str, dict[str, Any]]]) -> set[str]:
-        arc_ids = set()
-        for _, metadata in raw_nodes:
-            arc_id = metadata.get("arc_id")
-            if isinstance(arc_id, str):
-                arc_ids.add(arc_id)
-        return arc_ids
-
-    def _answer_from_raw_evidence(
-        self,
-        question: str,
-        raw_nodes: list[Node],
-        analysis: QueryAnalysis | None = None,
-    ) -> str:
-        state_ledger_arc_ids = self._state_ledger_arc_ids(question, self._raw_arc_ids(raw_nodes))
-        system_prompt = self._build_system_prompt(state_ledger_arc_ids, analysis)
-        combined_context = "\n".join(self._build_context_chunks(raw_nodes))
-
-        user_prompt = (
-            "Please answer the following question based ONLY on the raw source text provided below.\n\n"
-            "Every factual claim should cite one or more provided CITATION labels exactly as written. "
-            "Use episode numbers in citations, never Japanese episode titles.\n\n"
-            f"QUESTION: {question}\n\n"
-            f"CONTEXT:\n{combined_context}"
-        )
-
-        safe_print(f"Synthesizing final answer with {get_generation_model_name()}...")
-        result = create_text_agent(system_prompt).run_sync(user_prompt)
-        return result.output.strip() or "No answer generated."
-
-    def _answer_from_summary_evidence(
-        self,
-        question: str,
-        summary_nodes: list[Node],
-    ) -> str:
-        state_ledger_arc_ids = self._state_ledger_arc_ids(question, self._raw_arc_ids(summary_nodes))
-        system_prompt = self._build_system_prompt(
-            state_ledger_arc_ids,
-            None,
-            context_kind="summary",
-        )
-        combined_context = "\n".join(self._build_summary_context_chunks(summary_nodes))
-
-        user_prompt = (
-            "Please answer the following question based ONLY on the retrieved context provided "
-            "below. The context may contain generated summaries rather than raw source text.\n\n"
-            "Every factual claim should cite one or more provided CITATION labels exactly as "
-            "written. Use the summary citation labels exactly as provided, including "
-            "summary_level. Do not invent scene labels for summary evidence.\n\n"
-            f"QUESTION: {question}\n\n"
-            f"CONTEXT:\n{combined_context}"
-        )
-
-        safe_print(f"Synthesizing final answer with {get_generation_model_name()}...")
-        result = create_text_agent(system_prompt).run_sync(user_prompt)
-        return result.output.strip() or "No answer generated."
-
-    def _trace_node_id(self, document: str, metadata: dict[str, Any]) -> str:
-        chunk_id = metadata.get("chunk_id")
-        if isinstance(chunk_id, str) and chunk_id:
-            return chunk_id
-        file_path = metadata.get("file_path")
-        span = self._scene_span(metadata)
-        if isinstance(file_path, str) and span is not None:
-            return f"{file_path}:{span[0]}-{span[1]}"
-        key = self._node_key(document, metadata)
-        return json.dumps(key, ensure_ascii=False, sort_keys=True, default=str)
-
-    def _source_identity(self, metadata: dict[str, Any]) -> SourceIdentity | None:
-        span = self._scene_span(metadata)
-        if span is None:
-            return None
-        return SourceIdentity(
-            arc_id=str(metadata.get("arc_id", "")),
-            story_type=str(metadata.get("story_type", "")),
-            episode_name=str(metadata.get("episode_name", "")),
-            part_name=str(metadata.get("part_name", "")),
-            file_path=str(metadata.get("file_path", "")),
-            scene_start=span[0],
-            scene_end=span[1],
-        )
-
-    def _trace_candidate(
-        self,
-        node: Node,
-        *,
-        rank: int,
-        scores: CandidateScores | None = None,
-        signal_breakdown: dict[str, Any] | None = None,
-        provenance: str | None = None,
-        provenance_node_id: str | None = None,
-    ) -> CandidateTrace:
-        document, metadata = node
-        return CandidateTrace(
-            node_id=self._trace_node_id(document, metadata),
-            rank=rank,
-            candidate_kind="raw_span" if metadata.get("summary_level") == 4 else "summary",
-            text=document,
-            scores=scores or CandidateScores(),
-            metadata=dict(metadata),
-            source_span=self._source_identity(metadata),
-            signal_breakdown=signal_breakdown or {},
-            provenance=provenance,  # type: ignore[arg-type]
-            provenance_node_id=provenance_node_id,
-        )
-
-    def _trace_stage(
-        self,
-        name: StageName,
-        candidates: list[CandidateTrace] | None,
-        unavailable_reason: str | None = None,
-        metadata: dict[str, Any] | None = None,
-    ) -> StageTrace:
-        return StageTrace(
-            name=name,
-            candidates=candidates,
-            unavailable_reason=unavailable_reason,
-            metadata=metadata or {},
-        )
-
-    def _neighbor_trace_provenance(
-        self,
-        node: Node,
-        seed_nodes: list[Node],
-    ) -> tuple[str | None, str | None]:
-        document, metadata = node
-        key = self._node_key(document, metadata)
-        seed_keys = {
-            self._node_key(seed_document, seed_metadata)
-            for seed_document, seed_metadata in seed_nodes
-        }
-        if key in seed_keys:
-            return "direct_hit", None
-
-        candidate_span = self._scene_span(metadata)
-        if candidate_span is None:
-            return None, None
-        window = self._config().neighbor_scene_window
-        for seed_document, seed_metadata in seed_nodes:
-            if self._raw_part_filter(metadata) != self._raw_part_filter(seed_metadata):
-                continue
-            seed_span = self._scene_span(seed_metadata)
-            if seed_span is None:
-                continue
-            if candidate_span[0] <= seed_span[1] + window and candidate_span[1] >= seed_span[0] - window:
-                return "neighbor_of", self._trace_node_id(seed_document, seed_metadata)
-        return None, None
-
-    def _hybrid_retrieve_trace(
-        self,
-        question: str,
-        *,
-        n_results: int,
-        where: dict[str, Any] | None,
-        query_embedding: list[float] | None,
-        dense_unavailable_reason: str | None = None,
-    ) -> tuple[list[Node], dict[StageName, StageTrace]]:
-        dense_nodes: list[Node] = []
-        dense_distances: dict[tuple[Any, ...], float | None] = {}
-        if query_embedding is None:
-            dense_unavailable_reason = dense_unavailable_reason or "query embedding unavailable"
-        else:
-            try:
-                dense_ranked_nodes = self._retrieve_with_dense_scores(
-                    question,
-                    n_results=n_results,
-                    where=where,
-                    query_embedding=query_embedding,
-                )
-                for node, distance in dense_ranked_nodes:
-                    dense_nodes.append(node)
-                    dense_distances[self._node_key(*node)] = distance
-            except Exception as exc:
-                dense_unavailable_reason = f"dense retrieval unavailable: {exc}"
-
-        lexical_nodes = self._lexical_retrieve(question, n_results=n_results, where=where)
-        fused_with_scores = self._rrf_fuse_with_scores([dense_nodes, lexical_nodes])[:n_results]
-        fused_nodes = [node for node, _ in fused_with_scores]
-
-        dense_candidates = [
-            self._trace_candidate(
-                node,
-                rank=rank,
-                scores=CandidateScores(
-                    dense_rank=rank,
-                    dense_distance=dense_distances.get(self._node_key(*node)),
-                ),
-            )
-            for rank, node in enumerate(dense_nodes, start=1)
-        ]
-        lexical_candidates = [
-            self._trace_candidate(
-                node,
-                rank=rank,
-                scores=CandidateScores(lexical_rank=rank),
-            )
-            for rank, node in enumerate(lexical_nodes, start=1)
-        ]
-        fused_candidates = [
-            self._trace_candidate(
-                node,
-                rank=rank,
-                scores=CandidateScores(rrf_score=score),
-            )
-            for rank, (node, score) in enumerate(fused_with_scores, start=1)
-        ]
-        return fused_nodes, {
-            "dense_raw": self._trace_stage(
-                "dense_raw",
-                None if dense_unavailable_reason else dense_candidates,
-                dense_unavailable_reason,
-            ),
-            "lexical_raw": self._trace_stage("lexical_raw", lexical_candidates),
-            "rrf_fusion": self._trace_stage("rrf_fusion", fused_candidates),
-        }
-
-    def _raw_only_retrieve(
-        self,
-        question: str,
-        *,
-        query_embedding: list[float] | None = None,
-        analysis: QueryAnalysis | None = None,
-    ) -> list[Node]:
-        return self._hybrid_retrieve(
-            question,
-            n_results=self._config().raw_candidate_count,
-            where=self._where_for_analysis(
-                analysis,
-                summary_level=4,
-                include_scene_constraint=True,
-            ),
-            query_embedding=query_embedding,
-        )
-
-    def _filter_raw_nodes_by_analysis(
-        self,
-        nodes: list[Node],
-        analysis: QueryAnalysis,
-    ) -> list[Node]:
-        raw_filter = self._where_for_analysis(
-            analysis,
-            summary_level=4,
-            include_scene_constraint=True,
-        )
-        filtered = [
-            (document, metadata)
-            for document, metadata in nodes
-            if self._metadata_matches_filter(metadata, raw_filter)
-        ]
-        if analysis.scene_constraint is None:
-            return filtered
-
-        scene = analysis.scene_constraint
-        return [
-            (document, metadata)
-            for document, metadata in filtered
-            if (span := self._scene_span(metadata)) is not None
-            and span[0] <= scene.end
-            and span[1] >= scene.start
-        ]
-
-    def _story_order(self, metadata: dict[str, Any]) -> int | None:
-        order = metadata.get("story_order", metadata.get("canonical_story_order"))
-        return order if isinstance(order, int) else None
-
-    def _filter_before_semantic_boundary(
-        self,
-        question: str,
-        expanded_question: str,
-        raw_nodes: list[Node],
-        seed_nodes: list[Node],
-        analysis: QueryAnalysis,
-    ) -> list[Node]:
-        if analysis.semantic_boundary is None:
-            return raw_nodes
-
-        boundary_ranked_nodes = self._rank_raw_candidates(
-            analysis.semantic_boundary,
-            expanded_question,
-            raw_nodes,
-            seed_nodes,
-        )
-        if not boundary_ranked_nodes:
-            return []
-
-        _, boundary_metadata = boundary_ranked_nodes[0]
-        boundary_order = self._story_order(boundary_metadata)
+                if c…10667 tokens truncated…dary_order = self._story_order(boundary_metadata)
         if boundary_order is None:
             return raw_nodes
 
@@ -1933,18 +860,51 @@ class StoryQueryEngine:
 
     def query(self, question: str) -> str:
         """Executes the raw-first RAG query flow."""
+        prepared = self._prepare_query(question)
+        if prepared.immediate_answer is not None:
+            return prepared.immediate_answer
+        if prepared.system_prompt is None or prepared.user_prompt is None:
+            return "No answer generated."
+        return self._answer_from_prompts(prepared.system_prompt, prepared.user_prompt)
+
+    def stream_query(self, question: str) -> StreamingQueryResult:
+        """Prepares a query once and returns a one-use iterator of answer deltas."""
+        prepared = self._prepare_query(question)
+        return StreamingQueryResult(
+            answer_deltas=self._stream_prepared_answer(prepared),
+            router_metadata=prepared.router_metadata,
+        )
+
+    def _prepare_query(self, question: str) -> _PreparedQuery:
         if self._config().routing_mode == "llm_router":
             safe_print("Routing query to a typed retrieval tool...")
             routed = self._router_dispatch_with_trace(question)
+            router_stage = routed.stages.get("router")
+            router_metadata = dict(router_stage.metadata) if router_stage is not None else None
             if routed.direct_answer is not None:
-                return routed.direct_answer
+                return _PreparedQuery(
+                    immediate_answer=routed.direct_answer,
+                    router_metadata=router_metadata,
+                )
             if not routed.nodes:
-                return self._router_unavailable_message(routed.stages)
+                return _PreparedQuery(
+                    immediate_answer=self._router_unavailable_message(routed.stages),
+                    router_metadata=router_metadata,
+                )
             if self._routed_chosen_tool(routed.stages) == "search_summaries":
                 safe_print("Building answer context from routed summary evidence...")
+                system_prompt, user_prompt = self._summary_answer_prompts(question, routed.nodes)
             else:
                 safe_print("Building answer context from routed source evidence...")
-            return self._answer_from_routed_evidence(question, routed)
+                system_prompt, user_prompt = self._raw_answer_prompts(question, routed.nodes, None)
+            return _PreparedQuery(
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                router_metadata=router_metadata,
+                final_citation_labels=tuple(
+                    self._citation_label(metadata) for _, metadata in routed.nodes
+                ),
+            )
 
         safe_print("Searching raw source evidence...")
         analysis = None
@@ -1952,7 +912,7 @@ class StoryQueryEngine:
             analysis = analyze_query(question, self.glossary)
             structured_answer = self._structured_answer(question, analysis)
             if structured_answer is not None:
-                return structured_answer
+                return _PreparedQuery(immediate_answer=structured_answer)
         expanded_question = self._expanded_question(question)
         query_embedding = self._query_embedding(expanded_question)
         retrieved_nodes = self._raw_only_retrieve(
@@ -1969,7 +929,7 @@ class StoryQueryEngine:
             raw_nodes = self._filter_raw_nodes_by_analysis(raw_nodes, analysis)
 
         if not raw_nodes:
-            return INSUFFICIENT_SOURCE_CONTEXT
+            return _PreparedQuery(immediate_answer=INSUFFICIENT_SOURCE_CONTEXT)
 
         safe_print("Expanding neighboring raw evidence...")
         expanded_raw_nodes = self._expand_raw_neighbors(
@@ -2000,7 +960,48 @@ class StoryQueryEngine:
             final_raw_nodes = ranked_raw_nodes[: self._config().final_top_k]
 
         if not final_raw_nodes:
-            return INSUFFICIENT_SOURCE_CONTEXT
+            return _PreparedQuery(immediate_answer=INSUFFICIENT_SOURCE_CONTEXT)
 
         safe_print("Building answer context from raw source scenes...")
-        return self._answer_from_raw_evidence(question, final_raw_nodes, analysis)
+        system_prompt, user_prompt = self._raw_answer_prompts(question, final_raw_nodes, analysis)
+        return _PreparedQuery(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            final_citation_labels=tuple(
+                self._citation_label(metadata) for _, metadata in final_raw_nodes
+            ),
+        )
+
+    def _stream_prepared_answer(self, prepared: _PreparedQuery) -> Iterator[str]:
+        if prepared.immediate_answer is not None:
+            yield prepared.immediate_answer
+            return
+        if prepared.system_prompt is None or prepared.user_prompt is None:
+            yield "No answer generated."
+            return
+
+        safe_print(f"Synthesizing final answer with {get_generation_model_name()}...")
+        result = create_text_agent(prepared.system_prompt).run_stream_sync(prepared.user_prompt)
+        source_deltas = result.stream_text(delta=True, debounce_by=0.1)
+        pending_whitespace = ""
+        emitted_text = False
+        try:
+            for delta in source_deltas:
+                if not delta:
+                    continue
+                combined = pending_whitespace + delta
+                text = combined.rstrip()
+                if not text:
+                    pending_whitespace = combined
+                    continue
+                pending_whitespace = combined[len(text) :]
+                emitted_text = True
+                yield text
+        finally:
+            close = getattr(source_deltas, "close", None)
+            if close is not None:
+                close()
+
+        if not emitted_text:
+            yield "No answer generated."
+

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from linkura_story_indexer import cli
+from linkura_story_indexer.query.engine import StreamingQueryResult
+
+
+class RecordingConsole:
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def print(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append((args, kwargs))
+
+    def text(self) -> str:
+        return "\n".join(str(args[0]) for args, _ in self.calls if args)
+
+
+def _prompt_from(values: list[str]) -> Any:
+    questions = iter(values)
+    return lambda prompt: next(questions)
+
+
+def test_chat_streams_incremental_verbatim_output_and_reuses_router_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recording_console = RecordingConsole()
+
+    class FakeEngine:
+        def __init__(self, **kwargs: Any):
+            self.questions: list[str] = []
+
+        def stream_query(self, question: str) -> StreamingQueryResult:
+            self.questions.append(question)
+            return StreamingQueryResult(
+                answer_deltas=iter(["[first]", " second"]),
+                router_metadata={
+                    "router_model": "fixture-router",
+                    "chosen_tool": "search_raw",
+                    "validated_args": {"query": question},
+                    "fallback_used": False,
+                    "fallback_reason": None,
+                },
+            )
+
+    engine = FakeEngine()
+    monkeypatch.setattr(cli, "console", recording_console)
+    monkeypatch.setattr(cli, "initialize_query_settings", lambda: None)
+    monkeypatch.setattr(cli, "StoryQueryEngine", lambda **kwargs: engine)
+    monkeypatch.setattr(cli.typer, "prompt", _prompt_from(["question", "exit"]))
+
+    cli.chat(routing_mode="llm_router", show_router=True)
+
+    assert engine.questions == ["question"]
+    assert "  chosen_tool: search_raw" in recording_console.text()
+    chunk_calls = [call for call in recording_console.calls if call[0] in {("[first]",), (" second",)}]
+    assert [call[0][0] for call in chunk_calls] == ["[first]", " second"]
+    assert all(call[1]["markup"] is False for call in chunk_calls)
+    assert all(call[1]["highlight"] is True for call in chunk_calls)
+    assert all(call[1]["end"] == "" for call in chunk_calls)
+
+
+def test_chat_ctrl_c_closes_active_stream_and_continues(monkeypatch: pytest.MonkeyPatch) -> None:
+    recording_console = RecordingConsole()
+    closed = False
+
+    def interrupted_stream() -> Iterator[str]:
+        nonlocal closed
+        try:
+            yield "partial"
+            raise KeyboardInterrupt
+        finally:
+            closed = True
+
+    class FakeEngine:
+        def __init__(self, **kwargs: Any):
+            self.questions: list[str] = []
+
+        def stream_query(self, question: str) -> StreamingQueryResult:
+            self.questions.append(question)
+            if question == "first":
+                return StreamingQueryResult(answer_deltas=interrupted_stream())
+            return StreamingQueryResult(answer_deltas=iter(["complete"]))
+
+    engine = FakeEngine()
+    monkeypatch.setattr(cli, "console", recording_console)
+    monkeypatch.setattr(cli, "initialize_query_settings", lambda: None)
+    monkeypatch.setattr(cli, "StoryQueryEngine", lambda **kwargs: engine)
+    monkeypatch.setattr(cli.typer, "prompt", _prompt_from(["first", "second", "exit"]))
+
+    cli.chat(routing_mode="off", show_router=False)
+
+    assert closed is True
+    assert engine.questions == ["first", "second"]
+    assert "Answer interrupted. Ready for another question." in recording_console.text()
+    assert "complete" in recording_console.text()
+    assert "Chat session ended. Goodbye!" in recording_console.text()
+
+
+@pytest.mark.parametrize("prompt_error", [KeyboardInterrupt, EOFError])
+def test_chat_prompt_interrupt_or_eof_exits_normally(
+    monkeypatch: pytest.MonkeyPatch,
+    prompt_error: type[BaseException],
+) -> None:
+    recording_console = RecordingConsole()
+
+    class FakeEngine:
+        def __init__(self, **kwargs: Any):
+            self.stream_called = False
+
+        def stream_query(self, question: str) -> StreamingQueryResult:
+            self.stream_called = True
+            raise AssertionError("stream_query should not be called")
+
+    engine = FakeEngine()
+    monkeypatch.setattr(cli, "console", recording_console)
+    monkeypatch.setattr(cli, "initialize_query_settings", lambda: None)
+    monkeypatch.setattr(cli, "StoryQueryEngine", lambda **kwargs: engine)
+    monkeypatch.setattr(cli.typer, "prompt", lambda prompt: (_ for _ in ()).throw(prompt_error()))
+
+    cli.chat(routing_mode="off", show_router=False)
+
+    assert engine.stream_called is False
+    assert "Chat session ended. Goodbye!" in recording_console.text()
+
+
+def test_query_command_keeps_non_streaming_engine_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    recording_console = RecordingConsole()
+
+    class FakeEngine:
+        def __init__(self, **kwargs: Any):
+            self.query_calls: list[str] = []
+
+        def query(self, question: str) -> str:
+            self.query_calls.append(question)
+            return "synchronous answer"
+
+        def stream_query(self, question: str) -> StreamingQueryResult:
+            raise AssertionError("query command must not use stream_query")
+
+    engine = FakeEngine()
+    monkeypatch.setattr(cli, "console", recording_console)
+    monkeypatch.setattr(cli, "initialize_query_settings", lambda: None)
+    monkeypatch.setattr(cli, "StoryQueryEngine", lambda **kwargs: engine)
+
+    cli.query("question", routing_mode="off", show_router=False)
+
+    assert engine.query_calls == ["question"]
+    assert "synchronous answer" in recording_console.text()
+

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -309,8 +309,8 @@ def test_query_uses_configured_candidate_counts(monkeypatch):
     monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
     monkeypatch.setattr(
         engine,
-        "_answer_from_raw_evidence",
-        lambda question, nodes, analysis: "answered",
+        "_answer_from_prompts",
+        lambda system_prompt, user_prompt: "answered",
     )
 
     assert engine.query("What happened?") == "answered"
@@ -341,8 +341,8 @@ def test_query_default_does_not_analyze(monkeypatch):
     monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
     monkeypatch.setattr(
         engine,
-        "_answer_from_raw_evidence",
-        lambda question, nodes, analysis: "answered",
+        "_answer_from_prompts",
+        lambda system_prompt, user_prompt: "answered",
     )
 
     assert engine.query("What happened in the 105th term?") == "answered"
@@ -368,8 +368,8 @@ def test_query_default_uses_raw_filter_for_scoped_questions(monkeypatch):
     monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
     monkeypatch.setattr(
         engine,
-        "_answer_from_raw_evidence",
-        lambda question, nodes, analysis: "answered",
+        "_answer_from_prompts",
+        lambda system_prompt, user_prompt: "answered",
     )
 
     scoped_questions = [
@@ -397,8 +397,8 @@ def test_query_default_skips_structured_answers(monkeypatch):
     monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
     monkeypatch.setattr(
         engine,
-        "_answer_from_raw_evidence",
-        lambda question, nodes, analysis: "answered from raw",
+        "_answer_from_prompts",
+        lambda system_prompt, user_prompt: "answered from raw",
     )
 
     assert engine.query("Who said 「行こう」?") == "answered from raw"
@@ -422,16 +422,17 @@ def test_query_default_expands_ranks_and_synthesizes_raw_evidence(monkeypatch):
     )
     monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
 
-    def fake_answer(
+    def fake_prompts(
         question: str,
         nodes: list[tuple[str, dict[str, Any]]],
         analysis: Any,
-    ) -> str:
+    ) -> tuple[str, str]:
         captured_nodes.extend(nodes)
         captured_analysis.append(analysis)
-        return "answered"
+        return "system", "user"
 
-    monkeypatch.setattr(engine, "_answer_from_raw_evidence", fake_answer)
+    monkeypatch.setattr(engine, "_raw_answer_prompts", fake_prompts)
+    monkeypatch.setattr(engine, "_answer_from_prompts", lambda system, user: "answered")
 
     assert engine.query("What does Kaho do?") == "answered"
     assert {engine._scene_span(metadata) for _, metadata in captured_nodes} == {
@@ -465,8 +466,8 @@ def test_query_analysis_enabled_applies_analyzer_filters(monkeypatch):
     monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
     monkeypatch.setattr(
         engine,
-        "_answer_from_raw_evidence",
-        lambda question, nodes, analysis: "answered",
+        "_answer_from_prompts",
+        lambda system_prompt, user_prompt: "answered",
     )
 
     assert engine.query("what happened at the end of the 105th term?") == "answered"
@@ -584,192 +585,7 @@ def test_scene_range_constraint_matches_overlapping_coalesced_chunks() -> None:
         raw_node("scenes 5-6", scene_start=4, scene_end=5),
     ]
 
-    filtered = engine._filter_raw_nodes_by_analysis(nodes, analysis)
-
-    assert filtered == [nodes[1], nodes[2]]
-
-
-def test_temporal_filter_resolves_to_numeric_story_order() -> None:
-    engine = make_engine()
-
-    class FakeCollection:
-        def get(self, **kwargs: Any) -> dict[str, list[dict[str, Any]]]:
-            assert kwargs["where"] == {"$and": [{"summary_level": 4}, {"episode_number": 12}]}
-            return {"metadatas": [{"story_order": 120}, {"story_order": 125}]}
-
-    engine.collection = FakeCollection()
-    analysis = analyze_query("What did Kaho know before episode 12?")
-
-    where = engine._where_for_analysis(analysis, summary_level=4)
-
-    assert where == {
-        "$and": [
-            {"summary_level": 4},
-            {"story_order": {"$lt": 120}},
-        ]
-    }
-
-
-def test_semantic_boundary_keeps_prior_story_order(monkeypatch) -> None:
-    engine = make_engine()
-    analysis = analyze_query("scenes before Ruri falls asleep")
-    before = raw_node("before", scene_start=0)
-    boundary = raw_node("boundary", scene_start=1)
-    after = raw_node("after", scene_start=2)
-    before[1]["story_order"] = 10
-    boundary[1]["story_order"] = 20
-    after[1]["story_order"] = 30
-
-    monkeypatch.setattr(
-        engine,
-        "_rank_raw_candidates",
-        lambda question, expanded_question, raw_nodes, seed_nodes: [boundary],
-    )
-
-    filtered = engine._filter_before_semantic_boundary(
-        "scenes before Ruri falls asleep",
-        "expanded",
-        [before, boundary, after],
-        [boundary],
-        analysis,
-    )
-
-    assert filtered == [before]
-
-
-def test_tier_two_fanout_retrieves_child_raw_evidence(monkeypatch):
-    engine = make_engine()
-    calls: list[dict[str, Any]] = []
-    tier_two_summary = (
-        "episode summary",
-        {
-            "summary_level": 2,
-            "parent_episode_id": "103|Main|第3話『テスト』",
-        },
-    )
-    child = raw_node(
-        "child scene",
-        scene_start=2,
-        parent_part_id="103|Main|第3話『テスト』|2",
-    )
-
-    def fake_hybrid_retrieve(
-        question: str,
-        *,
-        n_results: int,
-        where: dict[str, Any] | None = None,
-        query_embedding: list[float] | None = None,
-    ) -> list[tuple[str, dict[str, Any]]]:
-        calls.append({"n_results": n_results, "where": where})
-        assert query_embedding == [0.1]
-        return [child]
-
-    monkeypatch.setattr(engine, "_hybrid_retrieve", fake_hybrid_retrieve)
-    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
-
-    expanded = engine._expand_summaries_to_raw_scenes("question", [tier_two_summary])
-
-    assert expanded == [child]
-    assert calls == [
-        {
-            "n_results": 30,
-            "where": {
-                "$and": [
-                    {"summary_level": 4},
-                    {"parent_episode_id": "103|Main|第3話『テスト』"},
-                ]
-            },
-        }
-    ]
-
-
-def test_summary_fanout_preserves_coalesced_child_spans(monkeypatch):
-    engine = make_engine()
-    tier_one_summary = (
-        "year summary",
-        {
-            "summary_level": 1,
-            "parent_year_id": "103",
-        },
-    )
-    coalesced_child = raw_node(
-        "coalesced child scene span",
-        scene_start=4,
-        scene_end=7,
-        parent_part_id="103|Main|第3話『テスト』|2",
-    )
-
-    monkeypatch.setattr(
-        engine,
-        "_hybrid_retrieve",
-        lambda question, **kwargs: [coalesced_child],
-    )
-    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
-
-    expanded = engine._expand_summaries_to_raw_scenes("question", [tier_one_summary])
-
-    assert expanded == [coalesced_child]
-    assert engine._scene_span(expanded[0][1]) == (4, 7)
-
-
-def test_query_uses_only_raw_retrieval_for_scoped_question(monkeypatch):
-    engine = make_engine()
-    query_calls: list[dict[str, Any]] = []
-    embedding_calls: list[list[str]] = []
-    agent_prompts: list[str] = []
-
-    class FakeCollection:
-        def query(self, **kwargs: Any) -> dict[str, list[list[Any]]]:
-            query_calls.append(kwargs)
-            if kwargs.get("where") == {"summary_level": 4}:
-                return {
-                    "documents": [["花帆 reached the end of the term in the raw scene."]],
-                    "metadatas": [
-                        [
-                            {
-                                "arc_id": "105",
-                                "story_type": "Main",
-                                "episode_name": "第12話『テスト』",
-                                "part_name": "2",
-                                "summary_level": 4,
-                                "file_path": "missing.md",
-                                "scene_index": 4,
-                                "scene_start": 4,
-                                "scene_end": 4,
-                                "canonical_story_order": 1050,
-                                "parent_part_id": "105|Main|第12話『テスト』|2",
-                            }
-                        ]
-                    ],
-                }
-            return {
-                "documents": [[]],
-                "metadatas": [[]],
-            }
-
-    class FakeAgent:
-        def run_sync(self, prompt: str) -> Any:
-            agent_prompts.append(prompt)
-
-            class Result:
-                output = "answered from raw scene"
-
-            return Result()
-
-    def fake_embed_texts(texts: list[str], *, task_type: str) -> list[list[float]]:
-        embedding_calls.append(texts)
-        return [[0.1]]
-
-    monkeypatch.setattr(query_engine, "embed_texts", fake_embed_texts)
-    monkeypatch.setattr(query_engine, "create_text_agent", lambda system_prompt: FakeAgent())
-    engine.collection = FakeCollection()
-
-    answer = engine.query("what happened to kaho at the end of the 105th term?")
-
-    assert answer == "answered from raw scene"
-    assert embedding_calls == [["what happened to kaho at the end of the 105th term?"]]
-    assert len(query_calls) == 1
-    assert query_calls[0]["where"] == {"summary_level": 4}
+    fi…1569 tokens truncated…mmary_level": 4}
     assert "SUMMARY:" not in agent_prompts[0]
     assert "花帆 reached the end of the term in the raw scene." in agent_prompts[0]
     assert "105 · Episode 12 · Part 2 · Scene 5" in agent_prompts[0]
@@ -1053,18 +869,145 @@ def test_query_caps_final_raw_evidence_to_configured_top_k(monkeypatch):
     monkeypatch.setattr(engine, "_hybrid_retrieve", lambda question, **kwargs: raw_nodes)
     monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
 
-    def fake_answer(
+    def fake_prompts(
         question: str,
         nodes: list[tuple[str, dict[str, Any]]],
         analysis: Any,
-    ) -> str:
+    ) -> tuple[str, str]:
         captured_counts.append(len(nodes))
-        return "answered"
+        return "system", "user"
 
-    monkeypatch.setattr(engine, "_answer_from_raw_evidence", fake_answer)
+    monkeypatch.setattr(engine, "_raw_answer_prompts", fake_prompts)
+    monkeypatch.setattr(engine, "_answer_from_prompts", lambda system, user: "answered")
 
     assert engine.query("What happened?") == "answered"
     assert captured_counts == [5]
+
+
+def test_stream_query_preserves_whitespace_boundaries_and_discards_trailing_whitespace(
+    monkeypatch,
+):
+    engine = make_engine()
+    raw_hit = raw_node("花帆: raw scene", scene_start=4)
+
+    class FakeStreamResult:
+        def stream_text(self, *, delta: bool, debounce_by: float) -> Any:
+            assert delta is True
+            assert debounce_by == 0.1
+            return iter(["  ", "Hello ", "\n", "world", "  "])
+
+    class FakeAgent:
+        def run_stream_sync(self, prompt: str) -> FakeStreamResult:
+            return FakeStreamResult()
+
+    monkeypatch.setattr(engine, "_hybrid_retrieve", lambda question, **kwargs: [raw_hit])
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
+    monkeypatch.setattr(query_engine, "create_text_agent", lambda system_prompt: FakeAgent())
+
+    result = engine.stream_query("What happened?")
+    deltas = result.answer_deltas
+
+    assert iter(deltas) is deltas
+    assert list(deltas) == ["  Hello", " \nworld"]
+    assert list(deltas) == []
+
+
+def test_stream_query_uses_empty_output_fallback(monkeypatch):
+    engine = make_engine()
+    raw_hit = raw_node("花帆: raw scene", scene_start=4)
+
+    class FakeStreamResult:
+        def stream_text(self, *, delta: bool, debounce_by: float) -> Any:
+            return iter(["", "  ", "\n"])
+
+    class FakeAgent:
+        def run_stream_sync(self, prompt: str) -> FakeStreamResult:
+            return FakeStreamResult()
+
+    monkeypatch.setattr(engine, "_hybrid_retrieve", lambda question, **kwargs: [raw_hit])
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
+    monkeypatch.setattr(query_engine, "create_text_agent", lambda system_prompt: FakeAgent())
+
+    assert list(engine.stream_query("What happened?").answer_deltas) == [
+        "No answer generated."
+    ]
+
+
+def test_stream_and_sync_queries_share_the_same_prompts_and_evidence(monkeypatch):
+    engine = make_engine()
+    raw_hit = raw_node("花帆: raw scene", scene_start=4)
+    calls: list[tuple[str, str, str]] = []
+
+    class FakeStreamResult:
+        def __init__(self, system_prompt: str, user_prompt: str):
+            self.system_prompt = system_prompt
+            self.user_prompt = user_prompt
+
+        def stream_text(self, *, delta: bool, debounce_by: float) -> Any:
+            calls.append(("stream", self.system_prompt, self.user_prompt))
+            return iter(["streamed answer"])
+
+    class FakeAgent:
+        def __init__(self, system_prompt: str):
+            self.system_prompt = system_prompt
+
+        def run_sync(self, prompt: str) -> Any:
+            calls.append(("sync", self.system_prompt, prompt))
+
+            class Result:
+                output = "synchronous answer"
+
+            return Result()
+
+        def run_stream_sync(self, prompt: str) -> FakeStreamResult:
+            return FakeStreamResult(self.system_prompt, prompt)
+
+    monkeypatch.setattr(engine, "_hybrid_retrieve", lambda question, **kwargs: [raw_hit])
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
+    monkeypatch.setattr(
+        query_engine,
+        "create_text_agent",
+        lambda system_prompt: FakeAgent(system_prompt),
+    )
+
+    assert engine.query("What happened?") == "synchronous answer"
+    assert list(engine.stream_query("What happened?").answer_deltas) == ["streamed answer"]
+    assert calls[0][1:] == calls[1][1:]
+
+
+def test_stream_query_immediate_answers_are_single_chunks(monkeypatch):
+    engine = make_engine()
+    engine.retrieval_config = RetrievalConfig(routing_mode="heuristic")
+
+    class FakeSourceStore:
+        def count_turns(self, speaker: str) -> int:
+            return 3
+
+    engine.source_store = FakeSourceStore()
+    engine.glossary = {"characters": {"花帆": "Kaho Hinoshita"}}
+    monkeypatch.setattr(
+        query_engine,
+        "create_text_agent",
+        lambda system_prompt: (_ for _ in ()).throw(
+            AssertionError("immediate answers must not create a model agent")
+        ),
+    )
+
+    result = engine.stream_query("How many turns does Kaho have?")
+
+    assert list(result.answer_deltas) == [
+        "花帆 has 3 dialogue turns in the indexed source records."
+    ]
+
+
+def test_stream_query_insufficient_context_is_one_immediate_chunk(monkeypatch):
+    engine = make_engine()
+    monkeypatch.setattr(engine, "_hybrid_retrieve", lambda question, **kwargs: [])
+    monkeypatch.setattr(engine, "_query_embedding", lambda question: [0.1])
+
+    result = engine.stream_query("What happened?")
+
+    assert list(result.answer_deltas) == [INSUFFICIENT_SOURCE_CONTEXT]
 
 
 def test_fetch_raw_text_returns_only_requested_scene(tmp_path):
@@ -1196,3 +1139,4 @@ def test_summary_citation_labels_include_summary_scope_without_scene():
     assert "Scene" not in year_label
     assert "Scene" not in episode_label
     assert "Scene" not in part_label
+

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -326,6 +326,65 @@ def test_llm_router_returns_direct_glossary_answer() -> None:
     assert trace.stages["router"].metadata["chosen_tool"] == "lookup_glossary"
 
 
+def test_stream_query_returns_direct_glossary_answer_with_router_metadata() -> None:
+    engine = make_engine()
+    engine.retrieval_config = RetrievalConfig(routing_mode="llm_router", final_top_k=5)
+    engine.query_router = FixtureQueryRouter("lookup_glossary", {"term": "日野下花帆"})
+
+    result = engine.stream_query("translate 日野下花帆")
+
+    deltas = list(result.answer_deltas)
+    assert len(deltas) == 1
+    assert deltas[0].startswith("日野下花帆 translates to Kaho Hinoshita.")
+    assert "花帆" in deltas[0]
+    assert result.router_metadata is not None
+    assert result.router_metadata["chosen_tool"] == "lookup_glossary"
+
+
+def test_stream_query_synthesizes_routed_summary_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = make_engine()
+    engine.retrieval_config = RetrievalConfig(routing_mode="llm_router", final_top_k=5)
+    engine.query_router = FixtureQueryRouter(
+        "search_summaries",
+        {"query": "routed summary query", "top_k": 1, "summary_level": 1},
+    )
+    prompts: list[str] = []
+
+    class FakeStreamResult:
+        def stream_text(self, *, delta: bool, debounce_by: float) -> Any:
+            assert delta is True
+            assert debounce_by == 0.1
+            return iter(["summary ", "answer"])
+
+    class FakeAgent:
+        def run_stream_sync(self, prompt: str) -> FakeStreamResult:
+            prompts.append(prompt)
+            return FakeStreamResult()
+
+    def fake_retrieve_summary_nodes_with_trace(
+        question: str,
+        *,
+        where: dict[str, Any] | None,
+        top_k: int,
+    ) -> RetrievalTraceResult:
+        return RetrievalTraceResult(nodes=[summary_node("summary evidence")], stages={})
+
+    monkeypatch.setattr(
+        engine,
+        "retrieve_summary_nodes_with_trace",
+        fake_retrieve_summary_nodes_with_trace,
+    )
+    monkeypatch.setattr(query_engine, "create_text_agent", lambda system_prompt: FakeAgent())
+
+    result = engine.stream_query("original")
+
+    assert list(result.answer_deltas) == ["summary", " answer"]
+    assert result.router_metadata is not None
+    assert result.router_metadata["chosen_tool"] == "search_summaries"
+    assert "SUMMARY EVIDENCE 1" in prompts[0]
+    assert "GENERATED SUMMARY TEXT" in prompts[0]
+
+
 def test_llm_router_surfaces_tool_errors_in_query_path() -> None:
     engine = make_engine()
     engine.retrieval_config = RetrievalConfig(routing_mode="llm_router", final_top_k=5)
@@ -344,6 +403,28 @@ def test_llm_router_surfaces_tool_errors_in_query_path() -> None:
 
     assert "Insufficient source context" in answer
     assert "Tool error: scene not found" in answer
+
+
+def test_stream_query_surfaces_routed_retrieval_errors_as_one_chunk() -> None:
+    engine = make_engine()
+    engine.retrieval_config = RetrievalConfig(routing_mode="llm_router", final_top_k=5)
+    engine.query_router = FixtureQueryRouter(
+        "get_scene",
+        {"file_path": "missing.md", "scene_index": 0},
+    )
+
+    class FakeSourceStore:
+        def get_scene(self, file_path: str, scene_index: int) -> None:
+            return None
+
+    engine.source_store = FakeSourceStore()
+
+    result = engine.stream_query("show missing scene")
+    deltas = list(result.answer_deltas)
+
+    assert len(deltas) == 1
+    assert "Insufficient source context" in deltas[0]
+    assert "Tool error: scene not found" in deltas[0]
 
 
 def test_fallback_dispatch_failure_returns_tool_result_error(
@@ -403,3 +484,4 @@ def test_fixture_router_falls_back_on_invalid_args_and_model_failure(
     assert failure_result.decision.fallback_used is True
     assert failure_result.decision.fallback_reason == "router model failure"
     assert captured == ["original:5", "original:5"]
+


### PR DESCRIPTION
## Summary

- share query preparation between synchronous and streaming answer paths
- stream final chat synthesis while preserving whitespace, router diagnostics, and Rich highlighting
- recover from turn-level Ctrl+C without ending the chat session
- keep `indexer query` on its existing synchronous path
- mark the chat streaming roadmap item complete

Closes #14

## Verification

- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest` (198 passed)
