### PR TITLE
feat: add agent evidence IDs

### DIFF
--- a/src/linkura_story_indexer/query/agent.py
+++ b/src/linkura_story_indexer/query/agent.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from inspect import Parameter, Signature
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic_ai import Agent, FunctionToolset, UsageLimits
 from pydantic_ai.exceptions import UsageLimitExceeded
 
@@ -20,6 +21,7 @@ from linkura_story_indexer.query.tools import (
     QUERY_TOOL_REGISTRY,
     QueryToolSpec,
     SearchRawInput,
+    ToolCandidate,
     ToolResult,
 )
 
@@ -32,12 +34,167 @@ class AgentAnswer(BaseModel):
     cited_labels: list[str] = Field(default_factory=list)
 
 
+class AgentAnswerDraft(BaseModel):
+    """The model-facing answer shape, whose citations use run-local evidence IDs."""
+
+    answer: str = Field(..., min_length=1)
+    cited_ids: list[str] = Field(default_factory=list)
+
+    # Keeping extras out of the generated schema lets older fixture models that still return
+    # cited_labels be read during the transition.  QueryAgent resolves those labels to IDs before
+    # exposing the public answer shape.
+    model_config = ConfigDict(extra="allow")
+
+
+class EvidenceRegistry:
+    """Assign stable, run-local IDs to the evidence candidates shown to the model."""
+
+    def __init__(self, engine: Any | None = None) -> None:
+        self.engine = engine
+        self._candidates: dict[str, ToolCandidate] = {}
+        self._ids_by_key: dict[tuple[Any, ...], str] = {}
+        self._next_id = 1
+
+    @staticmethod
+    def _raw_span(metadata: dict[str, Any]) -> tuple[str, int, int] | None:
+        file_path = metadata.get("file_path")
+        scene_start = metadata.get("scene_start")
+        scene_end = metadata.get("scene_end")
+        if scene_start is None and isinstance(metadata.get("scene_index"), int):
+            scene_start = metadata["scene_index"]
+        if scene_end is None and isinstance(metadata.get("scene_index"), int):
+            scene_end = metadata["scene_index"]
+        if (
+            not isinstance(file_path, str)
+            or not file_path
+            or not isinstance(scene_start, int)
+            or not isinstance(scene_end, int)
+            or scene_start < 0
+            or scene_end < scene_start
+        ):
+            return None
+        return file_path, scene_start, scene_end
+
+    def _summary_episode_value(self, metadata: dict[str, Any]) -> str:
+        helper = getattr(self.engine, "_summary_episode_value", None)
+        if callable(helper):
+            return str(helper(metadata))
+        if metadata.get("summary_level") == 1:
+            return "ALL_EPISODES"
+        episode_number = metadata.get("episode_number")
+        if isinstance(episode_number, int) and episode_number > 0:
+            return str(episode_number)
+        episode_name = metadata.get("episode_name")
+        if isinstance(episode_name, str):
+            match = re.search(r"第(\d+)話", episode_name)
+            if match:
+                return match.group(1)
+        return str(metadata.get("episode", "unknown"))
+
+    def _summary_part_label(self, metadata: dict[str, Any]) -> str:
+        helper = getattr(self.engine, "_summary_part_label", None)
+        if callable(helper):
+            return str(helper(metadata))
+        if metadata.get("summary_level") in {1, 2}:
+            return "ALL_PARTS"
+        part = metadata.get("part_name")
+        return part if isinstance(part, str) and part else "unknown"
+
+    def _identity_keys(self, candidate: ToolCandidate) -> list[tuple[Any, ...]]:
+        metadata = candidate.metadata
+        summary_level = metadata.get("summary_level")
+        if summary_level in {1, 2, 3}:
+            return [
+                (
+                    "summary",
+                    metadata.get("arc_id"),
+                    metadata.get("story_type"),
+                    summary_level,
+                    self._summary_episode_value(metadata),
+                    self._summary_part_label(metadata),
+                )
+            ]
+
+        keys: list[tuple[Any, ...]] = []
+        chunk_id = metadata.get("chunk_id")
+        if isinstance(chunk_id, str) and chunk_id:
+            # The chunk ID is the preferred raw identity when it is available.
+            keys.append(("raw", chunk_id))
+        span = self._raw_span(metadata)
+        if span is not None:
+            # This alias joins a single-scene chunk to a get_scene result, which has no chunk ID.
+            keys.append(("raw", *span))
+        if not keys:
+            # All normal evidence has one of the identities above.  Keep a same-object fallback
+            # for malformed/tool-test candidates without accidentally merging unrelated results.
+            keys.append(("object", id(candidate)))
+        return keys
+
+    def register(self, candidate: ToolCandidate) -> str:
+        """Return the candidate's ID, reusing it for the same underlying evidence."""
+        keys = self._identity_keys(candidate)
+        evidence_id = next(
+            (self._ids_by_key[key] for key in keys if key in self._ids_by_key),
+            None,
+        )
+        if evidence_id is None:
+            evidence_id = f"e{self._next_id}"
+            self._next_id += 1
+            self._candidates[evidence_id] = candidate
+        elif (
+            candidate.metadata.get("chunk_id")
+            and not self._candidates[evidence_id].metadata.get("chunk_id")
+        ):
+            # If a get_scene span was registered first, retain the preferred chunk-backed
+            # representation once the chunk result arrives.
+            self._candidates[evidence_id] = candidate
+
+        for key in keys:
+            self._ids_by_key[key] = evidence_id
+        return evidence_id
+
+    def resolve(self, evidence_id: str) -> ToolCandidate | None:
+        """Resolve a model-provided ID, returning None for unknown IDs."""
+        return self._candidates.get(evidence_id)
+
+    def items(self):
+        return self._candidates.items()
+
+    def source_block(self, candidate: ToolCandidate) -> dict[str, Any]:
+        metadata = candidate.metadata
+        if metadata.get("summary_level") in {1, 2, 3}:
+            return {
+                "arc_id": metadata.get("arc_id"),
+                "story_type": metadata.get("story_type"),
+                "summary_level": metadata.get("summary_level"),
+                "episode": self._summary_episode_value(metadata),
+                "part": self._summary_part_label(metadata),
+            }
+
+        span = self._raw_span(metadata)
+        if span is None:
+            file_path = metadata.get("file_path")
+            scene_start = metadata.get("scene_start")
+            scene_end = metadata.get("scene_end")
+        else:
+            file_path, scene_start, scene_end = span
+        source: dict[str, Any] = {
+            "file_path": file_path,
+            "scene_start": scene_start,
+            "scene_end": scene_end,
+        }
+        if isinstance(scene_start, int) and scene_start == scene_end:
+            source["scene_index"] = scene_start
+        return source
+
+
 @dataclass
 class AgentToolCall:
     step: int
     tool_name: str
     args: dict[str, Any]
     result: ToolResult
