### PR TITLE
Fix agentic OpenAI reasoning model tool calls

### DIFF
--- a/src/linkura_story_indexer/database.py
+++ b/src/linkura_story_indexer/database.py
@@ -36,6 +36,7 @@ _chroma_collections: dict[tuple[str, str], Any] = {}
 _genai_clients: dict[str, genai.Client] = {}
 _google_models: dict[tuple[str, str], GoogleModel] = {}
 _openai_models: dict[tuple[str, str, str], Any] = {}
+_openai_responses_models: dict[tuple[str, str, str], Any] = {}
 
 
 def get_google_api_key() -> str:
@@ -139,6 +140,27 @@ def create_generation_model(model_name: str | None = None) -> Any:
     )
 
 
+def create_agentic_generation_model(model_name: str | None = None) -> Any:
+    """Creates the generation model for tool-calling agent runs.
+
+    OpenAI reasoning models reject function tools on Chat Completions, so the
+    agentic path uses the Responses API. Set LINKURA_OPENAI_API=chat to force
+    Chat Completions (for OPENAI_BASE_URL proxies without a Responses endpoint).
+    """
+    provider = get_generation_provider_name()
+    model_name = model_name or get_generation_model_name()
+    if provider == "google":
+        return create_google_model(model_name)
+    if provider == "openai":
+        if os.getenv("LINKURA_OPENAI_API", "").strip().lower() == "chat":
+            return create_openai_model(model_name)
+        return create_openai_responses_model(model_name)
+    raise ValueError(
+        f"Unsupported LINKURA_INGEST_PROVIDER {provider!r}. "
+        f"Expected one of: {', '.join(sorted(SUPPORTED_GENERATION_PROVIDERS))}"
+    )
+
+
 def create_google_model(model_name: str | None = None) -> GoogleModel:
     api_key = get_google_api_key()
     model_name = model_name or get_chat_model_name()
@@ -172,6 +194,29 @@ def create_openai_model(model_name: str | None = None) -> Any:
             provider=OpenAIProvider(base_url=base_url or None, api_key=api_key),
         )
     return _openai_models[cache_key]
+
+
+def create_openai_responses_model(model_name: str | None = None) -> Any:
+    api_key = get_openai_api_key()
+    model_name = model_name or get_generation_model_name()
+    base_url = os.getenv("OPENAI_BASE_URL", "")
+    cache_key = (api_key, model_name, base_url)
+    if cache_key not in _openai_responses_models:
+        try:
+            from pydantic_ai.models.openai import OpenAIResponsesModel
+            from pydantic_ai.providers.openai import OpenAIProvider
+        except ImportError as exc:
+            raise ImportError(
+                "OpenAI generation requires the OpenAI extra. "
+                "Install dependencies with `uv sync` after adding "
+                '`pydantic-ai-slim[google,openai]`.'
+            ) from exc
+
+        _openai_responses_models[cache_key] = OpenAIResponsesModel(
+            model_name,
+            provider=OpenAIProvider(base_url=base_url or None, api_key=api_key),
+        )
+    return _openai_responses_models[cache_key]
 
 
 def get_genai_client() -> genai.Client:
@@ -303,3 +348,4 @@ def reset_client_caches() -> None:
     _genai_clients.clear()
     _google_models.clear()
     _openai_models.clear()
+    _openai_responses_models.clear()

--- a/src/linkura_story_indexer/query/agent.py
+++ b/src/linkura_story_indexer/query/agent.py
@@ -11,7 +11,10 @@ from pydantic import BaseModel, Field
 from pydantic_ai import Agent, FunctionToolset, UsageLimits
 from pydantic_ai.exceptions import UsageLimitExceeded
 
-from linkura_story_indexer.database import create_generation_model, get_generation_model_name
+from linkura_story_indexer.database import (
+    create_agentic_generation_model,
+    get_generation_model_name,
+)
 from linkura_story_indexer.query.router import _story_location_catalog
 from linkura_story_indexer.query.tools import (
     QUERY_TOOL_REGISTRY,
@@ -221,7 +224,7 @@ class QueryAgent:
         recorder: list[AgentToolCall],
     ) -> AgentAnswer:
         agent: Agent[None, AgentAnswer] = Agent(
-            self.model or create_generation_model(self.model_name),
+            self.model or create_agentic_generation_model(self.model_name),
             output_type=AgentAnswer,
             instructions=self._instructions(engine),
         )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, cast
+
+from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
 
 from linkura_story_indexer import database
 from linkura_story_indexer.database import EmbeddingDocument
@@ -103,6 +105,83 @@ def test_generation_model_honors_model_override(monkeypatch):
 
     assert database.create_generation_model("gpt-router") == "openai-model"
     assert calls == ["gpt-router"]
