### PR TITLE
feat: add agentic query mode and answer audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,30 @@ or summary fanout.
 Use `--routing-mode heuristic` when you want targeted scoped workflows that
 apply analyzer-derived filters or structured helpers. Use
 `--routing-mode llm_router` to let the configured router model select one
-typed query tool before retrieval. The router model is controlled by
-`LINKURA_ROUTER_MODEL`. With the Google provider it defaults to
+typed query tool before retrieval. Use `--routing-mode agentic` for a capped,
+multi-step tool-calling loop that can combine glossary lookup, retrieval,
+point-in-time State Ledger checks, and exact SQL dialogue counts. Counting
+questions in agentic mode must use `count_dialogue`; the answer is never an
+LLM estimate. Agentic mode uses at most eight model requests by default; set
+`LINKURA_AGENT_REQUEST_LIMIT` to change the cap. The router model is controlled
+by `LINKURA_ROUTER_MODEL`. With the Google provider it defaults to
 `gemini-3.1-flash-lite-preview`; with the OpenAI provider it defaults to the
 configured generation model.
 
 ```powershell
 indexer query "What happened in the 105th term?" --routing-mode heuristic
 indexer chat --routing-mode llm_router
+indexer query "How many dialogue turns does 花帆 have in 103?" --routing-mode agentic
+```
+
+Add `--audit` to `query` or `chat` for a secondary answer check against the
+retrieved evidence, State Ledger, and official Glossary. Audit is opt-in for
+interactive use and reports possible retcons, wrong honorifics, or
+hallucinated names without changing the draft answer.
+
+```powershell
+indexer query "What does 花帆 call Sayaka in episode 1?" --routing-mode agentic --audit
+indexer chat --routing-mode agentic --audit
 ```
 
 Use `--routing-mode off` to make the default explicit:
@@ -78,9 +94,22 @@ Run the checked-in retrieval golden set without answer generation:
 uv run indexer eval run --golden-set eval/golden_questions.json --routing-mode off --output runs/baseline.json
 ```
 
-Use `--routing-mode heuristic` to compare analyzer-derived filters, or
-`--routing-mode llm_router` to evaluate typed router dispatch. Until the
-reranker lands, reranker metrics are emitted as unavailable.
+Use `--routing-mode heuristic` to compare analyzer-derived filters,
+`--routing-mode llm_router` to evaluate typed router dispatch, or
+`--routing-mode agentic --answer-mode` to evaluate the multi-step agent. Add
+`--audit` to the answer-mode run to aggregate audit cleanliness and flag counts.
+The audit flag requires answer mode. Compare router and agentic runs with the
+same golden set:
+
+```powershell
+indexer eval run --routing-mode llm_router --answer-mode --output runs/router.json
+indexer eval run --routing-mode agentic --answer-mode --output runs/agentic.json
+indexer eval diff runs/router.json runs/agentic.json
+```
+
+Until the reranker lands, reranker metrics are emitted as unavailable. The
+current golden set remains single-scene; multi-hop and expanded quantitative
+coverage should be added in a follow-up evaluation issue.
 
 ## Index Rebuilds
 

--- a/docs/file-search-evaluation.md
+++ b/docs/file-search-evaluation.md
@@ -1,0 +1,152 @@
+# Gemini File Search for `linkura-story-indexer` — Evaluation
+
+Discussion notes evaluating whether to adopt Google's Gemini File Search
+(<https://ai.google.dev/gemini-api/docs/file-search>) and how it would interact
+with the existing pipeline.
+
+## 1. What File Search is
+
+Managed RAG service: upload files → auto chunk + embed with the store's
+configured embedding model (for example `models/gemini-embedding-2`) → stored
+in a `fileSearchStore` → invoke as a `Tool` on `generate_content`. Returns
+answers with `grounding_metadata` citations. Storage free; indexing billed at
+embed rates; retrieved tokens billed as context.
+
+**Critical architectural constraint:** no standalone retrieval endpoint.
+Confirmed in venv (`file_search_stores.py` only exposes CRUD + upload/import,
+no `query`/`search`). The only way to use the vectors is via the `Tool` on a
+generation call.
+
+## 2. How it maps to the existing pipeline
+
+| Component | Current | File Search equivalent |
+|---|---|---|
+| Chunker (`indexer/chunker.py`) | Coalesced scenes, 500/1200/1800 char window, `scene_start/end` metadata | Auto whitespace chunking by default; scene boundaries must be preserved by uploading pre-split chunk files and metadata |
+| Embeddings (`database.py`) | `gemini-embedding-2` with task prefixes | Same model, prefixes managed |
+| Vector store | Chroma `story_nodes`, rich metadata | Managed; custom metadata as typed key/value |
+| Retrieval (`query/engine.py`, `lexical.py`) | Semantic + FTS5 BM25 fused via RRF | Semantic only, no fusion possible |
+| Intent routing (`query/analysis.py`) | Heuristic classification + constraint extraction | Not provided |
+| Summarizer | 3-tier hierarchical, rolling context, hash cache | Not provided |
+| Provider abstraction | Google/OpenAI swappable | Gemini-only |
+
+## 3. Metadata support
+
+- Typed custom metadata: `{"key": ..., "string_value"|"numeric_value": ...}`
+- Query-time `metadata_filter` using AIP-160 syntax. Equality and conjunction
+  are the safest baseline; richer predicates should be validated empirically
+  against the API.
+- File Search tool knobs include `top_k`, `metadata_filter`, and optional
+  vector distance/similarity thresholds in the SDK. These tune retrieval inside
+  generation; they do not provide a standalone candidate API.
+- Multiple stores; `file_search_store_names` takes a list
+- `grounding_metadata` returns document title + custom metadata
+
+## 4. Chunking config — SDK carries no default
+
+`WhiteSpaceConfig.max_tokens_per_chunk` and `max_overlap_tokens` are both
+`Optional[int]` with `default=None`
+(`.venv/Lib/site-packages/google/genai/types.py:15468-15498`). SDK omits when
+unset; server-side default is undocumented.
+
+**Always set `chunking_config` explicitly in production.** Validate the
+accepted ceiling empirically (`max_tokens_per_chunk: 2048` is a reasonable
+starting point but untested).
+
+## 5. Summary corpus sizing (`summaries_cache.json`)
+
+449 entries, English (~4 chars/token):
+
+| Level | Count | Max chars | Max tokens (≈) |
+|---|---|---|---|
+| Part | 400 | 5,427 | ~1,360 |
+| Episode | 45 | 5,950 | ~1,490 |
+| Year | 4 | 7,297 | ~1,825 |
+
+All comfortably one-chunk-able if `max_tokens_per_chunk: 2048` is accepted.
+
+## 6. The "hybrid" trap (File Search as embedding-only replacement)
+
+**Doesn't work.** No retrieval endpoint = can't fuse File Search KNN with
+FTS5. Workaround (stub-prompt `generate_content`, harvest
+`grounding_metadata`) is wasteful and noisy.
+
+Only clean hybrid: **partition by corpus** — File Search owns one corpus
+end-to-end (e.g., summaries for public reader), Chroma keeps the other (raw
+scenes with hybrid retrieval). No fusion across them.
+
+## 7. Agentic search interaction
+
+Spectrum:
+
+1. Static heuristics (today: `analysis.py`)
+2. **LLM router** — single classification call, dispatch one tool (NOT yet
+   agentic)
+3. Tool-calling model — model picks tool(s) per turn
+4. Agentic loop — model sees results, re-calls, refines
+
+File Search is useful at rung 2, especially as a one-shot summary/raw-corpus
+answer tool, but becomes less useful as the system moves toward rung 3/4. It
+has tuning knobs (`top_k`, `metadata_filter`, thresholds), but retrieval remains
+trapped inside `generate_content` instead of exposing inspectable candidates.
+Real agentic value comes from rich, narrowly-typed tools (`search_summaries`,
+`search_raw`, `get_scene`, `get_character_state`) — which File Search can't
+provide by itself.
+
+**Provider lock-in:** File Search is a Gemini-only `Tool`. OpenAI agent path
+can't use it; the custom tool surface gets built regardless.
+
+## 8. Part summaries vs raw Japanese for one-shot RAG
+
+There is no universal winner. Pick the corpus based on the one-shot use case.
+
+For a public-reader conversational backend, **Part summaries** are the cleaner
+first experiment because they are dense, English, and already normalized for
+broad questions. For source-grounded factual QA, **raw chunks** preserve the
+truth better because summaries omit exact evidence.
+
+| Question type | Summaries | Raw JP |
+|---|---|---|
+| Plot, character, theme, recap | Excellent | Poor |
+| Exact dialogue | Useless | Decent |
+| Keyword / quote search | Bad | Decent (but FTS5 wins) |
+| Linguistic / translation | Useless | Best option |
+| Aggregate / count | Mediocre | Bad |
+
+Raw JP is a poor shape for broad English one-shot synthesis: cross-lingual,
+lower per-chunk density, and semantic retrieval is not lexical lookup. It is
+still the right shape for exact dialogue, source verification, linguistic /
+translation questions, and citation-grounded factual answers. To keep it usable,
+upload pre-split retrieval chunks with metadata rather than whole parts and
+blind server-side chunking.
+
+## 9. Multi-level summaries — redundancy concern
+
+Year ⊃ Episode ⊃ Part content-wise → top-K pollution when surfaced for the
+same question. But levels have **different shapes**, not just sizes
+(Year = thematic, Episode = arc cause/effect, Part = plot beats), so they
+earn their keep for *different* question scopes.
+
+- **No router** → upload Parts only. Avoid redundancy tax.
+- **With router** → multi-level via `summary_level` filter OR separate stores.
+  Each query hits exactly one tier.
+- **Year summaries (only 4)** → too few for retrieval; prepend directly to
+  prompt when router flags a thematic query.
+
+## 10. Recommended path
+
+1. **Don't replace Chroma.** It's load-bearing for hybrid retrieval,
+   scene-precise citations, OpenAI portability, and the agentic foundation.
+2. **Wrap `query/engine.py` modes as typed Pydantic-AI tools.** Foundation for
+   routing AND any later agentic loop.
+3. **Add File Search as ONE additional tool** over a *separate* corpus — most
+   likely Part summaries (and optionally Episode summaries) for the
+   "public reader" / broad one-shot conversational use case. Consider a
+   separate raw-chunk File Search store only for direct comparison against the
+   local raw retrieval path.
+4. **Build an LLM router (rung 2)** that picks among the typed tools.
+   Replaces heuristics in `analysis.py` with model judgment, returns
+   `{tool_name, args}` via structured output.
+5. **Year summaries: skip File Search.** Inject directly into prompts when
+   scope warrants.
+6. **Only climb to rung 3/4 (true agentic)** once router-mode is in production
+   and there's data on its misroutes.

--- a/src/linkura_story_indexer/cli.py
+++ b/src/linkura_story_indexer/cli.py
@@ -101,11 +101,38 @@ def _print_router_debug(engine: StoryQueryEngine, question: str) -> str:
     router_stage = trace.stages.get("router")
     if router_stage is not None:
         _print_router_metadata(router_stage.metadata)
+    else:
+        agent_stage = trace.stages.get("agent")
+        if agent_stage is not None:
+            _print_agent_metadata(agent_stage.metadata)
     return trace.answer_text or INSUFFICIENT_SOURCE_CONTEXT
 
 
 def _print_router_metadata(metadata: dict[str, Any]) -> None:
     for line in _router_debug_lines(metadata):
+        console.print(line)
+
+
+def _agent_debug_lines(metadata: dict[str, Any]) -> list[str]:
+    lines = ["[bold cyan]Agent:[/bold cyan]"]
+    for name in ("model", "request_count", "stop_reason", "fallback_reason"):
+        lines.append(f"  {name}: {metadata.get(name)}")
+    cited_labels = metadata.get("model_cited_labels")
+    if cited_labels:
+        lines.append(
+            "  model_cited_labels: "
+            + json.dumps(cited_labels, ensure_ascii=False, sort_keys=True)
+        )
+    tool_calls = metadata.get("tool_calls")
+    if tool_calls:
+        lines.append(
+            "  tool_calls: " + json.dumps(tool_calls, ensure_ascii=False, sort_keys=True)
+        )
+    return lines
+
+
+def _print_agent_metadata(metadata: dict[str, Any]) -> None:
+    for line in _agent_debug_lines(metadata):
         console.print(line)
 
 
@@ -342,24 +369,34 @@ def query(
     routing_mode: str = typer.Option(
         "off",
         "--routing-mode",
-        help="Routing mode: off, heuristic, or llm_router.",
+        help="Routing mode: off, heuristic, llm_router, or agentic.",
     ),
     show_router: bool = typer.Option(
         False,
         "--show-router/--hide-router",
-        help="Print the llm_router structured decision and validation metadata.",
+        help="Print router or agent structured decision and execution metadata.",
+    ),
+    audit: bool = typer.Option(
+        False,
+        "--audit/--no-audit",
+        help="Run the secondary answer audit pass.",
     ),
 ):
     """Answers a question based on the RAG index and State Ledger."""
     mode = _routing_mode(routing_mode)
     initialize_query_settings()
-    engine = StoryQueryEngine(retrieval_config=RetrievalConfig(routing_mode=mode))
+    engine = StoryQueryEngine(
+        retrieval_config=RetrievalConfig(routing_mode=mode, audit_enabled=audit)
+    )
     console.print(f"\n[bold blue]Question:[/bold blue] {question}")
-    if show_router and mode == "llm_router":
+    if show_router and mode in {"llm_router", "agentic"}:
         answer = _print_router_debug(engine, question)
     else:
         if show_router:
-            console.print("[yellow]--show-router only applies with --routing-mode llm_router.[/yellow]")
+            console.print(
+                "[yellow]--show-router only applies with --routing-mode llm_router or agentic."
+                "[/yellow]"
+            )
         answer = engine.query(question)
     console.print(f"\n[bold green]Answer:[/bold green]\n{answer}\n")
 
@@ -368,18 +405,29 @@ def chat(
     routing_mode: str = typer.Option(
         "off",
         "--routing-mode",
-        help="Routing mode: off, heuristic, or llm_router.",
+        help="Routing mode: off, heuristic, llm_router, or agentic.",
     ),
     show_router: bool = typer.Option(
         False,
         "--show-router/--hide-router",
-        help="Print the llm_router structured decision and validation metadata for each turn.",
+        help="Print router or agent structured execution metadata for each turn.",
+    ),
+    audit: bool = typer.Option(
+        False,
+        "--audit/--no-audit",
+        help="Run the secondary answer audit pass for each turn.",
     ),
 ):
-    """Starts an interactive chat session with the RAG index."""
+    """Starts an interactive chat session with the RAG index.
+
+    With --audit, each answer is prepared and emitted as one completed block so the
+    secondary audit can run before the response is displayed.
+    """
     mode = _routing_mode(routing_mode)
     initialize_query_settings()
-    engine = StoryQueryEngine(retrieval_config=RetrievalConfig(routing_mode=mode))
+    engine = StoryQueryEngine(
+        retrieval_config=RetrievalConfig(routing_mode=mode, audit_enabled=audit)
+    )
     console.print("[bold green]Interactive Chat Started! Type 'exit' or 'quit' to end.[/bold green]")
 
     while True:
@@ -400,9 +448,12 @@ def chat(
             answer_deltas = result.answer_deltas
             if show_router and mode == "llm_router" and result.router_metadata is not None:
                 _print_router_metadata(result.router_metadata)
+            elif show_router and mode == "agentic" and result.router_metadata is not None:
+                _print_agent_metadata(result.router_metadata)
             elif show_router:
                 console.print(
-                    "[yellow]--show-router only applies with --routing-mode llm_router.[/yellow]"
+                    "[yellow]--show-router only applies with --routing-mode llm_router or agentic."
+                    "[/yellow]"
                 )
             console.print("\n[bold green]Answer:[/bold green]")
             for delta in answer_deltas:
@@ -491,7 +542,7 @@ def eval_run_command(
     routing_mode: str = typer.Option(
         "off",
         "--routing-mode",
-        help="Routing mode: off, heuristic, or llm_router.",
+        help="Routing mode: off, heuristic, llm_router, or agentic.",
     ),
     output: str | None = typer.Option(
         None,
@@ -513,8 +564,16 @@ def eval_run_command(
         "--answer-mode/--retrieval-only",
         help="Also synthesize answers and evaluate answer text when credentials are configured.",
     ),
+    audit: bool = typer.Option(
+        False,
+        "--audit/--no-audit",
+        help="Run the secondary answer audit pass; requires --answer-mode.",
+    ),
 ):
     """Runs the retrieval evaluation harness."""
+    if audit and not answer_mode:
+        console.print("[red]Error: --audit requires --answer-mode.[/red]")
+        raise typer.Exit(1)
     try:
         run = run_eval_from_file(
             golden_set,
@@ -523,6 +582,7 @@ def eval_run_command(
             inspect_query_id=inspect_query_id,
             dump_traces_dir=dump_traces_dir,
             answer_mode=answer_mode,
+            audit_enabled=audit,
         )
     except (FileNotFoundError, ValueError) as exc:
         console.print(f"[red]Error: {exc}[/red]")

--- a/src/linkura_story_indexer/eval/metrics.py
+++ b/src/linkura_story_indexer/eval/metrics.py
@@ -109,6 +109,27 @@ def _glossary_consistent(trace: QueryTrace, question: GoldenQuestion) -> bool | 
     )
 
 
+def _audit_metrics(trace: QueryTrace) -> tuple[bool | None, int | None]:
+    stage = trace.stages.get("audit")
+    if stage is None:
+        return None, None
+    metadata = stage.metadata
+    report = metadata.get("report", metadata.get("audit_report"))
+    if isinstance(report, dict):
+        flags = report.get("flags", [])
+        errors = report.get("errors", [])
+    elif hasattr(report, "model_dump"):
+        report_data = report.model_dump(mode="json")
+        flags = report_data.get("flags", [])
+        errors = report_data.get("errors", [])
+    else:
+        flags = metadata.get("flags", [])
+        errors = metadata.get("errors", [])
+    if not isinstance(flags, list) or not isinstance(errors, list):
+        return None, None
+    return not flags and not errors, len(flags)
+
+
 def _rate(values: Iterable[bool | None], *, invert: bool = False) -> float | None:
     concrete = [value for value in values if value is not None]
     if not concrete:
@@ -127,6 +148,7 @@ def evaluate_query(trace: QueryTrace, question: GoldenQuestion) -> QueryMetrics:
     reranker_hit = None
     if reranker_stage is not None and reranker_stage.candidates is not None:
         reranker_hit = _any_gold_in_stage(trace, question, "reranker")
+    audit_clean, audit_flag_count = _audit_metrics(trace)
     return QueryMetrics(
         query_id=question.id,
         gold_source_ranks=ranks,
@@ -136,6 +158,8 @@ def evaluate_query(trace: QueryTrace, question: GoldenQuestion) -> QueryMetrics:
         temporal_leakage=_temporal_leakage(trace, question),
         glossary_consistent=_glossary_consistent(trace, question),
         reranker_hit=reranker_hit,
+        audit_clean=audit_clean,
+        audit_flag_count=audit_flag_count,
     )
 
 
@@ -155,6 +179,7 @@ def aggregate_metrics(query_metrics: list[QueryMetrics], traces: list[QueryTrace
     ):
         unavailable_reasons["reranker_hit_rate"] = "reranker stage unavailable; #23 has not landed"
     reranker_hit_rate = _rate(metric.reranker_hit for metric in query_metrics)
+    audit_clean_rate = _rate(metric.audit_clean for metric in query_metrics)
     return AggregateMetrics(
         query_count=query_count,
         recall_at_k=recall_at_k,
@@ -167,6 +192,7 @@ def aggregate_metrics(query_metrics: list[QueryMetrics], traces: list[QueryTrace
         temporal_leakage_rate=_rate(metric.temporal_leakage for metric in query_metrics),
         glossary_consistency=_rate(metric.glossary_consistent for metric in query_metrics),
         reranker_hit_rate=reranker_hit_rate,
+        audit_clean_rate=audit_clean_rate,
         unavailable_reasons=unavailable_reasons,
     )
 
@@ -183,6 +209,7 @@ def diff_runs(before: EvalRun, after: EvalRun) -> EvalDiff:
         "temporal_leakage_rate",
         "glossary_consistency",
         "reranker_hit_rate",
+        "audit_clean_rate",
     ):
         before_value = getattr(before_metrics, field)
         after_value = getattr(after_metrics, field)

--- a/src/linkura_story_indexer/eval/models.py
+++ b/src/linkura_story_indexer/eval/models.py
@@ -2,7 +2,7 @@ from typing import Any, Literal, cast, get_args
 
 from pydantic import BaseModel, Field, model_validator
 
-RoutingMode = Literal["off", "heuristic", "llm_router"]
+RoutingMode = Literal["off", "heuristic", "llm_router", "agentic"]
 EvalMode = RoutingMode
 ROUTING_MODES = cast(tuple[RoutingMode, ...], get_args(RoutingMode))
 CandidateKind = Literal["raw_span", "summary", "summary_section", "reranker"]
@@ -18,6 +18,8 @@ StageName = Literal[
     "final_top_k",
     "reranker",
     "router",
+    "agent",
+    "audit",
 ]
 NeighborProvenance = Literal["direct_hit", "neighbor_of"]
 
@@ -83,6 +85,7 @@ class RunConfig(BaseModel):
     top_k: int = 8
     answer_mode: bool = False
     reranker_enabled: bool = False
+    audit_enabled: bool = False
 
 
 class CandidateScores(BaseModel):
@@ -133,6 +136,8 @@ class QueryMetrics(BaseModel):
     temporal_leakage: bool | None = None
     glossary_consistent: bool | None = None
     reranker_hit: bool | None = None
+    audit_clean: bool | None = None
+    audit_flag_count: int | None = None
 
 
 class AggregateMetrics(BaseModel):
@@ -143,6 +148,7 @@ class AggregateMetrics(BaseModel):
     temporal_leakage_rate: float | None = None
     glossary_consistency: float | None = None
     reranker_hit_rate: float | None = None
+    audit_clean_rate: float | None = None
     unavailable_reasons: dict[str, str] = Field(default_factory=dict)
 
 

--- a/src/linkura_story_indexer/eval/runner.py
+++ b/src/linkura_story_indexer/eval/runner.py
@@ -25,9 +25,12 @@ def run_eval(
     mode: EvalMode = "off",
     engine: TraceEngine | None = None,
     answer_mode: bool = False,
+    audit_enabled: bool = False,
 ) -> EvalRun:
     if engine is None:
-        engine = StoryQueryEngine(retrieval_config=RetrievalConfig(routing_mode=mode))
+        engine = StoryQueryEngine(
+            retrieval_config=RetrievalConfig(routing_mode=mode, audit_enabled=audit_enabled)
+        )
 
     traces = [
         engine.retrieve_with_trace(
@@ -48,6 +51,7 @@ def run_eval(
             golden_set=golden_set_path,
             answer_mode=answer_mode,
             reranker_enabled=False,
+            audit_enabled=audit_enabled,
         ),
         aggregate_metrics=aggregate_metrics(query_metrics, traces),
         query_metrics=query_metrics,
@@ -63,6 +67,7 @@ def run_eval_from_file(
     inspect_query_id: str | None = None,
     dump_traces_dir: str | Path | None = None,
     answer_mode: bool = False,
+    audit_enabled: bool = False,
 ) -> EvalRun:
     golden_set = load_golden_set(golden_set_path)
     run = run_eval(
@@ -70,6 +75,7 @@ def run_eval_from_file(
         golden_set_path=str(golden_set_path),
         mode=mode,
         answer_mode=answer_mode,
+        audit_enabled=audit_enabled,
     )
     if output_path is not None:
         write_eval_run(run, output_path)

--- a/src/linkura_story_indexer/query/agent.py
+++ b/src/linkura_story_indexer/query/agent.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass
+from inspect import Parameter, Signature
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent, FunctionToolset, UsageLimits
+from pydantic_ai.exceptions import UsageLimitExceeded
+
+from linkura_story_indexer.database import create_generation_model, get_generation_model_name
+from linkura_story_indexer.query.router import _story_location_catalog
+from linkura_story_indexer.query.tools import (
+    QUERY_TOOL_REGISTRY,
+    QueryToolSpec,
+    SearchRawInput,
+    ToolResult,
+)
+
+AGENT_REQUEST_LIMIT = 8
+AgentStopReason = Literal["final_answer", "usage_limit", "model_error"]
+
+
+class AgentAnswer(BaseModel):
+    answer: str = Field(..., min_length=1)
+    cited_labels: list[str] = Field(default_factory=list)
+
+
+@dataclass
+class AgentToolCall:
+    step: int
+    tool_name: str
+    args: dict[str, Any]
+    result: ToolResult
+
+
+@dataclass
+class AgentRunResult:
+    answer: AgentAnswer
+    tool_calls: list[AgentToolCall]
+    stop_reason: AgentStopReason
+    model_name: str
+    request_count: int = 0
+    fallback_reason: str | None = None
+
+    @property
+    def recorder(self) -> list[AgentToolCall]:
+        """Compatibility alias for callers that refer to the per-run recorder."""
+        return self.tool_calls
+
+
+def _agent_tool_payload(result: ToolResult) -> dict[str, Any]:
+    """Return the small, model-facing subset of a full tool result."""
+    payload: dict[str, Any] = {}
+    if result.candidates:
+        payload["candidates"] = [
+            {"citation_label": candidate.citation_label, "text": candidate.text}
+            for candidate in result.candidates
+        ]
+
+    tool_output = result.metadata.get("tool_output")
+    if tool_output is not None:
+        payload["tool_output"] = tool_output
+    direct_answer = result.metadata.get("direct_answer")
+    if isinstance(direct_answer, str):
+        payload["direct_answer"] = direct_answer
+    if result.warnings:
+        payload["warnings"] = list(result.warnings)
+    if result.errors:
+        payload["errors"] = list(result.errors)
+    return payload
+
+
+def _agent_tool_wrapper(
+    engine: Any,
+    recorder: list[AgentToolCall],
+    spec: QueryToolSpec,
+) -> Any:
+    def wrapper(args: BaseModel) -> dict[str, Any]:
+        step = len(recorder) + 1
+        validated_args = spec.input_model.model_validate(args)
+        args_dict = validated_args.model_dump(mode="json")
+        try:
+            result = spec.dispatcher(engine, validated_args)
+        except Exception as exc:  # Tool failures should be visible to the agent and trace.
+            result = ToolResult(errors=[f"{spec.name} dispatch failed: {exc}"])
+        recorder.append(
+            AgentToolCall(
+                step=step,
+                tool_name=spec.name,
+                args=args_dict,
+                result=result,
+            )
+        )
+        return _agent_tool_payload(result)
+
+    wrapper.__name__ = spec.name
+    wrapper.__qualname__ = spec.name
+    wrapper.__doc__ = spec.description
+    wrapper.__annotations__ = {"args": spec.input_model, "return": dict[str, Any]}
+    setattr(
+        wrapper,
+        "__signature__",
+        Signature(
+            [
+                Parameter(
+                    "args",
+                    kind=Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=spec.input_model,
+                )
+            ],
+            return_annotation=dict[str, Any],
+        ),
+    )
+    return wrapper
+
+
+def build_agent_toolset(
+    engine: Any,
+    recorder: list[AgentToolCall],
+) -> FunctionToolset:
+    """Build an instrumented toolset from the shared typed query-tool registry."""
+    toolset = FunctionToolset()
+    for spec in QUERY_TOOL_REGISTRY.values():
+        toolset.add_function(
+            _agent_tool_wrapper(engine, recorder, spec),
+            name=spec.name,
+            description=spec.description,
+        )
+    return toolset
+
+
+def _agent_instructions(engine: Any | None = None) -> str:
+    try:
+        story_location_catalog = _story_location_catalog(engine)
+    except Exception:
+        story_location_catalog = "Available numbered episodes by arc are unavailable."
+
+    return (
+        "You are the multi-step retrieval agent for a source-grounded story index. "
+        "Use the registered query tools to gather evidence before answering. Never invent a "
+        "source, name, translation, state fact, honorific, or number. Your final structured "
+        "answer must contain a concise answer and every citation label that directly supports "
+        "it in cited_labels. Stop once the evidence is sufficient.\n\n"
+        "Tool strategy:\n"
+        "- For Japanese character, unit, location, or story-specific terms, call "
+        "lookup_glossary first when the term may be ambiguous; use its canonical term or "
+        "translation in the next search.\n"
+        "- Use search_raw for exact dialogue and scene evidence. After search_raw identifies "
+        "a precise file_path and scene_index, use get_scene for a focused follow-up when the "
+        "answer depends on that exact scene.\n"
+        "- Use search_summaries only for broad arc, episode, or part overviews.\n"
+        "- Use get_state for point-in-time roles, relationships, aliases, status, locations, "
+        "or honorific facts; provide as_of_episode when the question specifies a time.\n"
+        "- Quantitative rule: counting questions MUST call count_dialogue. Its SQL result is "
+        "the only authoritative number; never estimate or infer a count from prose, and state "
+        "the returned number verbatim in the answer.\n\n"
+        "Do not cite a label that was not returned by a tool. If a tool returns no evidence, "
+        "explain that the source context is insufficient rather than guessing.\n\n"
+        f"{story_location_catalog}\n\n"
+        "The user prompt is JSON containing question and default_top_k."
+    )
+
+
+def _configured_request_limit() -> int:
+    raw_limit = os.getenv("LINKURA_AGENT_REQUEST_LIMIT")
+    if raw_limit is None:
+        return AGENT_REQUEST_LIMIT
+    try:
+        limit = int(raw_limit)
+    except ValueError:
+        return AGENT_REQUEST_LIMIT
+    return limit if limit > 0 else AGENT_REQUEST_LIMIT
+
+
+def _answer_from_tool_calls(tool_calls: Sequence[AgentToolCall]) -> str:
+    for call in reversed(tool_calls):
+        direct_answer = call.result.metadata.get("direct_answer")
+        if isinstance(direct_answer, str) and direct_answer.strip():
+            return direct_answer.strip()
+
+    evidence_lines = []
+    for call in tool_calls:
+        for candidate in call.result.candidates:
+            evidence_lines.append(f"[{candidate.citation_label}] {candidate.text}")
+    if evidence_lines:
+        return "Evidence returned by the query tools:\n" + "\n".join(evidence_lines)
+
+    for call in reversed(tool_calls):
+        if call.result.errors:
+            return (
+                "Insufficient source context: the query tool failed. "
+                + call.result.errors[0]
+            )
+        if call.result.warnings:
+            return (
+                "Insufficient source context: the query tool returned a warning. "
+                + call.result.warnings[0]
+            )
+    return "Insufficient source context: no query-tool evidence was returned."
+
+
+class QueryAgent:
+    def __init__(self, model_name: str | None = None, *, model: Any | None = None) -> None:
+        self.model_name = model_name or get_generation_model_name()
+        self.model = model
+        self._last_request_count = 0
+
+    def _instructions(self, engine: Any | None) -> str:
+        return _agent_instructions(engine)
+
+    def _run_model(
+        self,
+        question: str,
+        *,
+        engine: Any,
+        final_top_k: int,
+        recorder: list[AgentToolCall],
+    ) -> AgentAnswer:
+        agent: Agent[None, AgentAnswer] = Agent(
+            self.model or create_generation_model(self.model_name),
+            output_type=AgentAnswer,
+            instructions=self._instructions(engine),
+        )
+        result = agent.run_sync(
+            json.dumps(
+                {"question": question, "default_top_k": final_top_k},
+                ensure_ascii=False,
+            ),
+            usage_limits=UsageLimits(request_limit=_configured_request_limit()),
+            toolsets=[build_agent_toolset(engine, recorder)],
+        )
+        self._last_request_count = result.usage().requests
+        return result.output
+
+    def _fallback_dispatch(
+        self,
+        engine: Any,
+        question: str,
+        final_top_k: int,
+        recorder: list[AgentToolCall],
+    ) -> None:
+        spec = QUERY_TOOL_REGISTRY["search_raw"]
+        args = SearchRawInput(query=question, top_k=final_top_k)
+        step = len(recorder) + 1
+        try:
+            result = spec.dispatcher(engine, args)
+        except Exception as exc:
+            result = ToolResult(errors=[f"fallback tool dispatch failed: {exc}"])
+        recorder.append(
+            AgentToolCall(
+                step=step,
+                tool_name=spec.name,
+                args=args.model_dump(mode="json"),
+                result=result,
+            )
+        )
+
+    def run(
+        self,
+        engine: Any,
+        question: str,
+        *,
+        final_top_k: int = 8,
+    ) -> AgentRunResult:
+        recorder: list[AgentToolCall] = []
+        self._last_request_count = 0
+        try:
+            answer = self._run_model(
+                question,
+                engine=engine,
+                final_top_k=final_top_k,
+                recorder=recorder,
+            )
+        except UsageLimitExceeded as exc:
+            reason = str(exc)
+            if not recorder:
+                self._fallback_dispatch(engine, question, final_top_k, recorder)
+            answer = AgentAnswer(answer=_answer_from_tool_calls(recorder))
+            return AgentRunResult(
+                answer=answer,
+                tool_calls=recorder,
+                stop_reason="usage_limit",
+                model_name=self.model_name,
+                request_count=self._last_request_count,
+                fallback_reason=reason,
+            )
+        except Exception as exc:
+            reason = str(exc)
+            if not recorder:
+                self._fallback_dispatch(engine, question, final_top_k, recorder)
+            answer = AgentAnswer(answer=_answer_from_tool_calls(recorder))
+            return AgentRunResult(
+                answer=answer,
+                tool_calls=recorder,
+                stop_reason="model_error",
+                model_name=self.model_name,
+                request_count=self._last_request_count,
+                fallback_reason=reason,
+            )
+
+        return AgentRunResult(
+            answer=answer,
+            tool_calls=recorder,
+            stop_reason="final_answer",
+            model_name=self.model_name,
+            request_count=self._last_request_count,
+        )
+
+
+class FixtureQueryAgent(QueryAgent):
+    """Deterministic scripted agent that still exercises real query dispatchers."""
+
+    def __init__(
+        self,
+        calls: Sequence[tuple[str, dict[str, Any]]] | None = None,
+        answer: str | AgentAnswer = "fixture answer",
+        *,
+        script: Sequence[tuple[str, dict[str, Any]]] | None = None,
+        scripted_calls: Sequence[tuple[str, dict[str, Any]]] | None = None,
+        tool_calls: Sequence[tuple[str, dict[str, Any]]] | None = None,
+        final_answer: str | AgentAnswer | None = None,
+        canned_answer: str | AgentAnswer | None = None,
+        cited_labels: Sequence[str] | None = None,
+        model_name: str = "fixture-agent",
+        error: Exception | None = None,
+    ) -> None:
+        super().__init__(model_name=model_name)
+        selected_calls = calls or script or scripted_calls or tool_calls or []
+        self.calls = list(selected_calls)
+        if final_answer is not None:
+            answer = final_answer
+        if canned_answer is not None:
+            answer = canned_answer
+        self._answer = (
+            answer
+            if isinstance(answer, AgentAnswer)
+            else AgentAnswer(answer=answer, cited_labels=list(cited_labels or []))
+        )
+        self._error = error
+
+    def _run_model(
+        self,
+        question: str,
+        *,
+        engine: Any,
+        final_top_k: int,
+        recorder: list[AgentToolCall],
+    ) -> AgentAnswer:
+        if self._error is not None:
+            raise self._error
+        for tool_name, raw_args in self.calls:
+            spec = QUERY_TOOL_REGISTRY.get(tool_name)
+            if spec is None:
+                raise ValueError(f"unknown fixture tool: {tool_name}")
+            args = spec.input_model.model_validate(raw_args)
+            step = len(recorder) + 1
+            try:
+                result = spec.dispatcher(engine, args)
+            except Exception as exc:
+                result = ToolResult(errors=[f"{tool_name} dispatch failed: {exc}"])
+            recorder.append(
+                AgentToolCall(
+                    step=step,
+                    tool_name=tool_name,
+                    args=args.model_dump(mode="json"),
+                    result=result,
+                )
+            )
+        return self._answer

--- a/src/linkura_story_indexer/query/audit.py
+++ b/src/linkura_story_indexer/query/audit.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from linkura_story_indexer.database import create_generation_model, get_generation_model_name
+
+AuditFlagType = Literal["retcon", "wrong_honorific", "hallucinated_name"]
+
+
+class AuditFlag(BaseModel):
+    flag_type: AuditFlagType
+    excerpt: str
+    rationale: str
+    evidence_ref: str
+
+
+class AuditReport(BaseModel):
+    flags: list[AuditFlag] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+
+
+def _audit_instructions() -> str:
+    return (
+        "Audit a draft answer against the supplied source evidence, State Ledger, and official "
+        "Glossary. Return a structured AuditReport. Only flag concrete contradictions or "
+        "unsupported proper names; do not penalize a cautious answer for omitting details.\n\n"
+        "Flag classes:\n"
+        "- retcon: the answer contradicts a State Ledger fact's temporal validity interval, "
+        "for example treating a later state as true before valid_from or after valid_to.\n"
+        "- wrong_honorific: the answer assigns or claims an honorific that contradicts the "
+        "State Ledger or the official Glossary.\n"
+        "- hallucinated_name: the answer introduces a proper name absent from the supplied "
+        "evidence, official Glossary, and State Ledger. Common grammar is not a proper name.\n\n"
+        "For each flag include the shortest relevant answer excerpt, a concise rationale, and "
+        "an evidence_ref pointing to the supporting source or saying that the required source "
+        "is absent. If there are no concrete issues, return an empty flags list."
+    )
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def build_audit_payload(
+    question: str,
+    answer: str,
+    evidence: Sequence[Any],
+    state_facts: Sequence[Any],
+    glossary: Mapping[str, Any] | None,
+) -> str:
+    """Build a stable, complete audit input without depending on model message history."""
+    payload = {
+        "question": question,
+        "answer": answer,
+        "evidence": _jsonable(evidence),
+        "state_facts": _jsonable(state_facts),
+        "glossary": _jsonable(glossary or {}),
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+class AnswerAuditor:
+    def __init__(self, model_name: str | None = None, *, model: Any | None = None) -> None:
+        self.model_name = model_name or os.getenv("LINKURA_AUDIT_MODEL") or get_generation_model_name()
+        self.model = model
+
+    def _run_model(self, payload: str) -> AuditReport:
+        agent: Agent[None, AuditReport] = Agent(
+            self.model or create_generation_model(self.model_name),
+            output_type=AuditReport,
+            instructions=_audit_instructions(),
+        )
+        return agent.run_sync(payload).output
+
+    def audit(
+        self,
+        question: str,
+        answer: str,
+        evidence: Sequence[Any],
+        state_facts: Sequence[Any],
+        glossary: Mapping[str, Any] | None,
+    ) -> AuditReport:
+        return self._run_model(
+            build_audit_payload(question, answer, evidence, state_facts, glossary)
+        )
+
+    def run(
+        self,
+        question: str,
+        answer: str,
+        evidence: Sequence[Any],
+        state_facts: Sequence[Any],
+        glossary: Mapping[str, Any] | None,
+    ) -> AuditReport:
+        return self.audit(
+            question,
+            answer,
+            evidence=evidence,
+            state_facts=state_facts,
+            glossary=glossary,
+        )
+
+
+class FixtureAnswerAuditor(AnswerAuditor):
+    def __init__(
+        self,
+        report: AuditReport | Mapping[str, Any],
+        *,
+        model_name: str = "fixture-auditor",
+        error: Exception | None = None,
+    ) -> None:
+        super().__init__(model_name=model_name)
+        self.report = report if isinstance(report, AuditReport) else AuditReport.model_validate(report)
+        self.error = error
+
+    def _run_model(self, payload: str) -> AuditReport:
+        if self.error is not None:
+            raise self.error
+        return self.report
+
+
+def render_audit_flags(report: AuditReport) -> str:
+    lines: list[str] = []
+    if report.flags:
+        lines.append("Audit flags:")
+        for flag in report.flags:
+            lines.append(
+                f"- {flag.flag_type}: {flag.excerpt} — {flag.rationale} "
+                f"(evidence: {flag.evidence_ref})"
+            )
+    if report.errors:
+        lines.append("Audit errors:")
+        lines.extend(f"- {error}" for error in report.errors)
+    if not lines:
+        return "Audit: clean."
+    return "\n".join(lines)

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -38,6 +38,9 @@ from .analysis import (
 )
 
 if TYPE_CHECKING:
+    from linkura_story_indexer.query.agent import QueryAgent
+    from linkura_story_indexer.query.audit import AnswerAuditor
+
     from .router import QueryRouter
 
 ROUTING_CANDIDATE_COUNT = 20
@@ -66,7 +69,8 @@ class RetrievalConfig:
     max_ranked_candidates: int = MAX_RANKED_CANDIDATES
     final_top_k: int = FINAL_TOP_K
     rrf_k: int = RRF_K
-    routing_mode: Literal["off", "heuristic", "llm_router"] = "off"
+    routing_mode: Literal["off", "heuristic", "llm_router", "agentic"] = "off"
+    audit_enabled: bool = False
 
     def __post_init__(self) -> None:
         if self.routing_candidate_count < 1:
@@ -124,6 +128,7 @@ class RoutedTraceResult:
     nodes: list[Node]
     stages: dict[StageName, StageTrace]
     direct_answer: str | None = None
+    citation_labels: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -141,6 +146,7 @@ class _PreparedQuery:
     user_prompt: str | None = None
     router_metadata: dict[str, Any] | None = None
     final_citation_labels: tuple[str, ...] = ()
+    audit_nodes: tuple[Node, ...] = ()
 
 
 class StoryQueryEngine:
@@ -151,12 +157,16 @@ class StoryQueryEngine:
         summary_cache_file: str = "summaries_cache.json",
         retrieval_config: RetrievalConfig | None = None,
         query_router: "QueryRouter | None" = None,
+        query_agent: "QueryAgent | None" = None,
+        answer_auditor: "AnswerAuditor | None" = None,
     ):
         self.collection = get_chroma_collection()
         self.lexical_index = LexicalIndex()
         self.source_store: Any = SourceRecordStore()
         self.retrieval_config = retrieval_config or DEFAULT_RETRIEVAL_CONFIG
         self.query_router = query_router
+        self.query_agent = query_agent
+        self.answer_auditor = answer_auditor
 
         self.state_ledger: dict[str, Any] = {}
         if os.path.exists(state_file):
@@ -1861,6 +1871,24 @@ class StoryQueryEngine:
             self.query_router = QueryRouter()
         return self.query_router
 
+    def _get_query_agent(self) -> "QueryAgent":
+        query_agent = getattr(self, "query_agent", None)
+        if query_agent is None:
+            from linkura_story_indexer.query.agent import QueryAgent
+
+            query_agent = QueryAgent()
+            self.query_agent = query_agent
+        return query_agent
+
+    def _get_answer_auditor(self) -> "AnswerAuditor":
+        answer_auditor = getattr(self, "answer_auditor", None)
+        if answer_auditor is None:
+            from linkura_story_indexer.query.audit import AnswerAuditor
+
+            answer_auditor = AnswerAuditor()
+            self.answer_auditor = answer_auditor
+        return answer_auditor
+
     def _trace_candidate_from_tool_candidate(
         self,
         candidate: Any,
@@ -1916,6 +1944,159 @@ class StoryQueryEngine:
             direct_answer=direct_answer if isinstance(direct_answer, str) else None,
         )
 
+    def _agent_dispatch_with_trace(self, question: str) -> RoutedTraceResult:
+        from linkura_story_indexer.query.agent import _agent_tool_payload
+
+        run = self._get_query_agent().run(
+            self,
+            question,
+            final_top_k=self._config().final_top_k,
+        )
+        call_summaries = []
+        candidates = []
+        seen_labels: set[str] = set()
+        for call in run.tool_calls:
+            payload = _agent_tool_payload(call.result)
+            call_summaries.append(
+                {
+                    "step": call.step,
+                    "tool_name": call.tool_name,
+                    "args": call.args,
+                    **payload,
+                }
+            )
+            for candidate in call.result.candidates:
+                if len(candidates) >= self._config().final_top_k:
+                    break
+                if candidate.citation_label in seen_labels:
+                    continue
+                seen_labels.add(candidate.citation_label)
+                candidate.rank = len(candidates) + 1
+                candidates.append(candidate)
+
+        final_candidates = [
+            self._trace_candidate_from_tool_candidate(candidate)
+            for candidate in candidates
+        ]
+        stages: dict[StageName, StageTrace] = {
+            "agent": self._trace_stage(
+                "agent",
+                None,
+                metadata={
+                    "model": run.model_name,
+                    "request_count": run.request_count,
+                    "stop_reason": run.stop_reason,
+                    "fallback_reason": run.fallback_reason,
+                    "tool_calls": call_summaries,
+                    "model_cited_labels": list(run.answer.cited_labels),
+                },
+            ),
+            "final_top_k": self._trace_stage("final_top_k", final_candidates),
+        }
+        nodes = [
+            (candidate.text, dict(candidate.metadata))
+            for candidate in candidates
+            if candidate.metadata
+        ]
+        citation_labels = tuple(candidate.citation_label for candidate in candidates)
+        return RoutedTraceResult(
+            nodes=nodes,
+            stages=stages,
+            direct_answer=run.answer.answer,
+            citation_labels=citation_labels,
+        )
+
+    def _audit_stage(
+        self,
+        question: str,
+        answer_text: str,
+        nodes: list[Node],
+    ) -> StageTrace:
+        from linkura_story_indexer.query.audit import AuditReport, build_audit_payload
+
+        evidence = [
+            {
+                "citation_label": self._citation_label(metadata),
+                "text": document,
+                "metadata": dict(metadata),
+            }
+            for document, metadata in nodes
+        ]
+        glossary = getattr(self, "glossary", None)
+        try:
+            arc_ids = self._question_arc_ids(question)
+        except Exception:
+            arc_ids = set()
+        arc_ids.update(
+            str(metadata["arc_id"])
+            for _, metadata in nodes
+            if isinstance(metadata.get("arc_id"), str)
+        )
+        analysis = None
+        try:
+            analysis = analyze_query(question, glossary)
+        except Exception:
+            analysis = None
+        try:
+            state_facts = self._state_ledger_slice(arc_ids, analysis)
+        except Exception:
+            try:
+                state_facts = self._state_ledger_slice(arc_ids)
+            except Exception:
+                state_facts = []
+
+        payload = build_audit_payload(
+            question,
+            answer_text,
+            evidence,
+            state_facts,
+            glossary or {},
+        )
+        try:
+            auditor = self._get_answer_auditor()
+            report = auditor.audit(
+                question,
+                answer_text,
+                evidence=evidence,
+                state_facts=state_facts,
+                glossary=glossary or {},
+            )
+        except Exception as exc:
+            auditor = None
+            report = AuditReport(errors=[str(exc)])
+
+        report_data = report.model_dump(mode="json")
+        flags = report_data.get("flags", [])
+        errors = report_data.get("errors", [])
+        return self._trace_stage(
+            "audit",
+            None,
+            metadata={
+                "model": getattr(auditor, "model_name", None),
+                "payload": payload,
+                "report": report_data,
+                "flags": flags,
+                "errors": errors,
+                "audit_clean": not flags and not errors,
+                "flag_count": len(flags),
+            },
+        )
+
+    def _append_audit(
+        self,
+        question: str,
+        answer_text: str,
+        nodes: list[Node],
+    ) -> str:
+        if not self._config().audit_enabled or not answer_text:
+            return answer_text
+        from linkura_story_indexer.query.audit import AuditReport, render_audit_flags
+
+        stage = self._audit_stage(question, answer_text, nodes)
+        report = AuditReport.model_validate(stage.metadata.get("report", {}))
+        rendered = render_audit_flags(report)
+        return f"{answer_text}\n\n{rendered}" if rendered else answer_text
+
     def _router_unavailable_message(self, stages: dict[StageName, StageTrace]) -> str:
         router_stage = stages.get("router")
         metadata = router_stage.metadata if router_stage is not None else {}
@@ -1950,8 +2131,12 @@ class StoryQueryEngine:
     ) -> QueryTrace:
         """Executes the raw-first retrieval flow and returns deterministic stage traces."""
         effective_mode: EvalMode = mode if mode is not None else self._config().routing_mode
-        if effective_mode == "llm_router":
-            routed = self._router_dispatch_with_trace(question)
+        if effective_mode in {"llm_router", "agentic"}:
+            routed = (
+                self._router_dispatch_with_trace(question)
+                if effective_mode == "llm_router"
+                else self._agent_dispatch_with_trace(question)
+            )
             answer_text = None
             if answer_mode:
                 if routed.direct_answer is not None:
@@ -1960,15 +2145,18 @@ class StoryQueryEngine:
                     answer_text = self._answer_from_routed_evidence(question, routed)
                 else:
                     answer_text = self._router_unavailable_message(routed.stages)
+            if answer_mode and self._config().audit_enabled and answer_text:
+                routed.stages["audit"] = self._audit_stage(question, answer_text, routed.nodes)
             return QueryTrace(
                 query_id=query_id,
                 question=question,
                 mode=effective_mode,
                 config=self._config().__dict__,
                 stages=routed.stages,
-                final_citation_labels=[
-                    self._citation_label(metadata) for _, metadata in routed.nodes
-                ],
+                final_citation_labels=list(
+                    routed.citation_labels
+                    or tuple(self._citation_label(metadata) for _, metadata in routed.nodes)
+                ),
                 answer_text=answer_text,
             )
 
@@ -1981,6 +2169,8 @@ class StoryQueryEngine:
         answer_text = None
         if answer_mode and final_raw_nodes:
             answer_text = self._answer_from_raw_evidence(question, final_raw_nodes, analysis)
+        if answer_mode and self._config().audit_enabled and answer_text:
+            retrieval.stages["audit"] = self._audit_stage(question, answer_text, final_raw_nodes)
 
         return QueryTrace(
             query_id=query_id,
@@ -1997,21 +2187,46 @@ class StoryQueryEngine:
     def query(self, question: str) -> str:
         """Executes the raw-first RAG query flow."""
         prepared = self._prepare_query(question)
+        answer = self._answer_from_prepared(prepared)
+        return self._append_audit(question, answer, list(prepared.audit_nodes))
+
+    def stream_query(self, question: str) -> StreamingQueryResult:
+        """Prepares a query once and returns a one-use iterator of answer deltas."""
+        prepared = self._prepare_query(question)
+        if self._config().audit_enabled:
+            answer = self._answer_from_prepared(prepared)
+            answer = self._append_audit(question, answer, list(prepared.audit_nodes))
+            return StreamingQueryResult(
+                answer_deltas=iter([answer]),
+                router_metadata=prepared.router_metadata,
+            )
+        return StreamingQueryResult(
+            answer_deltas=self._stream_prepared_answer(prepared),
+            router_metadata=prepared.router_metadata,
+        )
+
+    def _answer_from_prepared(self, prepared: _PreparedQuery) -> str:
         if prepared.immediate_answer is not None:
             return prepared.immediate_answer
         if prepared.system_prompt is None or prepared.user_prompt is None:
             return "No answer generated."
         return self._answer_from_prompts(prepared.system_prompt, prepared.user_prompt)
 
-    def stream_query(self, question: str) -> StreamingQueryResult:
-        """Prepares a query once and returns a one-use iterator of answer deltas."""
-        prepared = self._prepare_query(question)
-        return StreamingQueryResult(
-            answer_deltas=self._stream_prepared_answer(prepared),
-            router_metadata=prepared.router_metadata,
-        )
-
     def _prepare_query(self, question: str) -> _PreparedQuery:
+        if self._config().routing_mode == "agentic":
+            safe_print("Running the agentic retrieval loop...")
+            routed = self._agent_dispatch_with_trace(question)
+            agent_stage = routed.stages.get("agent")
+            agent_metadata = dict(agent_stage.metadata) if agent_stage is not None else None
+            return _PreparedQuery(
+                immediate_answer=routed.direct_answer or self._router_unavailable_message(
+                    routed.stages
+                ),
+                router_metadata=agent_metadata,
+                final_citation_labels=routed.citation_labels,
+                audit_nodes=tuple(routed.nodes),
+            )
+
         if self._config().routing_mode == "llm_router":
             safe_print("Routing query to a typed retrieval tool...")
             routed = self._router_dispatch_with_trace(question)
@@ -2021,6 +2236,7 @@ class StoryQueryEngine:
                 return _PreparedQuery(
                     immediate_answer=routed.direct_answer,
                     router_metadata=router_metadata,
+                    audit_nodes=tuple(routed.nodes),
                 )
             if not routed.nodes:
                 return _PreparedQuery(
@@ -2040,6 +2256,7 @@ class StoryQueryEngine:
                 final_citation_labels=tuple(
                     self._citation_label(metadata) for _, metadata in routed.nodes
                 ),
+                audit_nodes=tuple(routed.nodes),
             )
 
         safe_print("Searching raw source evidence...")
@@ -2106,6 +2323,7 @@ class StoryQueryEngine:
             final_citation_labels=tuple(
                 self._citation_label(metadata) for _, metadata in final_raw_nodes
             ),
+            audit_nodes=tuple(final_raw_nodes),
         )
 
     def _stream_prepared_answer(self, prepared: _PreparedQuery) -> Iterator[str]:

--- a/tests/test_answer_audit.py
+++ b/tests/test_answer_audit.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+
+from linkura_story_indexer.query.agent import FixtureQueryAgent
+from linkura_story_indexer.query.audit import (
+    AuditFlag,
+    AuditReport,
+    FixtureAnswerAuditor,
+    build_audit_payload,
+    render_audit_flags,
+)
+from linkura_story_indexer.query.engine import RetrievalConfig, StoryQueryEngine
+
+
+def make_engine(auditor: FixtureAnswerAuditor) -> StoryQueryEngine:
+    engine = StoryQueryEngine.__new__(StoryQueryEngine)
+    engine.retrieval_config = RetrievalConfig(routing_mode="agentic", audit_enabled=True)
+    engine.glossary = {"characters": {"日野下花帆": "Kaho Hinoshita"}}
+    engine.state_ledger = {
+        "facts": [
+            {
+                "subject": "花帆",
+                "predicate": "honorific_used_for",
+                "target": "さやか",
+                "object": "ちゃん",
+                "arc": "103",
+                "episode": "第1話",
+                "part": "1",
+                "scene": 0,
+                "valid_from": 1,
+                "valid_to": None,
+                "confidence": 1.0,
+                "extracted_quote": "さやかちゃん",
+                "file_path": "story/103/第1話/1.md",
+                "scene_index": 0,
+            },
+            {
+                "subject": "other",
+                "predicate": "status",
+                "target": None,
+                "object": "unscoped",
+                "arc": "104",
+                "episode": "第1話",
+                "part": "1",
+                "scene": 0,
+                "valid_from": 1,
+                "valid_to": None,
+                "confidence": 1.0,
+                "extracted_quote": "other",
+                "file_path": "story/104/第1話/1.md",
+                "scene_index": 0,
+            },
+        ]
+    }
+    engine.source_store = type("Store", (), {"iter_scenes": lambda self: []})()
+    engine.query_agent = FixtureQueryAgent(answer="The draft answer.")
+    engine.answer_auditor = auditor
+    return engine
+
+
+def test_audit_payload_contains_evidence_scoped_ledger_and_glossary() -> None:
+    payload = build_audit_payload(
+        "question",
+        "draft answer",
+        [{"citation_label": "103 · Scene 1", "text": "evidence"}],
+        [{"arc": "103", "object": "active"}],
+        {"characters": {"日野下花帆": "Kaho Hinoshita"}},
+    )
+
+    data = json.loads(payload)
+    assert data["evidence"][0]["text"] == "evidence"
+    assert data["state_facts"] == [{"arc": "103", "object": "active"}]
+    assert data["glossary"]["characters"]["日野下花帆"] == "Kaho Hinoshita"
+
+
+def test_fixture_auditor_flags_land_in_trace_and_render() -> None:
+    report = AuditReport(
+        flags=[
+            AuditFlag(
+                flag_type="retcon",
+                excerpt="later state",
+                rationale="outside the validity interval",
+                evidence_ref="ledger:103",
+            ),
+            AuditFlag(
+                flag_type="wrong_honorific",
+                excerpt="さやかさん",
+                rationale="ledger says ちゃん",
+                evidence_ref="ledger:103",
+            ),
+            AuditFlag(
+                flag_type="hallucinated_name",
+                excerpt="Unknown",
+                rationale="not in supplied evidence",
+                evidence_ref="absent",
+            ),
+        ]
+    )
+    engine = make_engine(FixtureAnswerAuditor(report))
+
+    trace = engine.retrieve_with_trace("What happened in 103?", answer_mode=True)
+
+    assert trace.answer_text == "The draft answer."
+    audit_stage = trace.stages["audit"]
+    assert audit_stage.metadata["flag_count"] == 3
+    assert {flag["flag_type"] for flag in audit_stage.metadata["flags"]} == {
+        "retcon",
+        "wrong_honorific",
+        "hallucinated_name",
+    }
+    rendered = render_audit_flags(report)
+    assert "Audit flags:" in rendered
+    assert "wrong_honorific" in rendered
+    assert "ledger:103" in rendered
+
+
+def test_auditor_failure_is_recorded_without_changing_answer() -> None:
+    engine = make_engine(
+        FixtureAnswerAuditor(AuditReport(), error=RuntimeError("audit unavailable"))
+    )
+
+    trace = engine.retrieve_with_trace("What happened in 103?", answer_mode=True)
+
+    assert trace.answer_text == "The draft answer."
+    assert trace.stages["audit"].metadata["errors"] == ["audit unavailable"]
+
+
+def test_query_appends_rendered_audit_for_opt_in_interactive_mode() -> None:
+    report = AuditReport(
+        flags=[
+            AuditFlag(
+                flag_type="hallucinated_name",
+                excerpt="Unknown",
+                rationale="absent from evidence",
+                evidence_ref="absent",
+            )
+        ]
+    )
+    engine = make_engine(FixtureAnswerAuditor(report))
+
+    answer = engine.query("What happened in 103?")
+
+    assert answer.startswith("The draft answer.")
+    assert "Audit flags:" in answer
+    assert "hallucinated_name" in answer

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -202,6 +202,61 @@ def test_diff_reports_aggregate_and_rank_changes() -> None:
     assert diff.rank_deltas[0].delta == -3
 
 
+def test_audit_metrics_aggregate_and_diff() -> None:
+    clean_trace = trace(final_candidates=[candidate(1, source(scene_start=1, scene_end=1))])
+    clean_trace.stages["audit"] = StageTrace(
+        name="audit",
+        candidates=None,
+        metadata={"report": {"flags": [], "errors": []}},
+    )
+    flagged_trace = trace(final_candidates=[candidate(1, source(scene_start=1, scene_end=1))])
+    flagged_trace.stages["audit"] = StageTrace(
+        name="audit",
+        candidates=None,
+        metadata={
+            "report": {
+                "flags": [
+                    {
+                        "flag_type": "retcon",
+                        "excerpt": "later",
+                        "rationale": "interval",
+                        "evidence_ref": "ledger",
+                    }
+                ],
+                "errors": [],
+            }
+        },
+    )
+
+    clean_metric = evaluate_query(clean_trace, question())
+    flagged_metric = evaluate_query(flagged_trace, question())
+    aggregate = aggregate_metrics(
+        [clean_metric, flagged_metric],
+        [clean_trace, flagged_trace],
+    )
+
+    assert clean_metric.audit_clean is True
+    assert clean_metric.audit_flag_count == 0
+    assert flagged_metric.audit_clean is False
+    assert flagged_metric.audit_flag_count == 1
+    assert aggregate.audit_clean_rate == 0.5
+
+    before = EvalRun(
+        config=RunConfig(golden_set="golden.json", audit_enabled=True),
+        aggregate_metrics=aggregate,
+        query_metrics=[clean_metric, flagged_metric],
+        traces=[clean_trace, flagged_trace],
+    )
+    after = EvalRun(
+        config=RunConfig(golden_set="golden.json", audit_enabled=True),
+        aggregate_metrics=aggregate.model_copy(update={"audit_clean_rate": 1.0}),
+        query_metrics=[clean_metric, flagged_metric],
+        traces=[clean_trace, flagged_trace],
+    )
+
+    assert diff_runs(before, after).aggregate_deltas["audit_clean_rate"] == 0.5
+
+
 def test_golden_set_rejects_duplicate_ids(tmp_path: Path) -> None:
     path = tmp_path / "golden.json"
     payload = {

--- a/tests/test_query_agent.py
+++ b/tests/test_query_agent.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic_ai.messages import ModelResponse, ToolCallPart
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.models.test import TestModel
+
+from linkura_story_indexer.eval.io import stable_json
+from linkura_story_indexer.query import engine as query_engine
+from linkura_story_indexer.query.agent import (
+    AgentAnswer,
+    FixtureQueryAgent,
+    QueryAgent,
+    build_agent_toolset,
+)
+from linkura_story_indexer.query.engine import (
+    RetrievalConfig,
+    RetrievalTraceResult,
+    StoryQueryEngine,
+)
+
+
+def make_engine() -> StoryQueryEngine:
+    engine = StoryQueryEngine.__new__(StoryQueryEngine)
+    engine.retrieval_config = RetrievalConfig(routing_mode="agentic", final_top_k=5)
+    engine.glossary = {"characters": {"日野下花帆": "Kaho Hinoshita"}}
+    engine.state_ledger = {}
+    return engine
+
+
+def raw_node(text: str = "raw evidence", scene_index: int = 0) -> tuple[str, dict[str, Any]]:
+    return (
+        text,
+        {
+            "arc_id": "103",
+            "story_type": "Main",
+            "episode_name": "第1話『花咲きたい！』",
+            "episode_number": 1,
+            "part_name": "1",
+            "summary_level": 4,
+            "file_path": "story/103/第1話『花咲きたい！』/1.md",
+            "scene_index": scene_index,
+            "scene_start": scene_index,
+            "scene_end": scene_index,
+            "canonical_story_order": scene_index + 1,
+            "chunk_id": f"chunk-103-{scene_index}",
+        },
+    )
+
+
+def test_agent_toolset_registers_the_shared_typed_schemas() -> None:
+    engine = make_engine()
+    recorder = []
+    toolset = build_agent_toolset(engine, recorder)
+    test_model = TestModel()
+
+    from pydantic_ai import Agent
+
+    Agent(test_model).run_sync("list tools", toolsets=[toolset])
+
+    request_parameters = test_model.last_model_request_parameters
+    assert request_parameters is not None
+    by_name = {tool.name: tool for tool in request_parameters.function_tools}
+    assert set(by_name) == {
+        "search_raw",
+        "search_summaries",
+        "get_scene",
+        "lookup_glossary",
+        "get_state",
+        "count_dialogue",
+    }
+    assert "speaker" in by_name["count_dialogue"].parameters_json_schema["properties"]
+
+
+def test_function_model_agent_records_multi_step_calls_and_reranks_candidates(
+    monkeypatch: Any,
+) -> None:
+    engine = make_engine()
+
+    def fake_retrieve(
+        question: str,
+        *,
+        where: dict[str, Any] | None = None,
+        top_k: int | None = None,
+        n_results: int | None = None,
+        analysis: Any = None,
+    ) -> RetrievalTraceResult:
+        return RetrievalTraceResult(nodes=[raw_node("search evidence")], stages={})
+
+    monkeypatch.setattr(engine, "retrieve_raw_nodes_with_trace", fake_retrieve)
+    monkeypatch.setattr(engine, "_fetch_raw_text", lambda metadata: "")
+
+    def scripted_model(messages: list[Any], info: Any) -> ModelResponse:
+        tool_returns = sum(
+            1
+            for message in messages
+            for part in getattr(message, "parts", [])
+            if getattr(part, "part_kind", None) == "tool-return"
+        )
+        if tool_returns == 0:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="lookup_glossary", args={"term": "花帆"})]
+            )
+        if tool_returns == 1:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="search_raw",
+                        args={"query": "Kaho", "top_k": 1},
+                    )
+                ]
+            )
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name=info.output_tools[0].name,
+                    args={
+                        "answer": "The evidence supports this answer.",
+                        "cited_labels": [
+                            "103 · Episode 1 · Part 1 · Scene 1",
+                        ],
+                    },
+                )
+            ]
+        )
+
+    engine.query_agent = QueryAgent(
+        model=FunctionModel(scripted_model),
+        model_name="function-agent",
+    )
+
+    trace = engine.retrieve_with_trace("What happened?", answer_mode=True)
+
+    assert trace.answer_text == "The evidence supports this answer."
+    assert trace.stages["agent"].metadata["stop_reason"] == "final_answer"
+    assert [
+        call["tool_name"] for call in trace.stages["agent"].metadata["tool_calls"]
+    ] == ["lookup_glossary", "search_raw"]
+    assert trace.stages["final_top_k"].candidates is not None
+    assert trace.stages["final_top_k"].candidates[0].rank == 1
+    assert trace.final_citation_labels == ["103 · Episode 1 · Part 1 · Scene 1"]
+
+
+def test_agent_counting_uses_the_sql_tool_result() -> None:
+    engine = make_engine()
+
+    class Store:
+        def count_turns(
+            self,
+            speaker: str,
+            *,
+            arc_id: str | None = None,
+            episode: int | None = None,
+            part: str | None = None,
+        ) -> int:
+            return 24
+
+    engine.source_store = Store()
+    engine.query_agent = FixtureQueryAgent(
+        calls=[("count_dialogue", {"speaker": "花帆", "arc_id": "103"})],
+        answer=AgentAnswer(answer="花帆 has 24 dialogue turns."),
+    )
+
+    trace = engine.retrieve_with_trace("How many turns?", answer_mode=True)
+
+    assert "24" in (trace.answer_text or "")
+    assert trace.stages["agent"].metadata["tool_calls"][0]["tool_name"] == "count_dialogue"
+
+
+def test_usage_limit_falls_back_to_one_raw_search(monkeypatch: Any) -> None:
+    engine = make_engine()
+    engine.source_store = object()
+
+    monkeypatch.setattr(
+        query_engine,
+        "INSUFFICIENT_SOURCE_CONTEXT",
+        "fallback context unavailable",
+    )
+
+    class FailingAgent(QueryAgent):
+        def _run_model(
+            self,
+            question: str,
+            *,
+            engine: Any,
+            final_top_k: int,
+            recorder: list[Any],
+        ) -> AgentAnswer:
+            from pydantic_ai.exceptions import UsageLimitExceeded
+
+            raise UsageLimitExceeded("request cap")
+
+    engine.query_agent = FailingAgent(model_name="limited")
+    result = engine.query_agent.run(engine, "question", final_top_k=5)
+
+    assert result.stop_reason == "usage_limit"
+    assert result.tool_calls[0].tool_name == "search_raw"
+    assert result.fallback_reason == "request cap"
+
+
+def test_fixture_agent_traces_are_stable_across_runs(monkeypatch: Any) -> None:
+    engine = make_engine()
+
+    def fake_retrieve(*args: Any, **kwargs: Any) -> RetrievalTraceResult:
+        return RetrievalTraceResult(nodes=[raw_node()], stages={})
+
+    monkeypatch.setattr(engine, "retrieve_raw_nodes_with_trace", fake_retrieve)
+    monkeypatch.setattr(engine, "_fetch_raw_text", lambda metadata: "")
+    engine.query_agent = FixtureQueryAgent(
+        calls=[("search_raw", {"query": "question", "top_k": 1})],
+        answer="fixture answer",
+    )
+
+    first = engine.retrieve_with_trace("question", query_id="q", answer_mode=True)
+    second = engine.retrieve_with_trace("question", query_id="q", answer_mode=True)
+
+    assert stable_json(first) == stable_json(second)


### PR DESCRIPTION
## Summary

Implements Issue #13:

- Adds capped pydantic-ai agentic query mode via `--routing-mode agentic`.
- Adds recorder-backed multi-step typed tool calling and deterministic fixture agents.
- Enforces SQL-backed `count_dialogue` for quantitative questions.
- Adds opt-in secondary answer auditing for retcons, wrong honorifics, and hallucinated names.
- Adds audit metrics and agentic-vs-router eval comparison wiring.
- Documents CLI usage and the current deferred golden-set extension.

## Verification

- `uv run pytest` — 236 passed
- `uv run ruff check .` — passed
- `uv run pyrefly check .` — passed

Closes #13