+    payload: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -46,21 +203,38 @@ class AgentRunResult:
     tool_calls: list[AgentToolCall]
     stop_reason: AgentStopReason
     model_name: str
+    registry: EvidenceRegistry = field(default_factory=EvidenceRegistry)
     request_count: int = 0
     fallback_reason: str | None = None
+    model_cited_ids: list[str] = field(default_factory=list)
+    cited_ids: list[str] = field(default_factory=list)
+    unresolved_cited_ids: list[str] = field(default_factory=list)
 
     @property
     def recorder(self) -> list[AgentToolCall]:
         """Compatibility alias for callers that refer to the per-run recorder."""
         return self.tool_calls
 
+    @property
+    def evidence_registry(self) -> EvidenceRegistry:
+        """Descriptive alias for callers that prefer the registry's full name."""
+        return self.registry
 
-def _agent_tool_payload(result: ToolResult) -> dict[str, Any]:
+
+def _agent_tool_payload(
+    result: ToolResult,
+    registry: EvidenceRegistry | None = None,
+) -> dict[str, Any]:
     """Return the small, model-facing subset of a full tool result."""
+    registry = registry or EvidenceRegistry()
     payload: dict[str, Any] = {}
     if result.candidates:
         payload["candidates"] = [
-            {"citation_label": candidate.citation_label, "text": candidate.text}
+            {
+                "id": registry.register(candidate),
+                "text": candidate.text,
+                "source": registry.source_block(candidate),
+            }
             for candidate in result.candidates
         ]
 
@@ -81,7 +255,10 @@ def _agent_tool_wrapper(
     engine: Any,
     recorder: list[AgentToolCall],
     spec: QueryToolSpec,
+    registry: EvidenceRegistry | None = None,
 ) -> Any:
+    registry = registry or EvidenceRegistry(engine)
+
     def wrapper(args: BaseModel) -> dict[str, Any]:
         step = len(recorder) + 1
         validated_args = spec.input_model.model_validate(args)
@@ -90,15 +267,17 @@ def _agent_tool_wrapper(
             result = spec.dispatcher(engine, validated_args)
         except Exception as exc:  # Tool failures should be visible to the agent and trace.
             result = ToolResult(errors=[f"{spec.name} dispatch failed: {exc}"])
+        payload = _agent_tool_payload(result, registry)
         recorder.append(
             AgentToolCall(
                 step=step,
                 tool_name=spec.name,
                 args=args_dict,
                 result=result,
+                payload=payload,
             )
         )
-        return _agent_tool_payload(result)
+        return payload
 
     wrapper.__name__ = spec.name
     wrapper.__qualname__ = spec.name
@@ -124,12 +303,14 @@ def _agent_tool_wrapper(
 def build_agent_toolset(
     engine: Any,
     recorder: list[AgentToolCall],
+    registry: EvidenceRegistry | None = None,
 ) -> FunctionToolset:
     """Build an instrumented toolset from the shared typed query-tool registry."""
+    registry = registry or EvidenceRegistry(engine)
     toolset = FunctionToolset()
     for spec in QUERY_TOOL_REGISTRY.values():
         toolset.add_function(
-            _agent_tool_wrapper(engine, recorder, spec),
+            _agent_tool_wrapper(engine, recorder, spec, registry),
             name=spec.name,
             description=spec.description,
         )
@@ -146,15 +327,16 @@ def _agent_instructions(engine: Any | None = None) -> str:
         "You are the multi-step retrieval agent for a source-grounded story index. "
         "Use the registered query tools to gather evidence before answering. Never invent a "
         "source, name, translation, state fact, honorific, or number. Your final structured "
-        "answer must contain a concise answer and every citation label that directly supports "
-        "it in cited_labels. Stop once the evidence is sufficient.\n\n"
+        "answer must contain a concise answer and every short evidence ID that directly supports "
+        "it in cited_ids. Stop once the evidence is sufficient.\n\n"
         "Tool strategy:\n"
         "- For Japanese character, unit, location, or story-specific terms, call "
         "lookup_glossary first when the term may be ambiguous; use its canonical term or "
         "translation in the next search.\n"
         "- Use vector_search_raw for exact dialogue and scene evidence. After vector_search_raw "
-        "identifies a precise file_path and scene_index, use get_scene for a focused follow-up when the "
-        "answer depends on that exact scene.\n"
+        "identifies a precise source, use get_scene for a focused follow-up when the answer depends "
+        "on that exact scene; pass the returned file_path and a zero-based scene_index within the "
+        "returned [scene_start, scene_end] span.\n"
         "- For the summary or recap of a specific year, episode, or part, MUST call get_summaries "
         "with location filters (for example, episode 3 means arc_id plus episode=3). Do not call "
         "vector_search_summaries for a known location; use it only to locate summaries by topic.\n"
@@ -163,7 +345,8 @@ def _agent_instructions(engine: Any | None = None) -> str:
         "- Quantitative rule: counting questions MUST call count_dialogue. Its SQL result is "
         "the only authoritative number; never estimate or infer a count from prose, and state "
         "the returned number verbatim in the answer.\n\n"
-        "Do not cite a label that was not returned by a tool. If a tool returns no evidence, "
+        "Tool results expose short IDs such as e1 and e2. Cite those IDs in cited_ids; never invent "
+        "an ID and never cite a label that was not returned by a tool. If a tool returns no evidence, "
         "explain that the source context is insufficient rather than guessing.\n\n"
         f"{story_location_catalog}\n\n"
         "The user prompt is JSON containing question and default_top_k."
@@ -213,6 +396,7 @@ class QueryAgent:
         self.model_name = model_name or get_generation_model_name()
         self.model = model
         self._last_request_count = 0
+        self._active_registry: EvidenceRegistry | None = None
 
     def _instructions(self, engine: Any | None) -> str:
         return _agent_instructions(engine)
@@ -223,11 +407,12 @@ class QueryAgent:
         *,
         engine: Any,
         final_top_k: int,
-        recorder: list[AgentToolCall],
-    ) -> AgentAnswer:
-        agent: Agent[None, AgentAnswer] = Agent(
+        recorder: list[Any],
+    ) -> AgentAnswerDraft | AgentAnswer:
+        registry = self._active_registry or EvidenceRegistry(engine)
+        agent: Agent[None, AgentAnswerDraft] = Agent(
             self.model or create_agentic_generation_model(self.model_name),
-            output_type=AgentAnswer,
+            output_type=AgentAnswerDraft,
             instructions=self._instructions(engine),
         )
         result = agent.run_sync(
@@ -236,7 +421,7 @@ class QueryAgent:
                 ensure_ascii=False,
             ),
             usage_limits=UsageLimits(request_limit=_configured_request_limit()),
-            toolsets=[build_agent_toolset(engine, recorder)],
+            toolsets=[build_agent_toolset(engine, recorder, registry)],
         )
         self._last_request_count = result.usage().requests
         return result.output
