### PR TITLE
Extract answer-generation prompts into packaged templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ indexer query "What happened in the 105th term?" --routing-mode off
 indexer chat --routing-mode off
 ```
 
+### Answer prompts
+
+Static answer-generation instructions are Markdown resources in
+`src/linkura_story_indexer/prompts`. Edit those files to revise answer policy;
+keep questions, retrieved context, glossary entries, and State Ledger facts as
+dynamic renderer inputs. Increment `PROMPT_VERSION` in the prompt module for a
+behavioral change so evaluations and future traces can identify the revision.
+When `summaries_cache.json` is present, every valid Year-level summary is also
+loaded into the system prompt as a generated Story Overview. These summaries
+can ground broad Year/Arc synthesis; narrower claims should continue drilling
+down to Episode, Part, or raw-scene evidence.
+
+Run the prompt and query-engine tests after a prompt change:
+
+```powershell
+uv run pytest tests/test_prompts.py tests/test_query_engine.py
+```
+
 ## Retrieval Evaluation
 
 Run the checked-in retrieval golden set without answer generation:

--- a/src/linkura_story_indexer/prompts/__init__.py
+++ b/src/linkura_story_indexer/prompts/__init__.py
@@ -5,7 +5,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Literal
 
-PROMPT_VERSION = "answer-v2"
+PROMPT_VERSION = "answer-v3"
 
 
 class PromptResourceError(RuntimeError):
@@ -44,10 +44,15 @@ def render_system_prompt(
     """Render the system prompt with dynamic consistency context."""
     if context_kind == "raw":
         context_policy = (
-            "Answer based strictly on the provided raw source text. Ground every final factual "
-            "claim in that raw evidence."
+            "The retrieved evidence in the user message is raw source text. Use it for exact "
+            "events, quotations, dialogue attribution, and other fine-grained claims. For broad "
+            "Year/Arc synthesis, the generated Year summaries in the Story Overview are also "
+            "eligible evidence."
         )
-        citation_policy = "Final citations must come from retrieved raw-evidence labels."
+        citation_policy = (
+            "Final citations must come from retrieved raw-evidence labels or, when using the "
+            "Story Overview for broad synthesis, its Year-summary labels."
+        )
     else:
         context_policy = (
             "The retrieved context may be generated summaries rather than raw source text. "

--- a/src/linkura_story_indexer/prompts/__init__.py
+++ b/src/linkura_story_indexer/prompts/__init__.py
@@ -1,0 +1,107 @@
+"""Load and render the packaged answer-generation prompts."""
+
+import json
+from importlib.resources import files
+from pathlib import Path
+from typing import Literal
+
+PROMPT_VERSION = "answer-v2"
+
+
+class PromptResourceError(RuntimeError):
+    """Raised when a required packaged prompt cannot be loaded."""
+
+
+def load_prompt(name: str) -> str:
+    """Load a UTF-8 Markdown prompt from this installed package."""
+    resource = files(__package__).joinpath(name)
+    try:
+        return resource.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, OSError) as exc:
+        raise PromptResourceError(
+            f"Required prompt resource {name!r} is missing from package {__package__!r}. "
+            "Reinstall or rebuild linkura-story-indexer with its Markdown package resources."
+        ) from exc
+
+
+def _render(name: str, values: dict[str, str]) -> str:
+    rendered = load_prompt(name)
+    for key, value in values.items():
+        token = f"[[{key}]]"
+        if token not in rendered:
+            raise PromptResourceError(f"Prompt resource {name!r} is missing required token {token}.")
+        rendered = rendered.replace(token, value)
+    return rendered.strip()
+
+
+def render_system_prompt(
+    *,
+    context_kind: Literal["raw", "summary"],
+    glossary: str,
+    state_ledger: str,
+    year_summaries: str,
+) -> str:
+    """Render the system prompt with dynamic consistency context."""
+    if context_kind == "raw":
+        context_policy = (
+            "Answer based strictly on the provided raw source text. Ground every final factual "
+            "claim in that raw evidence."
+        )
+        citation_policy = "Final citations must come from retrieved raw-evidence labels."
+    else:
+        context_policy = (
+            "The retrieved context may be generated summaries rather than raw source text. "
+            "Treat it as summary evidence, disclose that limitation when relevant, and never "
+            "present it as a quotation from or direct inspection of the raw source."
+        )
+        citation_policy = "Final citations must come from retrieved summary-context labels."
+    return _render(
+        "answer_system.md",
+        {
+            "PROMPT_VERSION": PROMPT_VERSION,
+            "CONTEXT_POLICY": context_policy,
+            "CITATION_POLICY": citation_policy,
+            "GLOSSARY": glossary,
+            "STATE_LEDGER": state_ledger,
+            "YEAR_SUMMARIES": year_summaries,
+        },
+    )
+
+
+def render_user_prompt(
+    *, context_kind: Literal["raw", "summary"], question: str, context: str
+) -> str:
+    """Render a mode-specific answer request without interpreting dynamic text."""
+    return _render(
+        f"answer_{context_kind}_user.md",
+        {"QUESTION": question, "CONTEXT": context},
+    )
+
+
+def load_year_summaries(cache_file: str | Path) -> dict[str, str]:
+    """Load valid Year-level summaries from a hierarchy summary cache."""
+    path = Path(cache_file)
+    if not path.exists():
+        return {}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PromptResourceError(
+            f"Could not load Year summaries from {path}: {exc}. "
+            "Regenerate or repair the summary cache."
+        ) from exc
+    if not isinstance(loaded, dict):
+        raise PromptResourceError(
+            f"Could not load Year summaries from {path}: the cache root must be an object."
+        )
+
+    summaries: dict[str, str] = {}
+    for key, entry in loaded.items():
+        if not isinstance(key, str) or not key.startswith("YEAR|") or not isinstance(entry, dict):
+            continue
+        arc_id = key.removeprefix("YEAR|")
+        summary = entry.get("summary")
+        level = entry.get("inputs", {}).get("level")
+        if arc_id and isinstance(summary, str) and summary.strip() and level == "year":
+            summaries[arc_id] = summary.strip()
+    return summaries

--- a/src/linkura_story_indexer/prompts/answer_raw_user.md
+++ b/src/linkura_story_indexer/prompts/answer_raw_user.md
@@ -4,6 +4,6 @@
 
 # Raw source evidence
 
-Answer based only on the raw source text below. Cite every factual claim with one or more provided `CITATION` labels exactly as written. Use episode numbers in citations, never Japanese episode titles.
+For a broad Year/Arc summary or synthesis, you may use the generated Year summaries in the system prompt's Story Overview. For exact or fine-grained claims, use the raw source text below. Cite every factual claim with one or more eligible `CITATION` labels exactly as written. Use episode numbers in raw-evidence citations, never Japanese episode titles.
 
 [[CONTEXT]]

--- a/src/linkura_story_indexer/prompts/answer_raw_user.md
+++ b/src/linkura_story_indexer/prompts/answer_raw_user.md
@@ -1,0 +1,9 @@
+# Question
+
+[[QUESTION]]
+
+# Raw source evidence
+
+Answer based only on the raw source text below. Cite every factual claim with one or more provided `CITATION` labels exactly as written. Use episode numbers in citations, never Japanese episode titles.
+
+[[CONTEXT]]

--- a/src/linkura_story_indexer/prompts/answer_summary_user.md
+++ b/src/linkura_story_indexer/prompts/answer_summary_user.md
@@ -1,0 +1,9 @@
+# Question
+
+[[QUESTION]]
+
+# Retrieved summary context
+
+Answer based only on the retrieved context below. It may contain generated summaries rather than raw source text. Cite every factual claim with one or more provided `CITATION` labels exactly as written. Preserve `summary_level` in summary labels and do not invent scene labels.
+
+[[CONTEXT]]

--- a/src/linkura_story_indexer/prompts/answer_system.md
+++ b/src/linkura_story_indexer/prompts/answer_system.md
@@ -1,0 +1,22 @@
+<!-- prompt-version: [[PROMPT_VERSION]] -->
+# Answer policy
+
+You are an expert lore-keeper and archivist for a Japanese narrative story.
+
+Answer only from the retrieved evidence supplied in the user message. Do not use outside knowledge. If that evidence does not contain enough information, state that the source context is insufficient instead of guessing.
+
+[[CONTEXT_POLICY]]
+
+Every factual claim must cite one or more `CITATION` labels exactly as supplied. Never invent, alter, or infer a citation label, and do not cite raw Japanese episode titles. [[CITATION_POLICY]]
+
+Year/Arc identifiers such as 103, 104, and 105 are narrative identifiers, not real-world calendar years. Never convert one to a year such as 2023, 2024, or 2025.
+
+Official Glossary translations and State Ledger facts are consistency context. Follow glossary translations and use ledger facts to avoid contradictions, but ground final claims in retrieved evidence and its citation labels.
+
+The Story Overview contains generated Year-level summaries. For broad requests to summarize or synthesize a Year/Arc, these summaries may directly ground the answer using their supplied summary `CITATION` labels. For quotations, exact dialogue attribution, or fine-grained factual claims, prefer retrieved Episode, Part, or raw-scene evidence. Never describe a generated summary as raw source text.
+
+[[YEAR_SUMMARIES]]
+
+[[GLOSSARY]]
+
+[[STATE_LEDGER]]

--- a/src/linkura_story_indexer/prompts/answer_system.md
+++ b/src/linkura_story_indexer/prompts/answer_system.md
@@ -3,7 +3,7 @@
 
 You are an expert lore-keeper and archivist for a Japanese narrative story.
 
-Answer only from the retrieved evidence supplied in the user message. Do not use outside knowledge. If that evidence does not contain enough information, state that the source context is insufficient instead of guessing.
+Answer only from evidence supplied in this prompt: the generated Year summaries in the Story Overview and the retrieved evidence in the user message. Do not use outside knowledge. If that evidence does not contain enough information, state that the source context is insufficient instead of guessing.
 
 [[CONTEXT_POLICY]]
 
@@ -11,7 +11,7 @@ Every factual claim must cite one or more `CITATION` labels exactly as supplied.
 
 Year/Arc identifiers such as 103, 104, and 105 are narrative identifiers, not real-world calendar years. Never convert one to a year such as 2023, 2024, or 2025.
 
-Official Glossary translations and State Ledger facts are consistency context. Follow glossary translations and use ledger facts to avoid contradictions, but ground final claims in retrieved evidence and its citation labels.
+Official Glossary translations and State Ledger facts are consistency context. Follow glossary translations and use ledger facts to avoid contradictions, but ground final claims in eligible Story Overview or retrieved evidence and its citation labels.
 
 The Story Overview contains generated Year-level summaries. For broad requests to summarize or synthesize a Year/Arc, these summaries may directly ground the answer using their supplied summary `CITATION` labels. For quotations, exact dialogue attribution, or fine-grained factual claims, prefer retrieved Episode, Part, or raw-scene evidence. Never describe a generated summary as raw source text.
 

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -27,6 +27,7 @@ from ..eval.models import (
 from ..indexer.parser import StoryParser
 from ..indexer.source_store import SourceRecordStore
 from ..lexical import LexicalIndex, expand_query_with_glossary
+from ..prompts import load_year_summaries, render_system_prompt, render_user_prompt
 from .analysis import (
     CHRONOLOGY_INTENT,
     EXACT_EVIDENCE_INTENT,
@@ -124,6 +125,7 @@ class StoryQueryEngine:
         self,
         state_file: str = "world_state.json",
         glossary_file: str = "glossary.json",
+        summary_cache_file: str = "summaries_cache.json",
         retrieval_config: RetrievalConfig | None = None,
         query_router: "QueryRouter | None" = None,
     ):
@@ -142,6 +144,8 @@ class StoryQueryEngine:
         if os.path.exists(glossary_file):
             with open(glossary_file, encoding="utf-8") as f:
                 self.glossary = json.load(f)
+
+        self.year_summaries = load_year_summaries(summary_cache_file)
 
     def _expanded_question(self, question: str) -> str:
         return expand_query_with_glossary(question, self.glossary)
@@ -254,49 +258,52 @@ class StoryQueryEngine:
         *,
         context_kind: Literal["raw", "summary"] = "raw",
     ) -> str:
-        """Builds the system prompt with invariants and state ledger."""
-        context_description = (
-            "provided raw source text"
-            if context_kind == "raw"
-            else "provided retrieved context, which may be generated summaries rather than raw source text"
-        )
-        citation_source = (
-            "retrieved raw evidence labels"
-            if context_kind == "raw"
-            else "retrieved context labels"
-        )
-        prompt = (
-            "You are an expert lore-keeper and archivist for a Japanese narrative story.\n"
-            f"Answer based strictly on the {context_description}.\n"
-            "Do NOT use outside knowledge. If the provided context does not contain the answer, "
-            "say so.\n"
-            "Cite sources using only the CITATION labels provided in retrieved context. "
-            "Do not cite raw Japanese episode titles. "
-            "Do not convert the Year/Arc ID to a real-world year like 2024.\n"
-        )
-
+        """Build the packaged system prompt with dynamic consistency context."""
+        glossary_sections: list[str] = []
         if self.glossary:
-            prompt += "\n--- OFFICIAL GLOSSARY (MANDATORY TRANSLATIONS) ---\n"
+            glossary_sections.append("--- OFFICIAL GLOSSARY (MANDATORY TRANSLATIONS) ---")
             for cat, terms in self.glossary.items():
-                prompt += f"\n{cat.replace('_', ' ').upper()}:\n"
+                glossary_sections.append(f"\n{cat.replace('_', ' ').upper()}:")
                 for jp, en in terms.items():
-                    prompt += f" - {jp} -> {en}\n"
+                    glossary_sections.append(f" - {jp} -> {en}")
 
         ledger_facts = self._state_ledger_slice(arc_ids, analysis)
+        ledger_sections: list[str] = []
         if ledger_facts:
-            prompt += "\n--- STATE LEDGER (FACTS) ---\n"
-            prompt += (
-                "Use these source-backed facts only for routing and consistency. "
-                f"Final answer citations must still come from {citation_source}.\n"
-            )
+            ledger_sections.append("--- STATE LEDGER (FACTS) ---")
             for arc_id in sorted(arc_ids):
                 arc_facts = [fact for fact in ledger_facts if fact.get("arc") == arc_id]
                 if not arc_facts:
                     continue
-                prompt += f"\nYEAR {arc_id} FACTS:\n"
-                prompt += json.dumps(arc_facts, ensure_ascii=False, separators=(",", ":")) + "\n"
+                ledger_sections.append(f"\nYEAR {arc_id} FACTS:")
+                ledger_sections.append(
+                    json.dumps(arc_facts, ensure_ascii=False, separators=(",", ":"))
+                )
 
-        return prompt
+        year_summary_sections: list[str] = []
+        for arc_id, summary in sorted(getattr(self, "year_summaries", {}).items()):
+            citation = (
+                f"{arc_id} · Main · Episode ALL_EPISODES · Part ALL_PARTS · summary_level 1"
+            )
+            year_summary_sections.extend(
+                [
+                    f"## YEAR/ARC {arc_id}",
+                    f"CITATION: {citation}",
+                    summary,
+                ]
+            )
+
+        return render_system_prompt(
+            context_kind=context_kind,
+            glossary="\n".join(glossary_sections),
+            state_ledger="\n".join(ledger_sections),
+            year_summaries=(
+                "--- STORY OVERVIEW (GENERATED YEAR SUMMARIES) ---\n\n"
+                + "\n\n".join(year_summary_sections)
+                if year_summary_sections
+                else ""
+            ),
+        )
 
     def _citation_label(self, metadata: dict[str, Any]) -> str:
         summary_level = metadata.get("summary_level")
@@ -1346,12 +1353,8 @@ class StoryQueryEngine:
         system_prompt = self._build_system_prompt(state_ledger_arc_ids, analysis)
         combined_context = "\n".join(self._build_context_chunks(raw_nodes))
 
-        user_prompt = (
-            "Please answer the following question based ONLY on the raw source text provided below.\n\n"
-            "Every factual claim should cite one or more provided CITATION labels exactly as written. "
-            "Use episode numbers in citations, never Japanese episode titles.\n\n"
-            f"QUESTION: {question}\n\n"
-            f"CONTEXT:\n{combined_context}"
+        user_prompt = render_user_prompt(
+            context_kind="raw", question=question, context=combined_context
         )
         return system_prompt, user_prompt
 
@@ -1368,7 +1371,9 @@ class StoryQueryEngine:
         question: str,
         summary_nodes: list[Node],
     ) -> tuple[str, str]:
-        state_ledger_arc_ids = self._state_ledger_arc_ids(question, self._raw_arc_ids(summary_nodes))
+        state_ledger_arc_ids = self._state_ledger_arc_ids(
+            question, self._raw_arc_ids(summary_nodes)
+        )
         system_prompt = self._build_system_prompt(
             state_ledger_arc_ids,
             None,
@@ -1376,14 +1381,8 @@ class StoryQueryEngine:
         )
         combined_context = "\n".join(self._build_summary_context_chunks(summary_nodes))
 
-        user_prompt = (
-            "Please answer the following question based ONLY on the retrieved context provided "
-            "below. The context may contain generated summaries rather than raw source text.\n\n"
-            "Every factual claim should cite one or more provided CITATION labels exactly as "
-            "written. Use the summary citation labels exactly as provided, including "
-            "summary_level. Do not invent scene labels for summary evidence.\n\n"
-            f"QUESTION: {question}\n\n"
-            f"CONTEXT:\n{combined_context}"
+        user_prompt = render_user_prompt(
+            context_kind="summary", question=question, context=combined_context
         )
 
         return system_prompt, user_prompt

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -25,10 +25,29 @@ def test_raw_and_summary_system_policies_are_distinct() -> None:
     )
 
     assert "raw source text" in raw
-    assert "generated summaries" not in raw
+    assert "may be generated summaries rather than raw source text" not in raw
     assert "generated summaries" in summary
     assert "never present it as a quotation" in summary
     assert prompts.PROMPT_VERSION in raw
+
+
+def test_raw_prompts_allow_year_overview_for_broad_synthesis() -> None:
+    system = prompts.render_system_prompt(
+        context_kind="raw",
+        glossary="",
+        state_ledger="",
+        year_summaries="## YEAR/ARC 105\nCITATION: year-label\nFull Year summary",
+    )
+    user = prompts.render_user_prompt(
+        context_kind="raw",
+        question="What happened in the 105th term?",
+        context="CITATION: raw-label\nOpening scene",
+    )
+
+    assert "Year summaries in the Story Overview are also eligible evidence" in system
+    assert "Year-summary labels" in system
+    assert "you may use the generated Year summaries" in user
+    assert "Answer based only on the raw source text below" not in user
 
 
 def test_dynamic_braces_and_markdown_are_not_interpreted() -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,78 @@
+from importlib.resources import files
+
+import pytest
+
+from linkura_story_indexer import prompts
+
+
+def test_packaged_prompt_resource_loads_after_working_directory_change(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    prompt = prompts.load_prompt("answer_system.md")
+
+    assert "# Answer policy" in prompt
+    assert files("linkura_story_indexer.prompts").joinpath("answer_raw_user.md").is_file()
+
+
+def test_raw_and_summary_system_policies_are_distinct() -> None:
+    raw = prompts.render_system_prompt(
+        context_kind="raw", glossary="", state_ledger="", year_summaries=""
+    )
+    summary = prompts.render_system_prompt(
+        context_kind="summary", glossary="", state_ledger="", year_summaries=""
+    )
+
+    assert "raw source text" in raw
+    assert "generated summaries" not in raw
+    assert "generated summaries" in summary
+    assert "never present it as a quotation" in summary
+    assert prompts.PROMPT_VERSION in raw
+
+
+def test_dynamic_braces_and_markdown_are_not_interpreted() -> None:
+    question = "What does {character} mean by [[not-a-token]] and **this**?"
+    context = 'CITATION: label\n```json\n{"value": "{literal}"}\n```'
+
+    rendered = prompts.render_user_prompt(
+        context_kind="raw", question=question, context=context
+    )
+
+    assert question in rendered
+    assert context in rendered
+
+
+def test_missing_resource_has_actionable_error() -> None:
+    with pytest.raises(prompts.PromptResourceError, match="Reinstall or rebuild"):
+        prompts.load_prompt("missing.md")
+
+
+def test_load_year_summaries_selects_only_valid_year_entries(tmp_path) -> None:
+    cache = tmp_path / "summaries.json"
+    cache.write_text(
+        """{
+          "YEAR|104": {"summary": "Year {104} **summary**", "inputs": {"level": "year"}},
+          "YEAR|103": {"summary": "Year 103", "inputs": {"level": "year"}},
+          "EPISODE|104|Main|1": {"summary": "Episode", "inputs": {"level": "episode"}},
+          "YEAR|bad": {"summary": "Wrong level", "inputs": {"level": "episode"}}
+        }""",
+        encoding="utf-8",
+    )
+
+    assert prompts.load_year_summaries(cache) == {
+        "104": "Year {104} **summary**",
+        "103": "Year 103",
+    }
+
+
+def test_load_year_summaries_allows_missing_cache(tmp_path) -> None:
+    assert prompts.load_year_summaries(tmp_path / "missing.json") == {}
+
+
+def test_load_year_summaries_rejects_malformed_cache(tmp_path) -> None:
+    cache = tmp_path / "broken.json"
+    cache.write_text("{broken", encoding="utf-8")
+
+    with pytest.raises(prompts.PromptResourceError, match="Regenerate or repair"):
+        prompts.load_year_summaries(cache)

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -59,7 +59,7 @@ def test_system_prompt_restores_raw_source_claim_and_compacts_ledger():
 
     prompt = engine._build_system_prompt({"103"})
 
-    assert "based strictly on the provided raw source text" in prompt
+    assert "retrieved evidence in the user message is raw source text" in prompt
     assert "Some retrieved context may be generated summaries" not in prompt
     assert '"subject":"Kaho Hinoshita"' in prompt
     assert '"extracted_quote":"Kaho"' in prompt

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -67,6 +67,26 @@ def test_system_prompt_restores_raw_source_claim_and_compacts_ledger():
     assert "YEAR 104 FACTS" not in prompt
 
 
+def test_system_prompt_includes_all_year_summaries_in_arc_order():
+    engine = make_engine()
+    engine.year_summaries = {
+        "105": "The {105} summary contains **Markdown**.",
+        "103": "The 103 summary.",
+        "104": "The 104 summary.",
+    }
+
+    prompt = engine._build_system_prompt({"104"})
+
+    assert prompt.index("## YEAR/ARC 103") < prompt.index("## YEAR/ARC 104")
+    assert prompt.index("## YEAR/ARC 104") < prompt.index("## YEAR/ARC 105")
+    assert "The {105} summary contains **Markdown**." in prompt
+    assert (
+        "CITATION: 104 · Main · Episode ALL_EPISODES · Part ALL_PARTS · summary_level 1"
+        in prompt
+    )
+    assert "may directly ground the answer" in prompt
+
+
 def test_state_ledger_arc_ids_prefers_explicit_question_arc():
     engine = make_engine()
 


### PR DESCRIPTION
## Summary

- move static answer-generation policy into packaged Markdown templates
- add a testable `importlib.resources` loader/renderer with prompt versioning and actionable failures
- preserve distinct raw- and summary-evidence grounding and citation rules
- load all cached Year-level summaries into the initial Story Overview for broad synthesis and agent navigation
- retain dynamic glossary and temporally sliced State Ledger context
- document prompt maintenance and testing

## Validation

- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest` (206 passed)
- built-wheel smoke check confirmed all Markdown prompt resources are packaged

Fixes #66