+
+
+def test_agentic_generation_model_uses_responses_api_for_openai(monkeypatch):
+    database.reset_client_caches()
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setenv("LINKURA_INGEST_PROVIDER", "openai")
+    monkeypatch.setenv("LINKURA_INGEST_MODEL", "gpt-5.6-luna")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.test/v1")
+    monkeypatch.delenv("LINKURA_OPENAI_API", raising=False)
+
+    model = database.create_agentic_generation_model()
+
+    assert isinstance(model, OpenAIResponsesModel)
+    assert not isinstance(model, OpenAIChatModel)
+    assert model.model_name == "gpt-5.6-luna"
+    provider = cast(Any, model.provider)
+    assert str(provider.client.base_url) == "https://example.test/v1/"
+    assert database.create_agentic_generation_model() is model
+
+    database.reset_client_caches()
+    fresh_model = database.create_agentic_generation_model()
+    assert fresh_model is not model
+    assert isinstance(fresh_model, OpenAIResponsesModel)
+
+    generation_model = database.create_generation_model()
+    assert isinstance(generation_model, OpenAIChatModel)
+    assert not isinstance(generation_model, OpenAIResponsesModel)
+
+
+def test_agentic_generation_model_uses_google_for_google_provider(monkeypatch):
+    monkeypatch.setenv("LINKURA_INGEST_PROVIDER", "google")
+    monkeypatch.setenv("LINKURA_INGEST_MODEL", "gemini-agent")
+    calls: list[str | None] = []
+
+    def fake_create_google_model(model_name: str | None = None) -> str:
+        calls.append(model_name)
+        return "google-model"
+
+    monkeypatch.setattr(database, "create_google_model", fake_create_google_model)
+
+    assert database.create_agentic_generation_model() == "google-model"
+    assert calls == ["gemini-agent"]
+
+
+def test_agentic_generation_model_chat_escape_hatch(monkeypatch):
+    monkeypatch.setenv("LINKURA_INGEST_PROVIDER", "openai")
+    monkeypatch.setenv("LINKURA_INGEST_MODEL", "gpt-5.6-luna")
+    monkeypatch.setenv("LINKURA_OPENAI_API", "chat")
+    calls: list[str | None] = []
+
+    def fake_create_openai_model(model_name: str | None = None) -> str:
+        calls.append(model_name)
+        return "chat-model"
+
+    monkeypatch.setattr(database, "create_openai_model", fake_create_openai_model)
+
+    assert database.create_agentic_generation_model() == "chat-model"
+    assert calls == ["gpt-5.6-luna"]
+
+
+def test_agentic_generation_model_honors_model_override(monkeypatch):
+    monkeypatch.setenv("LINKURA_INGEST_PROVIDER", "openai")
+    monkeypatch.delenv("LINKURA_OPENAI_API", raising=False)
+    calls: list[str | None] = []
+
+    def fake_create_openai_responses_model(model_name: str | None = None) -> str:
+        calls.append(model_name)
+        return "responses-model"
+
+    monkeypatch.setattr(
+        database,
+        "create_openai_responses_model",
+        fake_create_openai_responses_model,
+    )
+
+    assert database.create_agentic_generation_model("gpt-agent") == "responses-model"
+    assert calls == ["gpt-agent"]
 
 
 def test_generation_settings_validate_only_selected_provider(monkeypatch):

--- a/tests/test_query_agent.py
+++ b/tests/test_query_agent.py
@@ -73,6 +73,30 @@ def test_agent_toolset_registers_the_shared_typed_schemas() -> None:
     assert "speaker" in by_name["count_dialogue"].parameters_json_schema["properties"]
 
 
+def test_query_agent_builds_model_with_agentic_factory(monkeypatch: Any) -> None:
+    engine = make_engine()
+    test_model = TestModel(
+        call_tools=[],
+        custom_output_args={"answer": "agent answer", "cited_labels": []},
+    )
+    calls: list[str | None] = []
+
+    def fake_create_agentic_generation_model(model_name: str | None = None) -> TestModel:
+        calls.append(model_name)
+        return test_model
+
+    monkeypatch.setattr(
+        "linkura_story_indexer.query.agent.create_agentic_generation_model",
+        fake_create_agentic_generation_model,
+    )
+
+    result = QueryAgent(model_name="gpt-5.6-luna").run(engine, "question")
+
+    assert calls == ["gpt-5.6-luna"]
+    assert result.stop_reason == "final_answer"
+    assert result.answer.answer == "agent answer"
+
+
 def test_function_model_agent_records_multi_step_calls_and_reranks_candidates(
     monkeypatch: Any,
 ) -> None:


### PR DESCRIPTION
## Summary
- Use OpenAIResponsesModel for agentic OpenAI runs by default, enabling reasoning models with function tools.
- Keep the LINKURA_OPENAI_API=chat escape hatch for proxies without a Responses endpoint.
- Leave the non-agentic generation factory on OpenAIChatModel.
- Add regression coverage for dispatch, caching, and QueryAgent wiring.

## Testing
- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest` (241 passed)