@@ -247,7 +432,9 @@ class QueryAgent:
         question: str,
         final_top_k: int,
         recorder: list[AgentToolCall],
+        registry: EvidenceRegistry | None = None,
     ) -> None:
+        registry = registry or self._active_registry or EvidenceRegistry(engine)
         spec = QUERY_TOOL_REGISTRY["vector_search_raw"]
         args = SearchRawInput(query=question, top_k=final_top_k)
         step = len(recorder) + 1
@@ -255,13 +442,70 @@ class QueryAgent:
             result = spec.dispatcher(engine, args)
         except Exception as exc:
             result = ToolResult(errors=[f"fallback tool dispatch failed: {exc}"])
+        payload = _agent_tool_payload(result, registry)
         recorder.append(
             AgentToolCall(
                 step=step,
                 tool_name=spec.name,
                 args=args.model_dump(mode="json"),
                 result=result,
+                payload=payload,
             )
+        )
+
+    @staticmethod
+    def _ids_for_labels(registry: EvidenceRegistry, labels: Sequence[str]) -> list[str]:
+        ids: list[str] = []
+        for evidence_id, candidate in registry.items():
+            if candidate.citation_label in labels and evidence_id not in ids:
+                ids.append(evidence_id)
+        return ids
+
+    def _coerce_draft(
+        self,
+        answer: AgentAnswerDraft | AgentAnswer,
+        registry: EvidenceRegistry,
+    ) -> AgentAnswerDraft:
+        if isinstance(answer, AgentAnswerDraft):
+            draft = answer
+            legacy_labels = getattr(draft, "model_extra", None) or {}
+            cited_labels = legacy_labels.get("cited_labels")
+            if isinstance(cited_labels, list):
+                cited_ids = list(draft.cited_ids)
+                for evidence_id in self._ids_for_labels(registry, cited_labels):
+                    if evidence_id not in cited_ids:
+                        cited_ids.append(evidence_id)
+                if cited_ids != draft.cited_ids:
+                    return AgentAnswerDraft(answer=draft.answer, cited_ids=cited_ids)
+            return draft
+        return AgentAnswerDraft(
+            answer=answer.answer,
+            cited_ids=self._ids_for_labels(registry, answer.cited_labels),
+        )
+
+    def _resolve_draft(
+        self,
+        draft: AgentAnswerDraft,
+        registry: EvidenceRegistry,
+    ) -> tuple[AgentAnswer, list[str], list[str], list[str]]:
+        model_cited_ids = list(draft.cited_ids)
+        resolved_ids: list[str] = []
+        cited_labels: list[str] = []
+        unresolved_ids: list[str] = []
+        for evidence_id in model_cited_ids:
+            candidate = registry.resolve(evidence_id)
+            if candidate is None:
+                unresolved_ids.append(evidence_id)
+                continue
+            if evidence_id in resolved_ids:
+                continue
+            resolved_ids.append(evidence_id)
+            cited_labels.append(candidate.citation_label)
+        return (
+            AgentAnswer(answer=draft.answer, cited_labels=cited_labels),
+            model_cited_ids,
+            resolved_ids,
+            unresolved_ids,
         )
 
     def run(
@@ -273,46 +517,47 @@ class QueryAgent:
     ) -> AgentRunResult:
         recorder: list[AgentToolCall] = []
         self._last_request_count = 0
+        registry = EvidenceRegistry(engine)
+        self._active_registry = registry
+        raw_answer: AgentAnswerDraft | AgentAnswer
+        stop_reason: AgentStopReason
+        fallback_reason: str | None = None
         try:
-            answer = self._run_model(
+            raw_answer = self._run_model(
                 question,
                 engine=engine,
                 final_top_k=final_top_k,
                 recorder=recorder,
             )
+            stop_reason = "final_answer"
         except UsageLimitExceeded as exc:
-            reason = str(exc)
+            fallback_reason = str(exc)
             if not recorder:
                 self._fallback_dispatch(engine, question, final_top_k, recorder)
-            answer = AgentAnswer(answer=_answer_from_tool_calls(recorder))
-            return AgentRunResult(
-                answer=answer,
-                tool_calls=recorder,
-                stop_reason="usage_limit",
-                model_name=self.model_name,
-                request_count=self._last_request_count,
-                fallback_reason=reason,
-            )
+            raw_answer = AgentAnswerDraft(answer=_answer_from_tool_calls(recorder))
+            stop_reason = "usage_limit"
         except Exception as exc:
-            reason = str(exc)
+            fallback_reason = str(exc)
             if not recorder:
                 self._fallback_dispatch(engine, question, final_top_k, recorder)
-            answer = AgentAnswer(answer=_answer_from_tool_calls(recorder))
-            return AgentRunResult(
-                answer=answer,
-                tool_calls=recorder,
-                stop_reason="model_error",
-                model_name=self.model_name,
-                request_count=self._last_request_count,
-                fallback_reason=reason,
-            )
+            raw_answer = AgentAnswerDraft(answer=_answer_from_tool_calls(recorder))
+            stop_reason = "model_error"
+        finally:
+            self._active_registry = None
 
+        draft = self._coerce_draft(raw_answer, registry)
+        answer, model_cited_ids, cited_ids, unresolved_ids = self._resolve_draft(draft, registry)
         return AgentRunResult(
             answer=answer,
             tool_calls=recorder,
-            stop_reason="final_answer",
+            stop_reason=stop_reason,
             model_name=self.model_name,
+            registry=registry,
             request_count=self._last_request_count,
+            fallback_reason=fallback_reason,
+            model_cited_ids=model_cited_ids,
+            cited_ids=cited_ids,
+            unresolved_cited_ids=unresolved_ids,
         )
 
 
@@ -322,14 +567,15 @@ class FixtureQueryAgent(QueryAgent):
     def __init__(
         self,
         calls: Sequence[tuple[str, dict[str, Any]]] | None = None,
-        answer: str | AgentAnswer = "fixture answer",
+        answer: str | AgentAnswer | AgentAnswerDraft = "fixture answer",
         *,
         script: Sequence[tuple[str, dict[str, Any]]] | None = None,
         scripted_calls: Sequence[tuple[str, dict[str, Any]]] | None = None,
         tool_calls: Sequence[tuple[str, dict[str, Any]]] | None = None,
-        final_answer: str | AgentAnswer | None = None,
-        canned_answer: str | AgentAnswer | None = None,
+        final_answer: str | AgentAnswer | AgentAnswerDraft | None = None,
+        canned_answer: str | AgentAnswer | AgentAnswerDraft | None = None,
         cited_labels: Sequence[str] | None = None,
+        cited_ids: Sequence[str] | None = None,
         model_name: str = "fixture-agent",
         error: Exception | None = None,
     ) -> None:
@@ -340,11 +586,14 @@ class FixtureQueryAgent(QueryAgent):
             answer = final_answer
         if canned_answer is not None:
             answer = canned_answer
-        self._answer = (
-            answer
-            if isinstance(answer, AgentAnswer)
-            else AgentAnswer(answer=answer, cited_labels=list(cited_labels or []))
-        )
+        self._draft = answer if isinstance(answer, AgentAnswerDraft) else None
+        if isinstance(answer, AgentAnswerDraft):
+            self._answer = AgentAnswer(answer=answer.answer)
+        elif isinstance(answer, AgentAnswer):
+            self._answer = answer
+        else:
+            self._answer = AgentAnswer(answer=answer, cited_labels=list(cited_labels or []))
+        self._cited_ids = list(cited_ids or [])
         self._error = error
 
     def _run_model(
@@ -353,10 +602,11 @@ class FixtureQueryAgent(QueryAgent):
         *,
         engine: Any,
         final_top_k: int,
-        recorder: list[AgentToolCall],
-    ) -> AgentAnswer:
+        recorder: list[Any],
+    ) -> AgentAnswerDraft | AgentAnswer:
         if self._error is not None:
             raise self._error
+        registry = self._active_registry or EvidenceRegistry(engine)
         for tool_name, raw_args in self.calls:
             spec = QUERY_TOOL_REGISTRY.get(tool_name)
             if spec is None:
@@ -367,12 +617,24 @@ class FixtureQueryAgent(QueryAgent):
                 result = spec.dispatcher(engine, args)
             except Exception as exc:
                 result = ToolResult(errors=[f"{tool_name} dispatch failed: {exc}"])
+            payload = _agent_tool_payload(result, registry)
             recorder.append(
                 AgentToolCall(
                     step=step,
                     tool_name=tool_name,
                     args=args.model_dump(mode="json"),
                     result=result,
+                    payload=payload,
                 )
             )
-        return self._answer
+        if self._draft is not None:
+            return self._draft
+        if self._cited_ids:
+            return AgentAnswerDraft(answer=self._answer.answer, cited_ids=self._cited_ids)
+        return AgentAnswerDraft(
+            answer=self._answer.answer,
+            cited_ids=QueryAgent._ids_for_labels(
+                registry,
+                self._answer.cited_labels,
+            ),
+        )

--- a/src/linkura_story_indexer/query/agent.py
+++ b/src/linkura_story_indexer/query/agent.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-import re
-from collections.abc import Sequence
+from collections.abc import ItemsView, Sequence
 from dataclasses import dataclass, field
 from inspect import Parameter, Signature
 from typing import Any, Literal
@@ -40,16 +39,15 @@ class AgentAnswerDraft(BaseModel):
     answer: str = Field(..., min_length=1)
     cited_ids: list[str] = Field(default_factory=list)
 
-    # Keeping extras out of the generated schema lets older fixture models that still return
-    # cited_labels be read during the transition.  QueryAgent resolves those labels to IDs before
-    # exposing the public answer shape.
+    # TODO(issue-73): remove this compatibility allowance once legacy fixture models no longer
+    # return cited_labels. QueryAgent resolves those labels to IDs before exposing the public shape.
     model_config = ConfigDict(extra="allow")
 
 
 class EvidenceRegistry:
     """Assign stable, run-local IDs to the evidence candidates shown to the model."""
 
-    def __init__(self, engine: Any | None = None) -> None:
+    def __init__(self, engine: Any) -> None:
         self.engine = engine
         self._candidates: dict[str, ToolCandidate] = {}
         self._ids_by_key: dict[tuple[Any, ...], str] = {}
@@ -76,29 +74,10 @@ class EvidenceRegistry:
         return file_path, scene_start, scene_end
 
     def _summary_episode_value(self, metadata: dict[str, Any]) -> str:
-        helper = getattr(self.engine, "_summary_episode_value", None)
-        if callable(helper):
-            return str(helper(metadata))
-        if metadata.get("summary_level") == 1:
-            return "ALL_EPISODES"
-        episode_number = metadata.get("episode_number")
-        if isinstance(episode_number, int) and episode_number > 0:
-            return str(episode_number)
-        episode_name = metadata.get("episode_name")
-        if isinstance(episode_name, str):
-            match = re.search(r"第(\d+)話", episode_name)
-            if match:
-                return match.group(1)
-        return str(metadata.get("episode", "unknown"))
+        return str(self.engine._summary_episode_value(metadata))
 
     def _summary_part_label(self, metadata: dict[str, Any]) -> str:
-        helper = getattr(self.engine, "_summary_part_label", None)
-        if callable(helper):
-            return str(helper(metadata))
-        if metadata.get("summary_level") in {1, 2}:
-            return "ALL_PARTS"
-        part = metadata.get("part_name")
-        return part if isinstance(part, str) and part else "unknown"
+        return str(self.engine._summary_part_label(metadata))
 
     def _identity_keys(self, candidate: ToolCandidate) -> list[tuple[Any, ...]]:
         metadata = candidate.metadata
@@ -157,7 +136,7 @@ class EvidenceRegistry:
         """Resolve a model-provided ID, returning None for unknown IDs."""
         return self._candidates.get(evidence_id)
 
-    def items(self):
+    def items(self) -> ItemsView[str, ToolCandidate]:
         return self._candidates.items()
 
     def source_block(self, candidate: ToolCandidate) -> dict[str, Any]:
@@ -203,7 +182,7 @@ class AgentRunResult:
     tool_calls: list[AgentToolCall]
     stop_reason: AgentStopReason
     model_name: str
-    registry: EvidenceRegistry = field(default_factory=EvidenceRegistry)
+    registry: EvidenceRegistry
     request_count: int = 0
     fallback_reason: str | None = None
     model_cited_ids: list[str] = field(default_factory=list)
@@ -223,10 +202,9 @@ class AgentRunResult:
 
 def _agent_tool_payload(
     result: ToolResult,
-    registry: EvidenceRegistry | None = None,
+    registry: EvidenceRegistry,
 ) -> dict[str, Any]:
     """Return the small, model-facing subset of a full tool result."""
-    registry = registry or EvidenceRegistry()
     payload: dict[str, Any] = {}
     if result.candidates:
         payload["candidates"] = [
@@ -396,7 +374,6 @@ class QueryAgent:
         self.model_name = model_name or get_generation_model_name()
         self.model = model
         self._last_request_count = 0
-        self._active_registry: EvidenceRegistry | None = None
 
     def _instructions(self, engine: Any | None) -> str:
         return _agent_instructions(engine)
@@ -407,9 +384,9 @@ class QueryAgent:
         *,
         engine: Any,
         final_top_k: int,
-        recorder: list[Any],
+        recorder: list[AgentToolCall],
+        registry: EvidenceRegistry,
     ) -> AgentAnswerDraft | AgentAnswer:
-        registry = self._active_registry or EvidenceRegistry(engine)
         agent: Agent[None, AgentAnswerDraft] = Agent(
             self.model or create_agentic_generation_model(self.model_name),
             output_type=AgentAnswerDraft,
@@ -432,9 +409,8 @@ class QueryAgent:
         question: str,
         final_top_k: int,
         recorder: list[AgentToolCall],
-        registry: EvidenceRegistry | None = None,
+        registry: EvidenceRegistry,
     ) -> None:
-        registry = registry or self._active_registry or EvidenceRegistry(engine)
         spec = QUERY_TOOL_REGISTRY["vector_search_raw"]
         args = SearchRawInput(query=question, top_k=final_top_k)
         step = len(recorder) + 1
@@ -518,7 +494,6 @@ class QueryAgent:
         recorder: list[AgentToolCall] = []
         self._last_request_count = 0
         registry = EvidenceRegistry(engine)
-        self._active_registry = registry
         raw_answer: AgentAnswerDraft | AgentAnswer
         stop_reason: AgentStopReason
         fallback_reason: str | None = None
@@ -528,22 +503,33 @@ class QueryAgent:
                 engine=engine,
                 final_top_k=final_top_k,
                 recorder=recorder,
+                registry=registry,
             )
             stop_reason = "final_answer"
         except UsageLimitExceeded as exc:
             fallback_reason = str(exc)
             if not recorder:
-                self._fallback_dispatch(engine, question, final_top_k, recorder)
+                self._fallback_dispatch(
+                    engine,
+                    question,
+                    final_top_k,
+                    recorder,
+                    registry,
+                )
             raw_answer = AgentAnswerDraft(answer=_answer_from_tool_calls(recorder))
             stop_reason = "usage_limit"
         except Exception as exc:
             fallback_reason = str(exc)
             if not recorder:
-                self._fallback_dispatch(engine, question, final_top_k, recorder)
+                self._fallback_dispatch(
+                    engine,
+                    question,
+                    final_top_k,
+                    recorder,
+                    registry,
+                )
             raw_answer = AgentAnswerDraft(answer=_answer_from_tool_calls(recorder))
             stop_reason = "model_error"
-        finally:
-            self._active_registry = None
 
         draft = self._coerce_draft(raw_answer, registry)
         answer, model_cited_ids, cited_ids, unresolved_ids = self._resolve_draft(draft, registry)
@@ -602,11 +588,11 @@ class FixtureQueryAgent(QueryAgent):
         *,
         engine: Any,
         final_top_k: int,
-        recorder: list[Any],
+        recorder: list[AgentToolCall],
+        registry: EvidenceRegistry,
     ) -> AgentAnswerDraft | AgentAnswer:
         if self._error is not None:
             raise self._error
-        registry = self._active_registry or EvidenceRegistry(engine)
         for tool_name, raw_args in self.calls:
             spec = QUERY_TOOL_REGISTRY.get(tool_name)
             if spec is None:

--- a/src/linkura_story_indexer/query/engine.py
+++ b/src/linkura_story_indexer/query/engine.py
@@ -1946,18 +1946,16 @@ class StoryQueryEngine:
         )
 
     def _agent_dispatch_with_trace(self, question: str) -> RoutedTraceResult:
-        from linkura_story_indexer.query.agent import _agent_tool_payload
-
         run = self._get_query_agent().run(
             self,
             question,
             final_top_k=self._config().final_top_k,
         )
         call_summaries = []
-        candidates = []
-        seen_labels: set[str] = set()
+        candidates_by_id: dict[str, Any] = {}
+        candidate_ids: list[str] = []
         for call in run.tool_calls:
-            payload = _agent_tool_payload(call.result)
+            payload = call.payload
             call_summaries.append(
                 {
                     "step": call.step,
@@ -1966,14 +1964,42 @@ class StoryQueryEngine:
                     **payload,
                 }
             )
-            for candidate in call.result.candidates:
-                if len(candidates) >= self._config().final_top_k:
-                    break
-                if candidate.citation_label in seen_labels:
-                    continue
-                seen_labels.add(candidate.citation_label)
-                candidate.rank = len(candidates) + 1
-                candidates.append(candidate)
+
+            payload_candidates = payload.get("candidates")
+            for index, candidate in enumerate(call.result.candidates):
+                evidence_id: str | None = None
+                if isinstance(payload_candidates, list) and index < len(payload_candidates):
+                    payload_candidate = payload_candidates[index]
+                    if isinstance(payload_candidate, dict):
+                        raw_id = payload_candidate.get("id")
+                        if isinstance(raw_id, str):
+                            evidence_id = raw_id
+                if evidence_id is None:
+                    # This is only a compatibility path for externally constructed old call
+                    # records.  Normal runs always persist IDs in call.payload at dispatch time.
+                    evidence_id = run.registry.register(candidate)
+                registered_candidate = run.registry.resolve(evidence_id) or candidate
+                candidates_by_id.setdefault(evidence_id, registered_candidate)
+                if evidence_id not in candidate_ids:
+                    candidate_ids.append(evidence_id)
+
+        selected_ids = list(run.cited_ids)
+        if (
+            not selected_ids
+            and not run.model_cited_ids
+            and run.stop_reason in {"usage_limit", "model_error"}
+        ):
+            selected_ids = candidate_ids[: self._config().final_top_k]
+
+        candidates = []
+        for evidence_id in selected_ids:
+            candidate = candidates_by_id.get(evidence_id) or run.registry.resolve(evidence_id)
+            if candidate is None:
+                continue
+            if any(existing is candidate for existing in candidates):
+                continue
+            candidate.rank = len(candidates) + 1
+            candidates.append(candidate)
 
         final_candidates = [
             self._trace_candidate_from_tool_candidate(candidate)
@@ -1989,7 +2015,9 @@ class StoryQueryEngine:
                     "stop_reason": run.stop_reason,
                     "fallback_reason": run.fallback_reason,
                     "tool_calls": call_summaries,
+                    "model_cited_ids": list(run.model_cited_ids),
                     "model_cited_labels": list(run.answer.cited_labels),
+                    "unresolved_cited_ids": list(run.unresolved_cited_ids),
                 },
             ),
             "final_top_k": self._trace_stage("final_top_k", final_candidates),

--- a/tests/test_query_agent.py
+++ b/tests/test_query_agent.py
@@ -12,6 +12,7 @@ from linkura_story_indexer.query import engine as query_engine
 from linkura_story_indexer.query.agent import (
     AgentAnswer,
     AgentAnswerDraft,
+    AgentToolCall,
     EvidenceRegistry,
     FixtureQueryAgent,
     QueryAgent,
@@ -96,6 +97,26 @@ def test_evidence_registry_reuses_raw_spans_and_summary_tiers() -> None:
     assert registry.resolve("missing") is None
 
 
+def test_evidence_registry_reuses_summary_search_and_location_results() -> None:
+    engine = make_engine()
+    registry = EvidenceRegistry(engine)
+    vector_candidate = summary_candidate()
+    fetched_candidate = ToolCandidate(
+        text="fetched summary evidence",
+        citation_label="same summary tier",
+        metadata={
+            "arc_id": "103",
+            "story_type": "Main",
+            "summary_level": 2,
+            "episode_number": 1,
+        },
+        rank=1,
+    )
+
+    assert registry.register(vector_candidate) == "e1"
+    assert registry.register(fetched_candidate) == "e1"
+
+
 def test_agent_payload_uses_ids_and_compact_source_blocks() -> None:
     engine = make_engine()
     registry = EvidenceRegistry(engine)
@@ -177,6 +198,26 @@ def test_agent_trace_selects_only_model_cited_candidates(monkeypatch: Any) -> No
     tool_payload = trace.stages["agent"].metadata["tool_calls"][0]
     assert [candidate["id"] for candidate in tool_payload["candidates"]] == ["e1", "e2"]
     assert trace.stages["agent"].metadata["model_cited_ids"] == ["e2"]
+
+
+def test_successful_uncited_answer_keeps_final_evidence_empty(monkeypatch: Any) -> None:
+    engine = make_engine()
+
+    def fake_retrieve(*args: Any, **kwargs: Any) -> RetrievalTraceResult:
+        return RetrievalTraceResult(nodes=[raw_node()], stages={})
+
+    monkeypatch.setattr(engine, "retrieve_raw_nodes_with_trace", fake_retrieve)
+    monkeypatch.setattr(engine, "_fetch_raw_text", lambda metadata: "")
+    engine.query_agent = FixtureQueryAgent(
+        calls=[("vector_search_raw", {"query": "question", "top_k": 1})],
+        answer=AgentAnswerDraft(answer="insufficient context", cited_ids=[]),
+    )
+
+    trace = engine.retrieve_with_trace("question", answer_mode=True)
+
+    assert trace.answer_text == "insufficient context"
+    assert trace.stages["final_top_k"].candidates == []
+    assert trace.final_citation_labels == []
 
 
 def test_function_model_can_follow_raw_payload_into_get_scene_and_cite_id(
@@ -423,7 +464,8 @@ def test_usage_limit_falls_back_to_one_raw_search(monkeypatch: Any) -> None:
             *,
             engine: Any,
             final_top_k: int,
-            recorder: list[Any],
+            recorder: list[AgentToolCall],
+            registry: EvidenceRegistry,
         ) -> AgentAnswer:
             from pydantic_ai.exceptions import UsageLimitExceeded
 

--- a/tests/test_query_agent.py
+++ b/tests/test_query_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from pydantic_ai.messages import ModelResponse, ToolCallPart
@@ -10,8 +11,11 @@ from linkura_story_indexer.eval.io import stable_json
 from linkura_story_indexer.query import engine as query_engine
 from linkura_story_indexer.query.agent import (
     AgentAnswer,
+    AgentAnswerDraft,
+    EvidenceRegistry,
     FixtureQueryAgent,
     QueryAgent,
+    _agent_tool_payload,
     build_agent_toolset,
 )
 from linkura_story_indexer.query.engine import (
@@ -19,6 +23,7 @@ from linkura_story_indexer.query.engine import (
     RetrievalTraceResult,
     StoryQueryEngine,
 )
+from linkura_story_indexer.query.tools import ToolCandidate, ToolResult
 
 
 def make_engine() -> StoryQueryEngine:
@@ -47,6 +52,214 @@ def raw_node(text: str = "raw evidence", scene_index: int = 0) -> tuple[str, dic
             "chunk_id": f"chunk-103-{scene_index}",
         },
     )
+
+
+def summary_candidate(summary_level: int = 2, part_name: str = "1") -> ToolCandidate:
+    metadata = {
+        "arc_id": "103",
+        "story_type": "Main",
+        "episode_name": "第1話『花咲きたい！』",
+        "episode_number": 1,
+        "part_name": part_name,
+        "summary_level": summary_level,
+    }
+    return ToolCandidate(
+        text="summary evidence",
+        citation_label="103 · Main · Episode 1 · Part ALL_PARTS · summary_level 2",
+        metadata=metadata,
+        rank=1,
+    )
+
+
+def test_evidence_registry_reuses_raw_spans_and_summary_tiers() -> None:
+    engine = make_engine()
+    registry = EvidenceRegistry(engine)
+    raw_metadata = raw_node()[1]
+    chunk_candidate = ToolCandidate(
+        text="chunk evidence",
+        citation_label="raw",
+        metadata=raw_metadata,
+        rank=1,
+    )
+    scene_candidate = ToolCandidate(
+        text="scene evidence",
+        citation_label="raw",
+        metadata={key: value for key, value in raw_metadata.items() if key != "chunk_id"},
+        rank=1,
+    )
+
+    assert registry.register(chunk_candidate) == "e1"
+    assert registry.register(scene_candidate) == "e1"
+    assert registry.register(summary_candidate()) == "e2"
+    assert registry.register(summary_candidate()) == "e2"
+    assert registry.register(summary_candidate(summary_level=3, part_name="1")) == "e3"
+    assert registry.resolve("missing") is None
+
+
+def test_agent_payload_uses_ids_and_compact_source_blocks() -> None:
+    engine = make_engine()
+    registry = EvidenceRegistry(engine)
+    raw = ToolCandidate(
+        text="raw evidence",
+        citation_label="must not be exposed",
+        metadata=raw_node()[1],
+        rank=1,
+    )
+    summary = summary_candidate()
+
+    payload = _agent_tool_payload(ToolResult(candidates=[raw, summary]), registry)
+
+    assert payload["candidates"] == [
+        {
+            "id": "e1",
+            "text": "raw evidence",
+            "source": {
+                "file_path": "story/103/第1話『花咲きたい！』/1.md",
+                "scene_start": 0,
+                "scene_end": 0,
+                "scene_index": 0,
+            },
+        },
+        {
+            "id": "e2",
+            "text": "summary evidence",
+            "source": {
+                "arc_id": "103",
+                "story_type": "Main",
+                "summary_level": 2,
+                "episode": "1",
+                "part": "ALL_PARTS",
+            },
+        },
+    ]
+    assert all("citation_label" not in candidate for candidate in payload["candidates"])
+
+
+def test_agent_run_resolves_cited_ids_and_drops_unknown_ids(monkeypatch: Any) -> None:
+    engine = make_engine()
+
+    def fake_retrieve(*args: Any, **kwargs: Any) -> RetrievalTraceResult:
+        return RetrievalTraceResult(nodes=[raw_node()], stages={})
+
+    monkeypatch.setattr(engine, "retrieve_raw_nodes_with_trace", fake_retrieve)
+    monkeypatch.setattr(engine, "_fetch_raw_text", lambda metadata: "")
+    agent = FixtureQueryAgent(
+        calls=[("vector_search_raw", {"query": "question", "top_k": 1})],
+        answer=AgentAnswerDraft(answer="answered", cited_ids=["e1", "e404"]),
+    )
+
+    result = agent.run(engine, "question")
+
+    assert result.answer.cited_labels == ["103 · Episode 1 · Part 1 · Scene 1"]
+    assert result.cited_ids == ["e1"]
+    assert result.unresolved_cited_ids == ["e404"]
+
+
+def test_agent_trace_selects_only_model_cited_candidates(monkeypatch: Any) -> None:
+    engine = make_engine()
+
+    def fake_retrieve(*args: Any, **kwargs: Any) -> RetrievalTraceResult:
+        return RetrievalTraceResult(nodes=[raw_node("first"), raw_node("second", 1)], stages={})
+
+    monkeypatch.setattr(engine, "retrieve_raw_nodes_with_trace", fake_retrieve)
+    monkeypatch.setattr(engine, "_fetch_raw_text", lambda metadata: "")
+    engine.query_agent = FixtureQueryAgent(
+        calls=[("vector_search_raw", {"query": "question", "top_k": 2})],
+        answer=AgentAnswerDraft(answer="answered", cited_ids=["e2"]),
+    )
+
+    trace = engine.retrieve_with_trace("question", answer_mode=True)
+
+    assert [candidate.text for candidate in trace.stages["final_top_k"].candidates or []] == [
+        "second"
+    ]
+    assert trace.final_citation_labels == ["103 · Episode 1 · Part 1 · Scene 2"]
+    tool_payload = trace.stages["agent"].metadata["tool_calls"][0]
+    assert [candidate["id"] for candidate in tool_payload["candidates"]] == ["e1", "e2"]
+    assert trace.stages["agent"].metadata["model_cited_ids"] == ["e2"]
+
+
+def test_function_model_can_follow_raw_payload_into_get_scene_and_cite_id(
+    monkeypatch: Any,
+) -> None:
+    engine = make_engine()
+    node = raw_node("search scene")
+
+    def fake_retrieve(*args: Any, **kwargs: Any) -> RetrievalTraceResult:
+        return RetrievalTraceResult(nodes=[node], stages={})
+
+    class Store:
+        def get_scene(self, file_path: str, scene_index: int) -> dict[str, Any]:
+            assert file_path == node[1]["file_path"]
+            assert scene_index == 0
+            return {
+                "text": "focused scene",
+                "file_path": file_path,
+                "scene_index": scene_index,
+                "metadata": {key: value for key, value in node[1].items() if key != "chunk_id"},
+            }
+
+    monkeypatch.setattr(engine, "retrieve_raw_nodes_with_trace", fake_retrieve)
+    monkeypatch.setattr(engine, "_fetch_raw_text", lambda metadata: "")
+    engine.source_store = Store()
+
+    def tool_return_payload(messages: list[Any]) -> dict[str, Any]:
+        for message in reversed(messages):
+            for part in getattr(message, "parts", []):
+                if getattr(part, "part_kind", None) != "tool-return":
+                    continue
+                content = part.content
+                return json.loads(content) if isinstance(content, str) else content
+        raise AssertionError("expected a tool return")
+
+    def scripted_model(messages: list[Any], info: Any) -> ModelResponse:
+        tool_returns = sum(
+            1
+            for message in messages
+            for part in getattr(message, "parts", [])
+            if getattr(part, "part_kind", None) == "tool-return"
+        )
+        if tool_returns == 0:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="vector_search_raw", args={"query": "scene"})]
+            )
+        if tool_returns == 1:
+            payload = tool_return_payload(messages)
+            source = payload["candidates"][0]["source"]
+            assert "citation_label" not in payload["candidates"][0]
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="get_scene",
+                        args={
+                            "file_path": source["file_path"],
+                            "scene_index": source["scene_index"],
+                        },
+                    )
+                ]
+            )
+        payload = tool_return_payload(messages)
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name=info.output_tools[0].name,
+                    args={"answer": "focused answer", "cited_ids": [payload["candidates"][0]["id"]]},
+                )
+            ]
+        )
+
+    engine.query_agent = QueryAgent(
+        model=FunctionModel(scripted_model),
+        model_name="function-agent",
+    )
+
+    trace = engine.retrieve_with_trace("What happened?", answer_mode=True)
+
+    assert trace.answer_text == "focused answer"
+    assert trace.final_citation_labels == ["103 · Episode 1 · Part 1 · Scene 1"]
+    calls = trace.stages["agent"].metadata["tool_calls"]
+    assert calls[0]["candidates"][0]["id"] == "e1"
+    assert calls[1]["candidates"][0]["id"] == "e1"
 
 
 def test_agent_toolset_registers_the_shared_typed_schemas() -> None:


### PR DESCRIPTION
Closes #73

## Summary

- Add a per-run evidence registry with raw chunk/span and summary-tier identity reuse.
- Expose compact source coordinates and short evidence IDs in agent tool payloads.
- Resolve model `cited_ids` into public citation labels and select only cited evidence in traces.
- Preserve exact tool payloads for deterministic trace reconstruction.
- Thread the registry explicitly through model and fallback dispatch, avoiding mutable per-agent run state.
- Delegate summary identity formatting to the engine's existing helpers.
- Preserve the intentional empty final evidence set for successful uncited answers.
- Add unit, integration, and deterministic regression coverage.

## Validation

- `uv run ruff check . --fix`
- `uv run pyrefly check .`
- `uv run pytest` (263 passed)